### PR TITLE
Use common-beer-format symbolic keys in all maps

### DIFF
--- a/.clj-kondo/com.wallbrew/spoon/config.edn
+++ b/.clj-kondo/com.wallbrew/spoon/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {com.wallbrew.spoon.core/when-let+ clojure.core/let}}

--- a/.sealog/changes/1-3-0.edn
+++ b/.sealog/changes/1-3-0.edn
@@ -1,0 +1,11 @@
+{:version      {:major 1
+                :minor 3
+                :patch 0}
+ :version-type :semver3
+ :changes      {:added      ["Use [common-beer-format](https://github.com/Wall-Brew-Co/common-beer-format) to define keys in data maps."]
+                :changed    []
+                :deprecated []
+                :removed    []
+                :fixed      ["Fix typo in yeast data helper."]
+                :security   []}
+ :timestamp    "2023-03-09T01:03:49.667941Z"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Table of Contents
 
+* [1.3.0 - 2023-03-09](#130---2023-03-09)
 * [1.2.0 - 2023-02-10](#120---2023-02-10)
 * [1.1.0 - 2023-02-09](#110---2023-02-09)
 * [1.0.0 - 2022-07-09](#100---2022-07-09)
+
+## 1.3.0 - 2023-03-09
+
+* Added
+  * Use [common-beer-format](https://github.com/Wall-Brew-Co/common-beer-format) to define keys in data maps.
+* Fixed
+  * Fix typo in yeast data helper.
 
 ## 1.2.0 - 2023-02-10
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "common-beer-data",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "common-beer-data",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "ISC",
       "devDependencies": {
         "karma": "^6.3.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "common-beer-data",
-  "version": "1.2.0",
-  "description": "An implementation  of the BeerXML spec in multiple formats",
+  "version": "1.3.0",
+  "description": "An implementation  of the BeerXML spec in multiple formats.",
   "main": "index.js",
   "directories": {
     "test": "test"

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
   <groupId>com.wallbrew</groupId>
   <artifactId>common-beer-data</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
   <name>common-beer-data</name>
-  <description>A repository of common-beer-format data</description>
+  <description>A repository of common-beer-format data.</description>
   <url>https://github.com/Wall-Brew-Co/common-beer-data</url>
   <licenses>
     <license>
@@ -20,7 +20,7 @@
     <url>https://github.com/Wall-Brew-Co/common-beer-data</url>
     <connection>scm:git:git://github.com/Wall-Brew-Co/common-beer-data.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Wall-Brew-Co/common-beer-data.git</developerConnection>
-    <tag>0e2f5cab48fcc56129f323a575c318fea144623d</tag>
+    <tag>b8a5b4d0975487f518c810f7f8c150450a7e7f3a</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -66,6 +66,11 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>com.wallbrew</groupId>
+      <artifactId>common-beer-format</artifactId>
+      <version>2.2.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
       <version>1.11.1</version>
@@ -78,14 +83,8 @@
     </dependency>
     <dependency>
       <groupId>com.wallbrew</groupId>
-      <artifactId>common-beer-format</artifactId>
-      <version>2.2.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.wallbrew</groupId>
       <artifactId>spoon</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(defproject com.wallbrew/common-beer-data "1.2.0"
-  :description "A repository of common-beer-format data"
+(defproject com.wallbrew/common-beer-data "1.3.0"
+  :description "A repository of common-beer-format data."
   :url "https://github.com/Wall-Brew-Co/common-beer-data"
   :license {:name         "MIT"
             :url          "https://opensource.org/licenses/MIT"

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
             :comments     "Same-as all Wall-Brew projects"}
   :scm {:name "git"
         :url  "https://github.com/Wall-Brew-Co/common-beer-data"}
-  :dependencies [[org.clojure/clojure "1.11.1"]
+  :dependencies [[com.wallbrew/common-beer-format "2.2.1"]
+                 [org.clojure/clojure "1.11.1"]
                  [org.clojure/clojurescript "1.11.60" :scope "provided"]]
   :plugins [[com.github.clj-kondo/lein-clj-kondo "0.2.4"]
             [com.wallbrew/lein-sealog "1.0.2"]
@@ -15,8 +16,7 @@
             [lein-project-version "0.1.0"]
             [mvxcvi/cljstyle "0.15.0"]]
   :profiles {:uberjar {:aot :all}
-             :dev     {:dependencies [[com.wallbrew/common-beer-format "2.2.1"]
-                                      [com.wallbrew/spoon "1.2.1"]
+             :dev     {:dependencies [[com.wallbrew/spoon "1.2.1"]
                                       [doo "0.1.11"]
                                       [org.clojure/spec.alpha "0.3.218"]]
                        :plugins      [[lein-doo "0.1.11"]]}}

--- a/src/common_beer_data/core.cljc
+++ b/src/common_beer_data/core.cljc
@@ -1,5 +1,6 @@
 (ns common-beer-data.core
   "Quick functions and references to ingredient data."
+  {:added "1.0"}
   (:require [common-beer-data.fermentables.adjuncts :as adjuncts]
             [common-beer-data.fermentables.dry-extracts :as dry-extracts]
             [common-beer-data.fermentables.extracts :as extracts]

--- a/src/common_beer_data/fermentables/adjuncts.cljc
+++ b/src/common_beer_data/fermentables/adjuncts.cljc
@@ -1,13 +1,15 @@
 (ns common-beer-data.fermentables.adjuncts
-  "Data for common adjunctive fermentable ingredients")
+  "Data for common adjunctive fermentable ingredients."
+  {:added "1.0"}
+  (:require [common-beer-format.fermentables :as cbf]))
 
 
 (def ^:private adjunct-defaults
-  {:version        1
-   :amount         0.0
-   :recommend-mash false
-   :add-after-boil false
-   :type           "Adjunct"})
+  {cbf/version        1
+   cbf/amount         0.0
+   cbf/recommend-mash false
+   cbf/add-after-boil false
+   cbf/type           "Adjunct"})
 
 
 (defn ^:private build-adjunct
@@ -18,35 +20,35 @@
 (def barley-hulls
   "Neutral hulls used to improve lautering."
   (build-adjunct :barley-hulls
-                 {:name         "Barley Hulls"
-                  :yield        0.0
-                  :color        0
-                  :max-in-batch 0.05
-                  :potential    1.0
-                  :notes        "Neutral hulls used to improve lautering."}))
+                 {cbf/name         "Barley Hulls"
+                  cbf/yield        0.0
+                  cbf/color        0
+                  cbf/max-in-batch 0.05
+                  cbf/potential    1.0
+                  cbf/notes        "Neutral hulls used to improve lautering."}))
 
 
 (def grits
   "Imparts a corn and grain taste."
   (build-adjunct :grits
-                 {:name           "Grits"
-                  :yield          0.8
-                  :color          1
-                  :recommend-mash true
-                  :max-in-batch   0.1
-                  :potential      1.037
-                  :notes          "Imparts a corn and grain taste."}))
+                 {cbf/name           "Grits"
+                  cbf/yield          0.8
+                  cbf/color          1
+                  cbf/recommend-mash true
+                  cbf/max-in-batch   0.1
+                  cbf/potential      1.037
+                  cbf/notes          "Imparts a corn and grain taste."}))
 
 
 (def rice-hulls
   "Neutral hulls used to improve lautering."
   (build-adjunct :rice-hulls
-                 {:name         "Rice Hulls"
-                  :yield        0.0
-                  :color        0
-                  :max-in-batch 0.05
-                  :potential    1.0
-                  :notes        "Neutral hulls used to improve lautering."}))
+                 {cbf/name         "Rice Hulls"
+                  cbf/yield        0.0
+                  cbf/color        0
+                  cbf/max-in-batch 0.05
+                  cbf/potential    1.0
+                  cbf/notes        "Neutral hulls used to improve lautering."}))
 
 
 (def adjuncts

--- a/src/common_beer_data/fermentables/dry_extracts.cljc
+++ b/src/common_beer_data/fermentables/dry_extracts.cljc
@@ -1,15 +1,17 @@
 (ns common-beer-data.fermentables.dry-extracts
-  "Data for malt extracts and brewing sugars")
+  "Data for malt extracts and brewing sugars."
+  {:added "1.0"}
+  (:require [common-beer-format.fermentables :as cbf]))
 
 
 (def ^:private extract-defaults
-  {:version        1
-   :amount         0.0
-   :type           "Dry Extract"
-   :recommend-mash false
-   :add-after-boil false
-   :max-in-batch   1.0
-   :yield          0.95})
+  {cbf/version        1
+   cbf/amount         0.0
+   cbf/type           "Dry Extract"
+   cbf/recommend-mash false
+   cbf/add-after-boil false
+   cbf/max-in-batch   1.0
+   cbf/yield          0.95})
 
 
 (defn ^:private build-extract
@@ -20,46 +22,46 @@
 (def amber-dry-extract
   "Amber colored dry malt extract for general purpose use."
   (build-extract :amber-dry-extract
-                 {:name      "Amber Dry Extract"
-                  :color     13
-                  :potential 1.044
-                  :notes     "Amber colored dry malt extract for general purpose use."}))
+                 {cbf/name      "Amber Dry Extract"
+                  cbf/color     13
+                  cbf/potential 1.044
+                  cbf/notes     "Amber colored dry malt extract for general purpose use."}))
 
 
 (def dark-dry-extract
   "For general-purpose use in darker beers."
   (build-extract :dark-dry-extract
-                 {:name      "Dark Dry Extract"
-                  :color     18
-                  :potential 1.044
-                  :notes     "For general-purpose use in darker beers."}))
+                 {cbf/name      "Dark Dry Extract"
+                  cbf/color     18
+                  cbf/potential 1.044
+                  cbf/notes     "For general-purpose use in darker beers."}))
 
 
 (def extra-light-dry-extract
   "For general-purpose use in light and very light beers."
   (build-extract :extra-light-dry-extract
-                 {:name      "Extra Light Dry Extract"
-                  :color     3
-                  :potential 1.036
-                  :notes     "For general-purpose use in light and very light beers."}))
+                 {cbf/name      "Extra Light Dry Extract"
+                  cbf/color     3
+                  cbf/potential 1.036
+                  cbf/notes     "For general-purpose use in light and very light beers."}))
 
 
 (def light-dry-extract
   "For general-purpose use in light beers."
   (build-extract :light-dry-extract
-                 {:name      "Light Dry Extract"
-                  :color     8
-                  :potential 1.044
-                  :notes     "For general-purpose use in light beers."}))
+                 {cbf/name      "Light Dry Extract"
+                  cbf/color     8
+                  cbf/potential 1.044
+                  cbf/notes     "For general-purpose use in light beers."}))
 
 
 (def wheat-dry-extract
   "Wheat extract for general-purpose use in wheat beers."
   (build-extract :wheat-dry-extract
-                 {:name      "Wheat Dry Extract"
-                  :color     8
-                  :potential 1.044
-                  :notes     "Wheat extract for general-purpose use in wheat beers."}))
+                 {cbf/name      "Wheat Dry Extract"
+                  cbf/color     8
+                  cbf/potential 1.044
+                  cbf/notes     "Wheat extract for general-purpose use in wheat beers."}))
 
 
 (def dry-extracts

--- a/src/common_beer_data/fermentables/extracts.cljc
+++ b/src/common_beer_data/fermentables/extracts.cljc
@@ -1,12 +1,14 @@
 (ns common-beer-data.fermentables.extracts
-  "Data for malt extracts and brewing sugars")
+  "Data for malt extracts and brewing sugars."
+  {:added "1.0"}
+  (:require [common-beer-format.fermentables :as cbf]))
 
 
 (def ^:private extract-defaults
-  {:version        1
-   :amount         0.0
-   :recommend-mash false
-   :type           "Extract"})
+  {cbf/version        1
+   cbf/amount         0.0
+   cbf/recommend-mash false
+   cbf/type           "Extract"})
 
 
 (defn ^:private build-extract
@@ -17,25 +19,25 @@
 (def amber-liquid-extract
   "Amber colored liquid malt extract for general purpose use."
   (build-extract :amber-liquid-extract
-                 {:name           "Amber Liquid Extract"
-                  :yield          0.78
-                  :color          13
-                  :add-after-boil false
-                  :max-in-batch   1.0
-                  :potential      1.036
-                  :notes          "Amber colored liquid malt extract for general purpose use."}))
+                 {cbf/name           "Amber Liquid Extract"
+                  cbf/yield          0.78
+                  cbf/color          13
+                  cbf/add-after-boil false
+                  cbf/max-in-batch   1.0
+                  cbf/potential      1.036
+                  cbf/notes          "Amber colored liquid malt extract for general purpose use."}))
 
 
 (def dark-liquid-extract
   "For general-purpose use in darker beers."
   (build-extract :dark-liquid-extract
-                 {:name           "Dark Liquid Extract"
-                  :yield          0.78
-                  :color          18
-                  :add-after-boil false
-                  :max-in-batch   1.0
-                  :potential      1.036
-                  :notes          "For general-purpose use in darker beers."}))
+                 {cbf/name           "Dark Liquid Extract"
+                  cbf/yield          0.78
+                  cbf/color          18
+                  cbf/add-after-boil false
+                  cbf/max-in-batch   1.0
+                  cbf/potential      1.036
+                  cbf/notes          "For general-purpose use in darker beers."}))
 
 
 (def honey
@@ -43,61 +45,61 @@
    
    Can be added to primary fermentation, but must be pasteurized."
   (build-extract :honey
-                 {:name           "Honey"
-                  :yield          0.75
-                  :color          1
-                  :add-after-boil true
-                  :max-in-batch   0.3
-                  :potential      1.035
-                  :notes          "Used for light flavor and body. Can be added to primary fermentation, but must be pasteurized."}))
+                 {cbf/name           "Honey"
+                  cbf/yield          0.75
+                  cbf/color          1
+                  cbf/add-after-boil true
+                  cbf/max-in-batch   0.3
+                  cbf/potential      1.035
+                  cbf/notes          "Used for light flavor and body. Can be added to primary fermentation, but must be pasteurized."}))
 
 
 (def pale-liquid-extract
   "For general-purpose use in light and pale beers."
   (build-extract :pale-liquid-extract
-                 {:name           "Pale Liquid Extract"
-                  :yield          0.78
-                  :color          8
-                  :add-after-boil false
-                  :max-in-batch   1.0
-                  :potential      1.036
-                  :notes          "For general-purpose use in light and pale beers."}))
+                 {cbf/name           "Pale Liquid Extract"
+                  cbf/yield          0.78
+                  cbf/color          8
+                  cbf/add-after-boil false
+                  cbf/max-in-batch   1.0
+                  cbf/potential      1.036
+                  cbf/notes          "For general-purpose use in light and pale beers."}))
 
 
 (def pilsner-liquid-extract
   "For general-purpose use in pale beers."
   (build-extract :pilsner-liquid-extract
-                 {:name           "Pilsner Liquid Extract"
-                  :yield          0.78
-                  :color          4
-                  :add-after-boil false
-                  :max-in-batch   1.0
-                  :potential      1.036
-                  :notes          "For general-purpose use in pale beers."}))
+                 {cbf/name           "Pilsner Liquid Extract"
+                  cbf/yield          0.78
+                  cbf/color          4
+                  cbf/add-after-boil false
+                  cbf/max-in-batch   1.0
+                  cbf/potential      1.036
+                  cbf/notes          "For general-purpose use in pale beers."}))
 
 
 (def rice-extract-syrup
   "Used like other rice adjuncts in American and Japanese lagers."
   (build-extract :rice-extract-syrup
-                 {:name           "Rice Extract Syrup"
-                  :yield          0.69
-                  :color          7
-                  :add-after-boil false
-                  :max-in-batch   0.15
-                  :potential      1.032
-                  :notes          "Used like other rice adjuncts in American and Japanese lagers."}))
+                 {cbf/name           "Rice Extract Syrup"
+                  cbf/yield          0.69
+                  cbf/color          7
+                  cbf/add-after-boil false
+                  cbf/max-in-batch   0.15
+                  cbf/potential      1.032
+                  cbf/notes          "Used like other rice adjuncts in American and Japanese lagers."}))
 
 
 (def rye-liquid-extract
   "Mixed rye/barley extract for general-purpose brewing."
   (build-extract :rye-liquid-extract
-                 {:name           "Rye Liquid Extract"
-                  :yield          0.69
-                  :color          7
-                  :add-after-boil false
-                  :max-in-batch   1.0
-                  :potential      1.034
-                  :notes          "Mixed rye/barley extract for general-purpose brewing."}))
+                 {cbf/name           "Rye Liquid Extract"
+                  cbf/yield          0.69
+                  cbf/color          7
+                  cbf/add-after-boil false
+                  cbf/max-in-batch   1.0
+                  cbf/potential      1.034
+                  cbf/notes          "Mixed rye/barley extract for general-purpose brewing."}))
 
 
 (def sorghum-syrup
@@ -105,25 +107,25 @@
    
    Can be used as a substitute for Light Malt Extract."
   (build-extract :sorghum-syrup
-                 {:name           "Sorghum Syrup"
-                  :yield          0.78
-                  :color          7
-                  :add-after-boil false
-                  :max-in-batch   1.0
-                  :potential      1.036
-                  :notes          "A gluten-free extract based on sorghum grain. Can be used as a substitute for Light Malt Extract."}))
+                 {cbf/name           "Sorghum Syrup"
+                  cbf/yield          0.78
+                  cbf/color          7
+                  cbf/add-after-boil false
+                  cbf/max-in-batch   1.0
+                  cbf/potential      1.036
+                  cbf/notes          "A gluten-free extract based on sorghum grain. Can be used as a substitute for Light Malt Extract."}))
 
 
 (def wheat-liquid-extract
   "Wheat/barley extract for general-purpose use in wheat beers."
   (build-extract :wheat-liquid-extract
-                 {:name           "Wheat Liquid Extract"
-                  :yield          0.78
-                  :color          8
-                  :add-after-boil false
-                  :max-in-batch   1.0
-                  :potential      1.036
-                  :notes          "Wheat/barley extract for general-purpose use in wheat beers."}))
+                 {cbf/name           "Wheat Liquid Extract"
+                  cbf/yield          0.78
+                  cbf/color          8
+                  cbf/add-after-boil false
+                  cbf/max-in-batch   1.0
+                  cbf/potential      1.036
+                  cbf/notes          "Wheat/barley extract for general-purpose use in wheat beers."}))
 
 
 (def extracts

--- a/src/common_beer_data/fermentables/grains.cljc
+++ b/src/common_beer_data/fermentables/grains.cljc
@@ -1,11 +1,13 @@
 (ns common-beer-data.fermentables.grains
-  "Data for malt barley and core grains")
+  "Data for malt barley and core grains."
+  {:added "1.0"}
+  (:require [common-beer-format.fermentables :as cbf]))
 
 
 (def ^:private grain-defaults
-  {:version 1
-   :amount  0.0
-   :type    "Grain"})
+  {cbf/version 1
+   cbf/amount  0.0
+   cbf/type    "Grain"})
 
 
 (defn ^:private build-grain
@@ -19,18 +21,18 @@
    Used by German brewers to adjust malt PH without chemicals to adhere to German purity laws.
    Also enhances head retention."
   (build-grain :acid-malt
-               {:name             "Acid Malt"
-                :potential        1.027
-                :yield            0.587
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            3
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0.06
-                :notes            "Acid malt contains acids from natural lactic acids. Used by German brewers to adjust malt PH without chemicals to adhere to German purity laws. Also enhances the head retention."}))
+               {cbf/name             "Acid Malt"
+                cbf/potential        1.027
+                cbf/yield            0.587
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            3
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0.06
+                cbf/notes            "Acid malt contains acids from natural lactic acids. Used by German brewers to adjust malt PH without chemicals to adhere to German purity laws. Also enhances the head retention."}))
 
 
 (def amber-malt
@@ -39,35 +41,35 @@
    Intense flavor - so limit use.
    Low diastatic power so must be mashed with well modified malts."
   (build-grain :amber-malt
-               {:name             "Amber Malt"
-                :potential        1.035
-                :yield            0.75
-                :coarse-fine-diff 0.015
-                :moisture         0.028
-                :color            22
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  20
-                :max-in-batch     0.2
-                :protein          0.1
-                :notes            "Roasted specialty malt used in some English browns, milds and old ales to add color and a biscuit taste. Intense flavor - so limit use. Low diastatic power so must be mashed with well modified malts."}))
+               {cbf/name             "Amber Malt"
+                cbf/potential        1.035
+                cbf/yield            0.75
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.028
+                cbf/color            22
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  20
+                cbf/max-in-batch     0.2
+                cbf/protein          0.1
+                cbf/notes            "Roasted specialty malt used in some English browns, milds and old ales to add color and a biscuit taste. Intense flavor - so limit use. Low diastatic power so must be mashed with well modified malts."}))
 
 
 (def aromatic-malt
   "Provides a very strong malt flavor and aroma to your beer."
   (build-grain :aromatic-malt
-               {:name             "Aromatic Malt"
-                :potential        1.036
-                :yield            0.78
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            26
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  29
-                :max-in-batch     0.1
-                :protein          0.118
-                :notes            "Provides a very strong malt flavor and aroma to your beer."}))
+               {cbf/name             "Aromatic Malt"
+                cbf/potential        1.036
+                cbf/yield            0.78
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            26
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  29
+                cbf/max-in-batch     0.1
+                cbf/protein          0.118
+                cbf/notes            "Provides a very strong malt flavor and aroma to your beer."}))
 
 
 (def barley-flaked
@@ -75,18 +77,18 @@
    
    High haze producing protein prevents use in light beers."
   (build-grain :barley-flaked
-               {:name             "Barley, Flaked"
-                :potential        1.032
-                :yield            0.7
-                :coarse-fine-diff 0.015
-                :moisture         0.09
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.135
-                :notes            "Adds significant body to Porters and Stouts. High haze producing protein prevents use in light beers."}))
+               {cbf/name             "Barley, Flaked"
+                cbf/potential        1.032
+                cbf/yield            0.7
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.09
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.135
+                cbf/notes            "Adds significant body to Porters and Stouts. High haze producing protein prevents use in light beers."}))
 
 
 (def barley-raw
@@ -95,18 +97,18 @@
    Use in homebrew requires very fine milling combined with a decoction or multi-stage mash.
    Performs best when used in small quantities with well modified grains."
   (build-grain :barley-raw
-               {:name             "Barley, Raw"
-                :potential        1.028
-                :yield            0.609
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.15
-                :protein          0.117
-                :notes            "Raw, unmalted barley can be used to add body to your beer. Use in homebrew requires very fine milling combined with a decoction or multi-stage mash. Performs best when used in small quantities with well modified grains."}))
+               {cbf/name             "Barley, Raw"
+                cbf/potential        1.028
+                cbf/yield            0.609
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.15
+                cbf/protein          0.117
+                cbf/notes            "Raw, unmalted barley can be used to add body to your beer. Use in homebrew requires very fine milling combined with a decoction or multi-stage mash. Performs best when used in small quantities with well modified grains."}))
 
 
 (def barley-torrefied
@@ -115,18 +117,18 @@
    Used in place of raw barley for faster conversion and higher yields.
    High in haze producing protein."
   (build-grain :barley-torrefied
-               {:name             "Barley, Torrefied"
-                :potential        1.036
-                :yield            0.79
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.4
-                :protein          0.16
-                :notes            "Raw barley that has been popped to open the kernels. Used in place of raw barley for faster conversion and higher yields. High in haze producing protein."}))
+               {cbf/name             "Barley, Torrefied"
+                cbf/potential        1.036
+                cbf/yield            0.79
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.4
+                cbf/protein          0.16
+                cbf/notes            "Raw barley that has been popped to open the kernels. Used in place of raw barley for faster conversion and higher yields. High in haze producing protein."}))
 
 
 (def biscuit-malt
@@ -135,18 +137,18 @@
    Adds a biscuit like flavor and aroma.
    Can be used as a substitute for toasted malt."
   (build-grain :biscuit-malt
-               {:name             "Biscuit Malt"
-                :potential        1.036
-                :yield            0.79
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            23
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  6
-                :max-in-batch     0.1
-                :protein          0.105
-                :notes            "Use for English ales, brown ales and porters. Adds a biscuit like flavor and aroma. Can be used as a substitute for toasted malt."}))
+               {cbf/name             "Biscuit Malt"
+                cbf/potential        1.036
+                cbf/yield            0.79
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            23
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  6
+                cbf/max-in-batch     0.1
+                cbf/protein          0.105
+                cbf/notes            "Use for English ales, brown ales and porters. Adds a biscuit like flavor and aroma. Can be used as a substitute for toasted malt."}))
 
 
 (def black-patent-malt
@@ -154,18 +156,18 @@
    
    Used for: Coloring in small amounts, or flavoring of Stouts and Porters in larger amounts."
   (build-grain :black-patent-malt
-               {:name             "Black (Patent) Malt"
-                :potential        1.025
-                :yield            0.55
-                :coarse-fine-diff 0.015
-                :moisture         0.06
-                :color            500
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0.132
-                :notes            "Dark color and dry roasted flavor characteristic of Stouts and Porters. Used for: Coloring in small amounts, or flavoring of Stouts and Porters in larger amounts."}))
+               {cbf/name             "Black (Patent) Malt"
+                cbf/potential        1.025
+                cbf/yield            0.55
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.06
+                cbf/color            500
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0.132
+                cbf/notes            "Dark color and dry roasted flavor characteristic of Stouts and Porters. Used for: Coloring in small amounts, or flavoring of Stouts and Porters in larger amounts."}))
 
 
 (def black-barley-stout
@@ -174,18 +176,18 @@
    Imparts a sharp acrid flavor characteristic of dry stouts.
    Gives dryness to a stout or porter."
   (build-grain :black-barley-stout
-               {:name             "Black Barley (Stout)"
-                :potential        1.025
-                :yield            0.55
-                :coarse-fine-diff 0.015
-                :moisture         0.05
-                :color            500
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0.132
-                :notes            "Unmalted barley roasted at high temperature to create a dry, coffee like flavor. Imparts a sharp acrid flavor characteristic of dry stouts. Gives dryness to a stout or porter."}))
+               {cbf/name             "Black Barley (Stout)"
+                cbf/potential        1.025
+                cbf/yield            0.55
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.05
+                cbf/color            500
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0.132
+                cbf/notes            "Unmalted barley roasted at high temperature to create a dry, coffee like flavor. Imparts a sharp acrid flavor characteristic of dry stouts. Gives dryness to a stout or porter."}))
 
 
 (def brown-malt
@@ -193,18 +195,18 @@
    
    Used in nut brown ales, porters and some Belgian ales."
   (build-grain :brown-malt
-               {:name             "Brown Malt"
-                :potential        1.032
-                :yield            0.7
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            65
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0
-                :notes            "Imparts a dry, biscuit flavor. Used in nut brown ales, porters and some Belgian ales."}))
+               {cbf/name             "Brown Malt"
+                cbf/potential        1.032
+                cbf/yield            0.7
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            65
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0
+                cbf/notes            "Imparts a dry, biscuit flavor. Used in nut brown ales, porters and some Belgian ales."}))
 
 
 (def brumalt
@@ -212,256 +214,256 @@
    
    Helps create authentic maltiness without having to do a decoction mash."
   (build-grain :brumalt
-               {:name             "Brumalt"
-                :potential        1.033
-                :yield            0.717
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            23
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0.07
-                :notes            "Dark German malt developed to add malt flavor of Alt, Marzen and Oktoberfest beers. Helps create authentic maltiness without having to do a decoction mash."}))
+               {cbf/name             "Brumalt"
+                cbf/potential        1.033
+                cbf/yield            0.717
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            23
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0.07
+                cbf/notes            "Dark German malt developed to add malt flavor of Alt, Marzen and Oktoberfest beers. Helps create authentic maltiness without having to do a decoction mash."}))
 
 
 (def cara-pils-dextrine
   "Significantly increases foam/head retention and body of the beer."
   (build-grain :cara-pils-dextrine
-               {:name             "Cara-Pils/Dextrine"
-                :potential        1.033
-                :yield            0.72
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            2
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.132
-                :notes            "Significantly increases foam/head retention and body of the beer."}))
+               {cbf/name             "Cara-Pils/Dextrine"
+                cbf/potential        1.033
+                cbf/yield            0.72
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.132
+                cbf/notes            "Significantly increases foam/head retention and body of the beer."}))
 
 
 (def carafoam
   "Significantly increases foam/head retention and body of the beer."
   (build-grain :carafoam
-               {:name             "CaraFoam"
-                :potential        1.033
-                :yield            0.72
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            2
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.132
-                :notes            "Significantly increases foam/head retention and body of the beer."}))
+               {cbf/name             "CaraFoam"
+                cbf/potential        1.033
+                cbf/yield            0.72
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.132
+                cbf/notes            "Significantly increases foam/head retention and body of the beer."}))
 
 
 (def dextrine
   "Significantly increases foam/head retention and body of the beer."
   (build-grain :dextrine
-               {:name             "Dextrine"
-                :potential        1.033
-                :yield            0.72
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            2
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.132
-                :notes            "Significantly increases foam/head retention and body of the beer."}))
+               {cbf/name             "Dextrine"
+                cbf/potential        1.033
+                cbf/yield            0.72
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.132
+                cbf/notes            "Significantly increases foam/head retention and body of the beer."}))
 
 
 (def caraamber
   "Adds body, color and improves head retention."
   (build-grain :caraamber
-               {:name             "Caraamber"
-                :potential        1.035
-                :yield            0.75
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            30
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.132
-                :notes            "Adds body, color and improves head retention."}))
+               {cbf/name             "Caraamber"
+                cbf/potential        1.035
+                cbf/yield            0.75
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            30
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.132
+                cbf/notes            "Adds body, color and improves head retention."}))
 
 
 (def caramel-crystal-malt-10l
   "Adds body, color and improves head retention."
   (build-grain :caramel-crystal-malt-10l
-               {:name             "Caramel/Crystal Malt - 10L"
-                :potential        1.035
-                :yield            0.75
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            10
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.132
-                :notes            "Adds body, color and improves head retention."}))
+               {cbf/name             "Caramel/Crystal Malt - 10L"
+                cbf/potential        1.035
+                cbf/yield            0.75
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            10
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.132
+                cbf/notes            "Adds body, color and improves head retention."}))
 
 
 (def caramel-crystal-malt-20l
   "Adds body, color and improves head retention."
   (build-grain :caramel-crystal-malt-20l
-               {:name             "Caramel/Crystal Malt - 20L"
-                :potential        1.035
-                :yield            0.75
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            20
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.132
-                :notes            "Adds body, color and improves head retention."}))
+               {cbf/name             "Caramel/Crystal Malt - 20L"
+                cbf/potential        1.035
+                cbf/yield            0.75
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            20
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.132
+                cbf/notes            "Adds body, color and improves head retention."}))
 
 
 (def caramel-crystal-malt-30l
   "Adds body, color and improves head retention."
   (build-grain :caramel-crystal-malt-30l
-               {:name             "Caramel/Crystal Malt - 30L"
-                :potential        1.035
-                :yield            0.75
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            30
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.132
-                :notes            "Adds body, color and improves head retention."}))
+               {cbf/name             "Caramel/Crystal Malt - 30L"
+                cbf/potential        1.035
+                cbf/yield            0.75
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            30
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.132
+                cbf/notes            "Adds body, color and improves head retention."}))
 
 
 (def caramel-crystal-malt-40l
   "Adds body, color and improves head retention."
   (build-grain :caramel-crystal-malt-40l
-               {:name             "Caramel/Crystal Malt - 40L"
-                :potential        1.034
-                :yield            0.74
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            40
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.132
-                :notes            "Adds body, color and improves head retention."}))
+               {cbf/name             "Caramel/Crystal Malt - 40L"
+                cbf/potential        1.034
+                cbf/yield            0.74
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            40
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.132
+                cbf/notes            "Adds body, color and improves head retention."}))
 
 
 (def caramel-crystal-malt-60l
   "Adds body, color and improves head retention."
   (build-grain :caramel-crystal-malt-60l
-               {:name             "Caramel/Crystal Malt - 60L"
-                :potential        1.034
-                :yield            0.74
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            60
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.132
-                :notes            "Adds body, color and improves head retention."}))
+               {cbf/name             "Caramel/Crystal Malt - 60L"
+                cbf/potential        1.034
+                cbf/yield            0.74
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            60
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.132
+                cbf/notes            "Adds body, color and improves head retention."}))
 
 
 (def caramel-crystal-malt-80l
   "Adds body, color and improves head retention."
   (build-grain :caramel-crystal-malt-80l
-               {:name             "Caramel/Crystal Malt - 80L"
-                :potential        1.034
-                :yield            0.74
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            80
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.132
-                :notes            "Adds body, color and improves head retention."}))
+               {cbf/name             "Caramel/Crystal Malt - 80L"
+                cbf/potential        1.034
+                cbf/yield            0.74
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            80
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.132
+                cbf/notes            "Adds body, color and improves head retention."}))
 
 
 (def caramel-crystal-malt-90l
   "Adds body, color and improves head retention."
   (build-grain :caramel-crystal-malt-90l
-               {:name             "Caramel/Crystal Malt - 90L"
-                :potential        1.034
-                :yield            0.74
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            90
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.132
-                :notes            "Adds body, color and improves head retention."}))
+               {cbf/name             "Caramel/Crystal Malt - 90L"
+                cbf/potential        1.034
+                cbf/yield            0.74
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            90
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.132
+                cbf/notes            "Adds body, color and improves head retention."}))
 
 
 (def caramel-crystal-malt-120l
   "Adds body, color and improves head retention."
   (build-grain :caramel-crystal-malt-120l
-               {:name             "Caramel/Crystal Malt - 120L"
-                :potential        1.033
-                :yield            0.72
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            120
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.102
-                :notes            "Adds body, color and improves head retention."}))
+               {cbf/name             "Caramel/Crystal Malt - 120L"
+                cbf/potential        1.033
+                cbf/yield            0.72
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            120
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.102
+                cbf/notes            "Adds body, color and improves head retention."}))
 
 
 (def caramel-crystal-malt-140l
   "Adds body, color and improves head retention."
   (build-grain :caramel-crystal-malt-140l
-               {:name             "Caramel/Crystal Malt - 140L"
-                :potential        1.033
-                :yield            0.72
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            140
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.102
-                :notes            "Adds body, color and improves head retention."}))
+               {cbf/name             "Caramel/Crystal Malt - 140L"
+                cbf/potential        1.033
+                cbf/yield            0.72
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            140
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.102
+                cbf/notes            "Adds body, color and improves head retention."}))
 
 
 (def caramel-crystal-malt-160l
   "Adds body, color and improves head retention."
   (build-grain :caramel-crystal-malt-160l
-               {:name             "Caramel/Crystal Malt - 160L"
-                :potential        1.033
-                :yield            0.72
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            160
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.102
-                :notes            "Adds body, color and improves head retention."}))
+               {cbf/name             "Caramel/Crystal Malt - 160L"
+                cbf/potential        1.033
+                cbf/yield            0.72
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            160
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.102
+                cbf/notes            "Adds body, color and improves head retention."}))
 
 
 (def caramunich-malt
@@ -469,35 +471,35 @@
    
    Used in Belgian ales and German bocks."
   (build-grain :caramunich-malt
-               {:name             "Caramunich Malt"
-                :potential        1.033
-                :yield            0.717
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            56
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0
-                :notes            "Caramel, copper colored malt. Used in Belgian ales and German bocks."}))
+               {cbf/name             "Caramunich Malt"
+                cbf/potential        1.033
+                cbf/yield            0.717
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            56
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0
+                cbf/notes            "Caramel, copper colored malt. Used in Belgian ales and German bocks."}))
 
 
 (def carared
   "Adds body, color and improves head retention."
   (build-grain :carared
-               {:name             "Carared"
-                :potential        1.035
-                :yield            0.75
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            20
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0.132
-                :notes            "Adds body, color and improves head retention."}))
+               {cbf/name             "Carared"
+                cbf/potential        1.035
+                cbf/yield            0.75
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            20
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0.132
+                cbf/notes            "Adds body, color and improves head retention."}))
 
 
 (def caravienne-malt
@@ -505,18 +507,18 @@
    
    Used in light Trappist and Abbey style Belgian ales."
   (build-grain :caravienne-malt
-               {:name             "Caravienne Malt"
-                :potential        1.034
-                :yield            0.739
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            22
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0
-                :notes            "Light Belgian crystal malt. Used in light Trappist and Abbey style Belgian ales."}))
+               {cbf/name             "Caravienne Malt"
+                cbf/potential        1.034
+                cbf/yield            0.739
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            22
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0
+                cbf/notes            "Light Belgian crystal malt. Used in light Trappist and Abbey style Belgian ales."}))
 
 
 (def chocolate-malt
@@ -524,18 +526,18 @@
    
    Maintains some malty flavor, not as dark as roasted malt."
   (build-grain :chocolate-malt
-               {:name             "Chocolate Malt"
-                :potential        1.028
-                :yield            0.6
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            350
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0.132
-                :notes            "Dark malt that gives a rich red or brown color and nutty flavor. Maintains some malty flavor, not as dark as roasted malt."}))
+               {cbf/name             "Chocolate Malt"
+                cbf/potential        1.028
+                cbf/yield            0.6
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            350
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0.132
+                cbf/notes            "Dark malt that gives a rich red or brown color and nutty flavor. Maintains some malty flavor, not as dark as roasted malt."}))
 
 
 (def chocolate-malt-uk
@@ -543,52 +545,52 @@
    
    Maintains some malty flavor, not as dark as roasted malt."
   (build-grain :chocolate-malt-uk
-               {:name             "Chocolate Malt (UK)"
-                :potential        1.034
-                :yield            0.73
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            450
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0.105
-                :notes            "Dark malt that gives a rich red or brown color and nutty flavor. Maintains some malty flavor, not as dark as roasted malt."}))
+               {cbf/name             "Chocolate Malt (UK)"
+                cbf/potential        1.034
+                cbf/yield            0.73
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            450
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0.105
+                cbf/notes            "Dark malt that gives a rich red or brown color and nutty flavor. Maintains some malty flavor, not as dark as roasted malt."}))
 
 
 (def corn-flaked
   "Generally a neutral flavor; used to reduce maltiness of beer."
   (build-grain :corn-flaked
-               {:name             "Corn (Flaked)"
-                :potential        1.030
-                :yield            0.825
-                :coarse-fine-diff 0.015
-                :moisture         0.09
-                :color            3
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     1
-                :protein          0.1
-                :notes            "Generally a neutral flavor, used to reduce maltiness of beer."}))
+               {cbf/name             "Corn (Flaked)"
+                cbf/potential        1.030
+                cbf/yield            0.825
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.09
+                cbf/color            3
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     1
+                cbf/protein          0.1
+                cbf/notes            "Generally a neutral flavor, used to reduce maltiness of beer."}))
 
 
 (def maris-otter-pale-malt
   "A base malt from the UK."
   (build-grain :maris-otter-pale-malt
-               {:name             "Maris Otter Pale Malt"
-                :potential        1.037
-                :yield            0.8
-                :coarse-fine-diff 0.013
-                :moisture         0.035
-                :color            1
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  10
-                :max-in-batch     1
-                :protein          0.1
-                :notes            "A base malt from the UK."}))
+               {cbf/name             "Maris Otter Pale Malt"
+                cbf/potential        1.037
+                cbf/yield            0.8
+                cbf/coarse-fine-diff 0.013
+                cbf/moisture         0.035
+                cbf/color            1
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  10
+                cbf/max-in-batch     1
+                cbf/protein          0.1
+                cbf/notes            "A base malt from the UK."}))
 
 
 (def melanoiden-malt
@@ -597,35 +599,35 @@
    Promotes a full flavor and rounds off beer color.
    Promotes deep red color and malty flavor."
   (build-grain :melanoiden-malt
-               {:name             "Melanoiden Malt"
-                :potential        1.037
-                :yield            0.8
-                :coarse-fine-diff 0.013
-                :moisture         0.035
-                :color            20
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  10
-                :max-in-batch     0.15
-                :protein          0.11
-                :notes            "Aromatic malt from Banberg, Germany. Promotes a full flavor and rounds off beer color. Promotes deep red color and malty flavor."}))
+               {cbf/name             "Melanoiden Malt"
+                cbf/potential        1.037
+                cbf/yield            0.8
+                cbf/coarse-fine-diff 0.013
+                cbf/moisture         0.035
+                cbf/color            20
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  10
+                cbf/max-in-batch     0.15
+                cbf/protein          0.11
+                cbf/notes            "Aromatic malt from Banberg, Germany. Promotes a full flavor and rounds off beer color. Promotes deep red color and malty flavor."}))
 
 
 (def mild-malt
   "Also called 'English Mild' - a light specialty malt used in Brown Ales."
   (build-grain :mild-malt
-               {:name             "Mild Malt"
-                :potential        1.037
-                :yield            0.8
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            4
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  53
-                :max-in-batch     1
-                :protein          0.106
-                :notes            "Also called 'English Mild' - a light specialty malt used in Brown Ales."}))
+               {cbf/name             "Mild Malt"
+                cbf/potential        1.037
+                cbf/yield            0.8
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            4
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  53
+                cbf/max-in-batch     1
+                cbf/protein          0.106
+                cbf/notes            "Also called 'English Mild' - a light specialty malt used in Brown Ales."}))
 
 
 (def munich-malt
@@ -633,52 +635,52 @@
    
    Does not contribute signficantly to body or head retention."
   (build-grain :munich-malt
-               {:name             "Munich Malt"
-                :potential        1.037
-                :yield            0.8
-                :coarse-fine-diff 0.013
-                :moisture         0.05
-                :color            9
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  72
-                :max-in-batch     0.8
-                :protein          0.115
-                :notes            "Malty-sweet flavor characteristic and adds a reddish amber color to the beer. Does not contribute signficantly to body or head retention."}))
+               {cbf/name             "Munich Malt"
+                cbf/potential        1.037
+                cbf/yield            0.8
+                cbf/coarse-fine-diff 0.013
+                cbf/moisture         0.05
+                cbf/color            9
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  72
+                cbf/max-in-batch     0.8
+                cbf/protein          0.115
+                cbf/notes            "Malty-sweet flavor characteristic and adds a reddish amber color to the beer. Does not contribute signficantly to body or head retention."}))
 
 
 (def munich-malt-10l
   "Malty-sweet flavor characteristic and adds a slight orange color to the beer."
   (build-grain :munich-malt-10l
-               {:name             "Munich Malt - 10L"
-                :potential        1.035
-                :yield            0.77
-                :coarse-fine-diff 0.028
-                :moisture         0.05
-                :color            10
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  50
-                :max-in-batch     0.8
-                :protein          0.135
-                :notes            "Malty-sweet flavor characteristic and adds a slight orange color to the beer."}))
+               {cbf/name             "Munich Malt - 10L"
+                cbf/potential        1.035
+                cbf/yield            0.77
+                cbf/coarse-fine-diff 0.028
+                cbf/moisture         0.05
+                cbf/color            10
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  50
+                cbf/max-in-batch     0.8
+                cbf/protein          0.135
+                cbf/notes            "Malty-sweet flavor characteristic and adds a slight orange color to the beer."}))
 
 
 (def munich-malt-20l
   "Malty-sweet flavor characteristic and adds a slight orange color to the beer."
   (build-grain :munich-malt-20l
-               {:name             "Munich Malt - 20L"
-                :potential        1.035
-                :yield            0.75
-                :coarse-fine-diff 0.028
-                :moisture         0.05
-                :color            20
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  25
-                :max-in-batch     0.8
-                :protein          0.135
-                :notes            "Malty-sweet flavor characteristic and adds a orange to deep orange color to the beer."}))
+               {cbf/name             "Munich Malt - 20L"
+                cbf/potential        1.035
+                cbf/yield            0.75
+                cbf/coarse-fine-diff 0.028
+                cbf/moisture         0.05
+                cbf/color            20
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  25
+                cbf/max-in-batch     0.8
+                cbf/protein          0.135
+                cbf/notes            "Malty-sweet flavor characteristic and adds a orange to deep orange color to the beer."}))
 
 
 (def oats-flaked
@@ -687,18 +689,18 @@
    Adds substantial protein haze to light beers.
    Protein rest recommended unless flakes are pre-gelatinized."
   (build-grain :oats-flaked
-               {:name             "Oats, Flaked"
-                :potential        1.037
-                :yield            0.8
-                :coarse-fine-diff 0.015
-                :moisture         0.09
-                :color            1
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.3
-                :protein          0.09
-                :notes            "Adds body, mouth feel and head retention to the beer. Adds substantial protein haze to light beers. Protein rest recommended unless flakes are pre-gelatinized."}))
+               {cbf/name             "Oats, Flaked"
+                cbf/potential        1.037
+                cbf/yield            0.8
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.09
+                cbf/color            1
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.3
+                cbf/protein          0.09
+                cbf/notes            "Adds body, mouth feel and head retention to the beer. Adds substantial protein haze to light beers. Protein rest recommended unless flakes are pre-gelatinized."}))
 
 
 (def oats-malted
@@ -706,86 +708,86 @@
    
    Creates chill haze in lighter beers, so is primarily used in dark ones."
   (build-grain :oats-malted
-               {:name             "Oats, Malted"
-                :potential        1.037
-                :yield            0.8
-                :coarse-fine-diff 0.015
-                :moisture         0.09
-                :color            1
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0.09
-                :notes            "Malted oats. Adds body, mouth feel and head retention to the beer. Creates chill haze in lighter beers, so is primarily used in dark ones."}))
+               {cbf/name             "Oats, Malted"
+                cbf/potential        1.037
+                cbf/yield            0.8
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.09
+                cbf/color            1
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0.09
+                cbf/notes            "Malted oats. Adds body, mouth feel and head retention to the beer. Creates chill haze in lighter beers, so is primarily used in dark ones."}))
 
 
 (def pale-malt-2-row-belgium
   "Base malt for all beer styles."
   (build-grain :pale-malt-2-row-belgium
-               {:name             "Pale Malt (2 Row) - Belgium"
-                :potential        1.037
-                :yield            0.8
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            3
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  60
-                :max-in-batch     1
-                :protein          0.105
-                :notes            "Base malt for all beer styles."}))
+               {cbf/name             "Pale Malt (2 Row) - Belgium"
+                cbf/potential        1.037
+                cbf/yield            0.8
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            3
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  60
+                cbf/max-in-batch     1
+                cbf/protein          0.105
+                cbf/notes            "Base malt for all beer styles."}))
 
 
 (def pale-malt-2-row-uk
   "Base malt for all beer styles."
   (build-grain :pale-malt-2-row-uk
-               {:name             "Pale Malt (2 Row) - UK"
-                :potential        1.036
-                :yield            0.78
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            3
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  45
-                :max-in-batch     1
-                :protein          0.101
-                :notes            "Base malt for all English beer styles."}))
+               {cbf/name             "Pale Malt (2 Row) - UK"
+                cbf/potential        1.036
+                cbf/yield            0.78
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            3
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  45
+                cbf/max-in-batch     1
+                cbf/protein          0.101
+                cbf/notes            "Base malt for all English beer styles."}))
 
 
 (def pale-malt-2-row-us
   "Base malt for all beer styles."
   (build-grain :pale-malt-2-row-us
-               {:name             "Pale Malt (2 Row) - USA"
-                :potential        1.036
-                :yield            0.79
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  140
-                :max-in-batch     1
-                :protein          0.123
-                :notes            "Base malt for all beer styles."}))
+               {cbf/name             "Pale Malt (2 Row) - USA"
+                cbf/potential        1.036
+                cbf/yield            0.79
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  140
+                cbf/max-in-batch     1
+                cbf/protein          0.123
+                cbf/notes            "Base malt for all beer styles."}))
 
 
 (def pale-malt-6-row-us
   "Base malt for all beer styles."
   (build-grain :pale-malt-6-row-us
-               {:name             "Pale Malt (6 Row) - USA"
-                :potential        1.035
-                :yield            0.76
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  150
-                :max-in-batch     1
-                :protein          0.13
-                :notes            "Base malt for all beer styles."}))
+               {cbf/name             "Pale Malt (6 Row) - USA"
+                cbf/potential        1.035
+                cbf/yield            0.76
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  150
+                cbf/max-in-batch     1
+                cbf/protein          0.13
+                cbf/notes            "Base malt for all beer styles."}))
 
 
 (def peat-smoked-malt
@@ -793,69 +795,69 @@
    
    Used in scottish ales and wee heavy ales."
   (build-grain :peat-smoked-malt
-               {:name             "Peat Smoked Malt"
-                :potential        1.034
-                :yield            0.74
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            3
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.2
-                :protein          0
-                :notes            "Robust smoky malt that provides a smoky flavor. Used in scottish ales and wee heavy ales."}))
+               {cbf/name             "Peat Smoked Malt"
+                cbf/potential        1.034
+                cbf/yield            0.74
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            3
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.2
+                cbf/protein          0
+                cbf/notes            "Robust smoky malt that provides a smoky flavor. Used in scottish ales and wee heavy ales."}))
 
 
 (def pilsner-2-row-belgium
   "Belgian base malt for Continental lagers."
   (build-grain :pilsner-2-row-belgium
-               {:name             "Pilsner (2 Row) - Belgium"
-                :potential        1.036
-                :yield            0.79
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  105
-                :max-in-batch     1
-                :protein          0.105
-                :notes            "Belgian base malt for Continental lagers."}))
+               {cbf/name             "Pilsner (2 Row) - Belgium"
+                cbf/potential        1.036
+                cbf/yield            0.79
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  105
+                cbf/max-in-batch     1
+                cbf/protein          0.105
+                cbf/notes            "Belgian base malt for Continental lagers."}))
 
 
 (def pilsner-2-row-germany
   "German base for Pilsners and Bohemian Lagers."
   (build-grain :pilsner-2-row-germany
-               {:name             "Pilsner (2 Row) - Germany"
-                :potential        1.037
-                :yield            0.81
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  110
-                :max-in-batch     1
-                :protein          0.11
-                :notes            "German base for Pilsners and Bohemian Lagers."}))
+               {cbf/name             "Pilsner (2 Row) - Germany"
+                cbf/potential        1.037
+                cbf/yield            0.81
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  110
+                cbf/max-in-batch     1
+                cbf/protein          0.11
+                cbf/notes            "German base for Pilsners and Bohemian Lagers."}))
 
 
 (def pilsner-2-row-uk
   "Pilsner base malt."
   (build-grain :pilsner-2-row-uk
-               {:name             "Pilsner (2 Row) - UK"
-                :potential        1.036
-                :yield            0.78
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            1
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  60
-                :max-in-batch     1
-                :protein          0.1
-                :notes            "Pilsner base malt."}))
+               {cbf/name             "Pilsner (2 Row) - UK"
+                cbf/potential        1.036
+                cbf/yield            0.78
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            1
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  60
+                cbf/max-in-batch     1
+                cbf/protein          0.1
+                cbf/notes            "Pilsner base malt."}))
 
 
 (def rice-flaked
@@ -863,18 +865,18 @@
    
    Produces a milder, less grainy tasting beer."
   (build-grain :rice-flaked
-               {:name             "Rice, Flaked"
-                :potential        1.032
-                :yield            0.7
-                :coarse-fine-diff 0.015
-                :moisture         0.09
-                :color            1
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.25
-                :protein          0.1
-                :notes            "Used to add fermentable sugar without increasing body. Produces a milder, less grainy tasting beer."}))
+               {cbf/name             "Rice, Flaked"
+                cbf/potential        1.032
+                cbf/yield            0.7
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.09
+                cbf/color            1
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.25
+                cbf/protein          0.1
+                cbf/notes            "Used to add fermentable sugar without increasing body. Produces a milder, less grainy tasting beer."}))
 
 
 (def roasted-barley
@@ -882,18 +884,18 @@
    
    Imparts a red to deep brown color to beer, and very strong roasted flavor."
   (build-grain :roasted-barley
-               {:name             "Roasted Barley"
-                :potential        1.025
-                :yield            0.55
-                :coarse-fine-diff 0.015
-                :moisture         0.05
-                :color            300
-                :recommend-mash   false
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0.132
-                :notes            "Roasted at high temperature to create a burnt, grainy, coffee like flavor. Imparts a red to deep brown color to beer, and very strong roasted flavor."}))
+               {cbf/name             "Roasted Barley"
+                cbf/potential        1.025
+                cbf/yield            0.55
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.05
+                cbf/color            300
+                cbf/recommend-mash   false
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0.132
+                cbf/notes            "Roasted at high temperature to create a burnt, grainy, coffee like flavor. Imparts a red to deep brown color to beer, and very strong roasted flavor."}))
 
 
 (def rye-malt
@@ -901,52 +903,52 @@
    
    Yields a deep red color, and a distinctive rye flavor."
   (build-grain :rye-malt
-               {:name             "Rye Malt"
-                :potential        1.029
-                :yield            0.63
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            5
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  75
-                :max-in-batch     0.15
-                :protein          0.103
-                :notes            "Adds a dry, crisp character to the beer. Yields a deep red color, and a distinctive rye flavor."}))
+               {cbf/name             "Rye Malt"
+                cbf/potential        1.029
+                cbf/yield            0.63
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            5
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  75
+                cbf/max-in-batch     0.15
+                cbf/protein          0.103
+                cbf/notes            "Adds a dry, crisp character to the beer. Yields a deep red color, and a distinctive rye flavor."}))
 
 
 (def rye-flaked
   "Imparts a dry, crisp rye flavor to rye beers. Can be easier to mash than raw rye."
   (build-grain :rye-flaked
-               {:name             "Rye, Flaked"
-                :potential        1.036
-                :yield            0.783
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0
-                :notes            "Imparts a dry, crisp rye flavor to rye beers. Can be easier to mash than raw rye."}))
+               {cbf/name             "Rye, Flaked"
+                cbf/potential        1.036
+                cbf/yield            0.783
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0
+                cbf/notes            "Imparts a dry, crisp rye flavor to rye beers. Can be easier to mash than raw rye."}))
 
 
 (def smoked-malt
   "Malt that has been smoked over an open fire. Creates a distinctive smoke flavor and aroma."
   (build-grain :smoked-malt
-               {:name             "Smoked Malt"
-                :potential        1.037
-                :yield            0.8
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            9
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     1
-                :protein          0.115
-                :notes            "Malt that has been smoked over an open fire. Creates a distinctive smoke flavor and aroma."}))
+               {cbf/name             "Smoked Malt"
+                cbf/potential        1.037
+                cbf/yield            0.8
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            9
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     1
+                cbf/protein          0.115
+                cbf/notes            "Malt that has been smoked over an open fire. Creates a distinctive smoke flavor and aroma."}))
 
 
 (def special-b-malt
@@ -954,18 +956,18 @@
    
    Used in dark Belgian Abbey and Trappist ales."
   (build-grain :special-b-malt
-               {:name             "Special B Malt"
-                :potential        1.030
-                :yield            0.652
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            180
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0
-                :notes            "Extreme caramel aroma and flavored malt. Used in dark Belgian Abbey and Trappist ales."}))
+               {cbf/name             "Special B Malt"
+                cbf/potential        1.030
+                cbf/yield            0.652
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            180
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0
+                cbf/notes            "Extreme caramel aroma and flavored malt. Used in dark Belgian Abbey and Trappist ales."}))
 
 
 (def special-roast
@@ -973,52 +975,52 @@
    
    Adds a toasted, biscuit like flavor and aroma."
   (build-grain :special-roast
-               {:name             "Special Roast"
-                :potential        1.033
-                :yield            0.72
-                :coarse-fine-diff 0.015
-                :moisture         0.025
-                :color            50
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  6
-                :max-in-batch     0.1
-                :protein          0.105
-                :notes            "Use for English ales, nut brown ales and porters. Adds a toasted, biscuit like flavor and aroma."}))
+               {cbf/name             "Special Roast"
+                cbf/potential        1.033
+                cbf/yield            0.72
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.025
+                cbf/color            50
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  6
+                cbf/max-in-batch     0.1
+                cbf/protein          0.105
+                cbf/notes            "Use for English ales, nut brown ales and porters. Adds a toasted, biscuit like flavor and aroma."}))
 
 
 (def toasted-malt
   "Similar to Biscuit or Victory malt, this malt adds reddish/orange color and improved body without sweetness along with a toasted flavor."
   (build-grain :toasted-malt
-               {:name             "Toasted Malt"
-                :potential        1.033
-                :yield            0.717
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            27
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0.117
-                :notes            "Similar to Biscuit or Victory malt, this malt adds reddish/orange color and improved body without sweetness along with a toasted flavor."}))
+               {cbf/name             "Toasted Malt"
+                cbf/potential        1.033
+                cbf/yield            0.717
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            27
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0.117
+                cbf/notes            "Similar to Biscuit or Victory malt, this malt adds reddish/orange color and improved body without sweetness along with a toasted flavor."}))
 
 
 (def victory-malt
   "Toasted malt that adds a Biscuit or toasted flavor to English ales."
   (build-grain :victory-malt
-               {:name             "Victory Malt"
-                :potential        1.034
-                :yield            0.73
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            25
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  50
-                :max-in-batch     0.15
-                :protein          0.132
-                :notes            "Toasted malt that adds a Biscuit or toasted flavor to English ales."}))
+               {cbf/name             "Victory Malt"
+                cbf/potential        1.034
+                cbf/yield            0.73
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            25
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  50
+                cbf/max-in-batch     0.15
+                cbf/protein          0.132
+                cbf/notes            "Toasted malt that adds a Biscuit or toasted flavor to English ales."}))
 
 
 (def vienna-malt
@@ -1026,69 +1028,69 @@
    
    Imparts a golden to orange color to the beer."
   (build-grain :vienna-malt
-               {:name             "Vienna Malt"
-                :potential        1.036
-                :yield            0.78
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            4
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  50
-                :max-in-batch     0.9
-                :protein          0.11
-                :notes            "Kiln dried malt darker than Pale Malt, but not as dark as Munich Malt. Imparts a golden to orange color to the beer."}))
+               {cbf/name             "Vienna Malt"
+                cbf/potential        1.036
+                cbf/yield            0.78
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            4
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  50
+                cbf/max-in-batch     0.9
+                cbf/protein          0.11
+                cbf/notes            "Kiln dried malt darker than Pale Malt, but not as dark as Munich Malt. Imparts a golden to orange color to the beer."}))
 
 
 (def wheat-malt-belgium
   "Malted wheat for use in Wheat beers."
   (build-grain :wheat-malt-belgium
-               {:name             "Wheat Malt - Belgium"
-                :potential        1.037
-                :yield            0.81
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  74
-                :max-in-batch     0.6
-                :protein          0.115
-                :notes            "Malted wheat for use in Wheat beers."}))
+               {cbf/name             "Wheat Malt - Belgium"
+                cbf/potential        1.037
+                cbf/yield            0.81
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  74
+                cbf/max-in-batch     0.6
+                cbf/protein          0.115
+                cbf/notes            "Malted wheat for use in Wheat beers."}))
 
 
 (def dark-wheat-malt
   "Dark malted wheat base for use in dark wheat styles such as Dunkleweizen."
   (build-grain :dark-wheat-malt
-               {:name             "Dark Wheat Malt"
-                :potential        1.039
-                :yield            0.84
-                :coarse-fine-diff 0.015
-                :moisture         0.035
-                :color            9
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  10
-                :max-in-batch     0.2
-                :protein          0.115
-                :notes            "Dark malted wheat base for use in dark wheat styles such as Dunkleweizen."}))
+               {cbf/name             "Dark Wheat Malt"
+                cbf/potential        1.039
+                cbf/yield            0.84
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.035
+                cbf/color            9
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  10
+                cbf/max-in-batch     0.2
+                cbf/protein          0.115
+                cbf/notes            "Dark malted wheat base for use in dark wheat styles such as Dunkleweizen."}))
 
 
 (def wheat-malt-germany
   "Malted wheat base for use in all wheat styles."
   (build-grain :wheat-malt-germany
-               {:name             "Wheat Malt - Germany"
-                :potential        1.039
-                :yield            0.84
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  95
-                :max-in-batch     0.6
-                :protein          0.125
-                :notes            "Malted wheat base for use in all wheat styles."}))
+               {cbf/name             "Wheat Malt - Germany"
+                cbf/potential        1.039
+                cbf/yield            0.84
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  95
+                cbf/max-in-batch     0.6
+                cbf/protein          0.125
+                cbf/notes            "Malted wheat base for use in all wheat styles."}))
 
 
 (def wheat-flaked
@@ -1096,18 +1098,18 @@
    
    May be used in small amounts to improve head retention and body."
   (build-grain :wheat-flaked
-               {:name             "Wheat, Flaked"
-                :potential        1.035
-                :yield            0.77
-                :coarse-fine-diff 0.015
-                :moisture         0.09
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.4
-                :protein          0.16
-                :notes            "Flaked wheat adds to increased body and foam retention. May be used in small amounts to improve head retention and body."}))
+               {cbf/name             "Wheat, Flaked"
+                cbf/potential        1.035
+                cbf/yield            0.77
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.09
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.4
+                cbf/protein          0.16
+                cbf/notes            "Flaked wheat adds to increased body and foam retention. May be used in small amounts to improve head retention and body."}))
 
 
 (def wheat-roasted
@@ -1115,18 +1117,18 @@
    
    Adds a deep, dark brown color to dunkelweizens and other dark beer styles."
   (build-grain :wheat-roasted
-               {:name             "Wheat, Roasted"
-                :potential        1.025
-                :yield            0.543
-                :coarse-fine-diff 0.015
-                :moisture         0.04
-                :color            425
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.1
-                :protein          0.13
-                :notes            "Also called Chocolate Wheat Malt. Adds a deep, dark brown color to dunkelweizens and other dark beer styles."}))
+               {cbf/name             "Wheat, Roasted"
+                cbf/potential        1.025
+                cbf/yield            0.543
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.04
+                cbf/color            425
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.1
+                cbf/protein          0.13
+                cbf/notes            "Also called Chocolate Wheat Malt. Adds a deep, dark brown color to dunkelweizens and other dark beer styles."}))
 
 
 (def wheat-torrified
@@ -1134,35 +1136,35 @@
    
    Protein rest recommended when mashing."
   (build-grain :wheat-torrified
-               {:name             "Wheat, Torrified"
-                :potential        1.036
-                :yield            0.79
-                :coarse-fine-diff 0.015
-                :moisture         0.09
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  0
-                :max-in-batch     0.4
-                :protein          0.16
-                :notes            "Unmodified wheat that has been popped to open the kernels. Protein rest recommended when mashing."}))
+               {cbf/name             "Wheat, Torrified"
+                cbf/potential        1.036
+                cbf/yield            0.79
+                cbf/coarse-fine-diff 0.015
+                cbf/moisture         0.09
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  0
+                cbf/max-in-batch     0.4
+                cbf/protein          0.16
+                cbf/notes            "Unmodified wheat that has been popped to open the kernels. Protein rest recommended when mashing."}))
 
 
 (def white-wheat-malt
   "White wheat gives a malty flavor not available from raw wheat."
   (build-grain :white-wheat-malt
-               {:name             "White Wheat Malt"
-                :potential        1.040
-                :yield            0.86
-                :coarse-fine-diff 0.022
-                :moisture         0.04
-                :color            2
-                :recommend-mash   true
-                :add-after-boil   false
-                :diastatic-power  130
-                :max-in-batch     0.6
-                :protein          0.145
-                :notes            "White wheat gives a malty flavor not available from raw wheat."}))
+               {cbf/name             "White Wheat Malt"
+                cbf/potential        1.040
+                cbf/yield            0.86
+                cbf/coarse-fine-diff 0.022
+                cbf/moisture         0.04
+                cbf/color            2
+                cbf/recommend-mash   true
+                cbf/add-after-boil   false
+                cbf/diastatic-power  130
+                cbf/max-in-batch     0.6
+                cbf/protein          0.145
+                cbf/notes            "White wheat gives a malty flavor not available from raw wheat."}))
 
 
 (def grains

--- a/src/common_beer_data/fermentables/sugars.cljc
+++ b/src/common_beer_data/fermentables/sugars.cljc
@@ -1,13 +1,15 @@
 (ns common-beer-data.fermentables.sugars
-  "Data for sugars and syrups used in brewing")
+  "Data for sugars and syrups used in brewing."
+  {:added "1.0"}
+  (:require [common-beer-format.fermentables :as cbf]))
 
 
 (def ^:private sugar-defaults
-  {:version        1
-   :amount         0.0
-   :type           "Sugar"
-   :recommend-mash false
-   :add-after-boil false})
+  {cbf/version        1
+   cbf/amount         0.0
+   cbf/type           "Sugar"
+   cbf/recommend-mash false
+   cbf/add-after-boil false})
 
 
 (defn ^:private build-sugar
@@ -18,177 +20,177 @@
 (def dark-brown-sugar
   "Imparts a sweet, rich flavor."
   (build-sugar :dark-brown-sugar
-               {:name         "Dark Brown Sugar"
-                :color        50
-                :potential    1.046
-                :max-in-batch 0.1
-                :yield        1.0
-                :notes        "Imparts a sweet, rich flavor."}))
+               {cbf/name         "Dark Brown Sugar"
+                cbf/color        50
+                cbf/potential    1.046
+                cbf/max-in-batch 0.1
+                cbf/yield        1.0
+                cbf/notes        "Imparts a sweet, rich flavor."}))
 
 
 (def light-brown-sugar
   "Imparts a sweet, rich flavor."
   (build-sugar :light-brown-sugar
-               {:name         "Light Brown Sugar"
-                :color        8
-                :potential    1.046
-                :max-in-batch 0.1
-                :yield        1.0
-                :notes        "Imparts a sweet, rich flavor."}))
+               {cbf/name         "Light Brown Sugar"
+                cbf/color        8
+                cbf/potential    1.046
+                cbf/max-in-batch 0.1
+                cbf/yield        1.0
+                cbf/notes        "Imparts a sweet, rich flavor."}))
 
 
 (def belgian-candi-syrup-45l
   "Crystalized candi sugar for use in Tripels, Dubbels, and holiday ales."
   (build-sugar :belgian-candi-syrup-45l
-               {:name         "Belgian Candi Syrup - 45L"
-                :potential    1.032
-                :yield        0.783
-                :color        60
-                :max-in-batch 0.2
-                :notes        "Crystalized candi sugar for use in Tripels, Dubbels, and holiday ales."}))
+               {cbf/name         "Belgian Candi Syrup - 45L"
+                cbf/potential    1.032
+                cbf/yield        0.783
+                cbf/color        60
+                cbf/max-in-batch 0.2
+                cbf/notes        "Crystalized candi sugar for use in Tripels, Dubbels, and holiday ales."}))
 
 
 (def belgian-candi-syrup-90l
   "Crystalized candi sugar for use in Tripels, Dubbels, and holiday ales."
   (build-sugar :belgian-candi-syrup-90l
-               {:name         "Belgian Candi Syrup - 90L"
-                :yield        0.783
-                :potential    1.032
-                :color        121
-                :max-in-batch 0.2
-                :notes        "Crystalized candi sugar for use in Tripels, Dubbels, and holiday ales."}))
+               {cbf/name         "Belgian Candi Syrup - 90L"
+                cbf/yield        0.783
+                cbf/potential    1.032
+                cbf/color        121
+                cbf/max-in-batch 0.2
+                cbf/notes        "Crystalized candi sugar for use in Tripels, Dubbels, and holiday ales."}))
 
 
 (def belgian-candi-syrup-180l
   "Crystalized candi sugar for use in Tripels, Dubbels, and holiday ales."
   (build-sugar :belgian-candi-syrup-180l
-               {:name         "Belgian Candi Syrup - 180L"
-                :potential    1.032
-                :yield        0.783
-                :color        243
-                :max-in-batch 0.2
-                :notes        "Crystalized candi sugar for use in Tripels, Dubbels, and holiday ales."}))
+               {cbf/name         "Belgian Candi Syrup - 180L"
+                cbf/potential    1.032
+                cbf/yield        0.783
+                cbf/color        243
+                cbf/max-in-batch 0.2
+                cbf/notes        "Crystalized candi sugar for use in Tripels, Dubbels, and holiday ales."}))
 
 
 (def clear-candi-sugar
   "Crystalized candi sugar for use in Tripels, Dubbels, and holiday ales."
   (build-sugar :clear-candi-sugar
-               {:name         "Clear Candi Sugar"
-                :potential    1.036
-                :yield        0.783
-                :color        1
-                :max-in-batch 0.2
-                :notes        "Crystalized candi sugar for use in Tripels, Dubbels, and holiday ales."}))
+               {cbf/name         "Clear Candi Sugar"
+                cbf/potential    1.036
+                cbf/yield        0.783
+                cbf/color        1
+                cbf/max-in-batch 0.2
+                cbf/notes        "Crystalized candi sugar for use in Tripels, Dubbels, and holiday ales."}))
 
 
 (def cane-sugar
   "Common, household sugar used to lighten the flavor and body."
   (build-sugar :cane-sugar
-               {:name         "Cane Sugar"
-                :potential    1.046
-                :yield        1.0
-                :color        0
-                :max-in-batch 0.07
-                :notes        "Common, household sugar used to lighten the flavor and body."}))
+               {cbf/name         "Cane Sugar"
+                cbf/potential    1.046
+                cbf/yield        1.0
+                cbf/color        0
+                cbf/max-in-batch 0.07
+                cbf/notes        "Common, household sugar used to lighten the flavor and body."}))
 
 
 (def beet-sugar
   "Common, household sugar used to lighten the flavor and body."
   (build-sugar :beet-sugar
-               {:name         "Beet Sugar"
-                :potential    1.046
-                :yield        1.0
-                :color        0
-                :max-in-batch 0.07
-                :notes        "Common, household sugar used to lighten the flavor and body."}))
+               {cbf/name         "Beet Sugar"
+                cbf/potential    1.046
+                cbf/yield        1.0
+                cbf/color        0
+                cbf/max-in-batch 0.07
+                cbf/notes        "Common, household sugar used to lighten the flavor and body."}))
 
 
 (def corn-sugar
   "Common bottling sugar."
   (build-sugar :corn-sugar
-               {:name         "Corn Sugar"
-                :potential    1.046
-                :yield        1.0
-                :color        0
-                :max-in-batch 0.05
-                :notes        "Common bottling sugar."}))
+               {cbf/name         "Corn Sugar"
+                cbf/potential    1.046
+                cbf/yield        1.0
+                cbf/color        0
+                cbf/max-in-batch 0.05
+                cbf/notes        "Common bottling sugar."}))
 
 
 (def dextrose
   "Common bottling sugar."
   (build-sugar :dextrose
-               {:name         "Dextrose"
-                :potential    1.046
-                :yield        1.0
-                :color        0
-                :max-in-batch 0.05
-                :notes        "Common bottling sugar."}))
+               {cbf/name         "Dextrose"
+                cbf/potential    1.046
+                cbf/yield        1.0
+                cbf/color        0
+                cbf/max-in-batch 0.05
+                cbf/notes        "Common bottling sugar."}))
 
 
 (def corn-syrup
   "Syrup derived from corn sugar."
   (build-sugar :corn-syrup
-               {:name         "Corn Syrup"
-                :potential    1.036
-                :yield        0.783
-                :color        0
-                :max-in-batch 0.1
-                :notes        "Syrup derived from corn sugar."}))
+               {cbf/name         "Corn Syrup"
+                cbf/potential    1.036
+                cbf/yield        0.783
+                cbf/color        0
+                cbf/max-in-batch 0.1
+                cbf/notes        "Syrup derived from corn sugar."}))
 
 
 (def demerara-sugar
   "A dark, unrefined sugar that contains molasses."
   (build-sugar :demerara-sugar
-               {:name         "Demerara Sugar"
-                :potential    1.046
-                :yield        1.0
-                :color        2
-                :max-in-batch 0.1
-                :notes        "A dark, unrefined sugar that contains molasses."}))
+               {cbf/name         "Demerara Sugar"
+                cbf/potential    1.046
+                cbf/yield        1.0
+                cbf/color        2
+                cbf/max-in-batch 0.1
+                cbf/notes        "A dark, unrefined sugar that contains molasses."}))
 
 
 (def invert-sugar
   "A sugar used to increase starting gravity."
   (build-sugar :invert-sugar
-               {:name         "Invert Sugar"
-                :potential    1.046
-                :yield        1.0
-                :color        0
-                :max-in-batch 0.1
-                :notes        "A sugar used to increase starting gravity."}))
+               {cbf/name         "Invert Sugar"
+                cbf/potential    1.046
+                cbf/yield        1.0
+                cbf/color        0
+                cbf/max-in-batch 0.1
+                cbf/notes        "A sugar used to increase starting gravity."}))
 
 
 (def milk-sugar
   "A partially fermentable sugar that adds lasting sweetness."
   (build-sugar :milk-sugar
-               {:name         "Milk Sugar"
-                :potential    1.035
-                :yield        0.761
-                :color        0
-                :max-in-batch 0.1
-                :notes        "A partially fermentable sugar that adds lasting sweetness."}))
+               {cbf/name         "Milk Sugar"
+                cbf/potential    1.035
+                cbf/yield        0.761
+                cbf/color        0
+                cbf/max-in-batch 0.1
+                cbf/notes        "A partially fermentable sugar that adds lasting sweetness."}))
 
 
 (def lactose
   "A partially fermentable sugar that adds lasting sweetness."
   (build-sugar :lactose
-               {:name         "Lactose"
-                :potential    1.035
-                :yield        0.761
-                :color        0
-                :max-in-batch 0.1
-                :notes        "A partially fermentable sugar that adds lasting sweetness."}))
+               {cbf/name         "Lactose"
+                cbf/potential    1.035
+                cbf/yield        0.761
+                cbf/color        0
+                cbf/max-in-batch 0.1
+                cbf/notes        "A partially fermentable sugar that adds lasting sweetness."}))
 
 
 (def molasses
   "A strong, dark, and sweet sugar."
   (build-sugar :molasses
-               {:name         "Molasses"
-                :potential    1.036
-                :yield        0.783
-                :color        80
-                :max-in-batch 0.05
-                :notes        "A strong, dark, and sweet sugar."}))
+               {cbf/name         "Molasses"
+                cbf/potential    1.036
+                cbf/yield        0.783
+                cbf/color        80
+                cbf/max-in-batch 0.05
+                cbf/notes        "A strong, dark, and sweet sugar."}))
 
 
 (def maple-syrup
@@ -196,45 +198,45 @@
    
    If added at bottling, the smooth maple flavor comes through."
   (build-sugar :maple-syrup
-               {:name         "Maple Syrup"
-                :potential    1.030
-                :yield        0.652
-                :color        35
-                :max-in-batch 0.10
-                :notes        "If added during the boil it will add a dry, woodsy flavor. If added at bottling, the smooth maple flavor comes through."}))
+               {cbf/name         "Maple Syrup"
+                cbf/potential    1.030
+                cbf/yield        0.652
+                cbf/color        35
+                cbf/max-in-batch 0.10
+                cbf/notes        "If added during the boil it will add a dry, woodsy flavor. If added at bottling, the smooth maple flavor comes through."}))
 
 
 (def table-sugar
   "A sugar used to increase starting gravity."
   (build-sugar :table-sugar
-               {:name         "Table Sugar"
-                :potential    1.046
-                :yield        1.0
-                :color        1
-                :max-in-batch 0.1
-                :notes        "A sugar used to increase starting gravity."}))
+               {cbf/name         "Table Sugar"
+                cbf/potential    1.046
+                cbf/yield        1.0
+                cbf/color        1
+                cbf/max-in-batch 0.1
+                cbf/notes        "A sugar used to increase starting gravity."}))
 
 
 (def sucrose
   "A sugar used to increase starting gravity."
   (build-sugar :sucrose
-               {:name         "Sucrose"
-                :potential    1.046
-                :yield        1.0
-                :color        1
-                :max-in-batch 0.1
-                :notes        "A sugar used to increase starting gravity."}))
+               {cbf/name         "Sucrose"
+                cbf/potential    1.046
+                cbf/yield        1.0
+                cbf/color        1
+                cbf/max-in-batch 0.1
+                cbf/notes        "A sugar used to increase starting gravity."}))
 
 
 (def turbinado
   "A light, raw brown sugar used to increase starting gravity."
   (build-sugar :turbinado
-               {:name         "Turbinado"
-                :potential    1.044
-                :yield        0.957
-                :color        10
-                :max-in-batch 0.1
-                :notes        "A light, raw brown sugar used to increase starting gravity."}))
+               {cbf/name         "Turbinado"
+                cbf/potential    1.044
+                cbf/yield        0.957
+                cbf/color        10
+                cbf/max-in-batch 0.1
+                cbf/notes        "A light, raw brown sugar used to increase starting gravity."}))
 
 
 (def sugars

--- a/src/common_beer_data/hops/aroma.cljc
+++ b/src/common_beer_data/hops/aroma.cljc
@@ -1,54 +1,56 @@
 (ns common-beer-data.hops.aroma
   "Data for aromatic hops."
-  (:require [common-beer-data.hops.hops :as hops]))
+  {:added "1.0"}
+  (:require [common-beer-data.hops.hops :as hops]
+            [common-beer-format.hops :as cbf]))
 
 
 (def crystal
   "Woody, floral, and fruity with spice notes of cinnamon, nutmeg, and black pepper."
   (hops/build-hop :crystal
-                  {:beta          0.065
-                   :name          "Crystal"
-                   :cohumulone    0.25
-                   :type          "Aroma"
-                   :myrcene       0.45
-                   :humulene      0.25
-                   :hsi           0.65
-                   :notes         "Woody, floral, and fruity with spice notes of cinnamon, nutmeg, and black pepper."
-                   :caryophyllene 0.07
-                   :alpha         0.055
-                   :substitutes   "Liberty, Mt Hood, Hallertau"}))
+                  {cbf/beta          0.065
+                   cbf/name          "Crystal"
+                   cbf/cohumulone    0.25
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.45
+                   cbf/humulene      0.25
+                   cbf/hsi           0.65
+                   cbf/notes         "Woody, floral, and fruity with spice notes of cinnamon, nutmeg, and black pepper."
+                   cbf/caryophyllene 0.07
+                   cbf/alpha         0.055
+                   cbf/substitutes   "Liberty, Mt Hood, Hallertau"}))
 
 
 (def liberty
   "Notes of lemon and spice."
   (hops/build-hop :liberty
-                  {:beta          0.04
-                   :name          "Liberty"
-                   :cohumulone    0.25
-                   :type          "Aroma"
-                   :myrcene       0.45
-                   :humulene      0.31
-                   :hsi           0.45
-                   :notes         "Notes of lemon and spice."
-                   :caryophyllene 0.1
-                   :alpha         0.05
-                   :substitutes   "Mt Hood, Hallertau"}))
+                  {cbf/beta          0.04
+                   cbf/name          "Liberty"
+                   cbf/cohumulone    0.25
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.45
+                   cbf/humulene      0.31
+                   cbf/hsi           0.45
+                   cbf/notes         "Notes of lemon and spice."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.05
+                   cbf/substitutes   "Mt Hood, Hallertau"}))
 
 
 (def glacier
   "Herby, woody, and citrusy notes."
   (hops/build-hop :glacier
-                  {:beta          0.082
-                   :name          "Glacier"
-                   :cohumulone    0.13
-                   :type          "Aroma"
-                   :myrcene       0.45
-                   :humulene      0.3
-                   :hsi           0.7
-                   :notes         "Herby, woody, and citrusy notes."
-                   :caryophyllene 0.1
-                   :alpha         0.055
-                   :substitutes   "Willamette"}))
+                  {cbf/beta          0.082
+                   cbf/name          "Glacier"
+                   cbf/cohumulone    0.13
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.45
+                   cbf/humulene      0.3
+                   cbf/hsi           0.7
+                   cbf/notes         "Herby, woody, and citrusy notes."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.055
+                   cbf/substitutes   "Willamette"}))
 
 
 (def mt-hood
@@ -56,33 +58,33 @@
    
    Mild spicy flavor."
   (hops/build-hop :mt-hood
-                  {:beta          0.08
-                   :name          "Mt. Hood"
-                   :cohumulone    0.22
-                   :type          "Aroma"
-                   :myrcene       0.35
-                   :humulene      0.2
-                   :hsi           0.55
-                   :notes         "Hallertau derivant. Mild spicy flavor."
-                   :caryophyllene 0.11
-                   :alpha         0.07
-                   :substitutes   "Crystal"}))
+                  {cbf/beta          0.08
+                   cbf/name          "Mt. Hood"
+                   cbf/cohumulone    0.22
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.35
+                   cbf/humulene      0.2
+                   cbf/hsi           0.55
+                   cbf/notes         "Hallertau derivant. Mild spicy flavor."
+                   cbf/caryophyllene 0.11
+                   cbf/alpha         0.07
+                   cbf/substitutes   "Crystal"}))
 
 
 (def strisselspalt
   "Pleasant mixture of herbal, floral, and citrus notes."
   (hops/build-hop :strisselspalt
-                  {:beta          0.045
-                   :name          "Strisselspalt"
-                   :cohumulone    0.25
-                   :type          "Aroma"
-                   :myrcene       0.42
-                   :humulene      0.22
-                   :hsi           0.65
-                   :notes         "Pleasant mixture of herbal, floral, and citrus notes."
-                   :caryophyllene 0.09
-                   :alpha         0.045
-                   :substitutes   "Hallertau, Mt Hood"}))
+                  {cbf/beta          0.045
+                   cbf/name          "Strisselspalt"
+                   cbf/cohumulone    0.25
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.42
+                   cbf/humulene      0.22
+                   cbf/hsi           0.65
+                   cbf/notes         "Pleasant mixture of herbal, floral, and citrus notes."
+                   cbf/caryophyllene 0.09
+                   cbf/alpha         0.045
+                   cbf/substitutes   "Hallertau, Mt Hood"}))
 
 
 (def simcoe
@@ -90,65 +92,65 @@
    
    Aromas of grapefruit, pine, and herbs."
   (hops/build-hop :simcoe
-                  {:beta          0.05
-                   :name          "Simcoe"
-                   :cohumulone    0.17
-                   :type          "Aroma"
-                   :myrcene       0.65
-                   :humulene      0.15
-                   :hsi           0.75
-                   :notes         "Bright citrus flavors with earthy undertones. Aromas of grapefruit, pine, and herbs."
-                   :caryophyllene 0.07
-                   :alpha         0.14
-                   :substitutes   "Summit"}))
+                  {cbf/beta          0.05
+                   cbf/name          "Simcoe"
+                   cbf/cohumulone    0.17
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.65
+                   cbf/humulene      0.15
+                   cbf/hsi           0.75
+                   cbf/notes         "Bright citrus flavors with earthy undertones. Aromas of grapefruit, pine, and herbs."
+                   cbf/caryophyllene 0.07
+                   cbf/alpha         0.14
+                   cbf/substitutes   "Summit"}))
 
 
 (def cascade
   "Floral, with elements of citrus."
   (hops/build-hop :cascade
-                  {:beta          0.07
-                   :name          "Cascade"
-                   :cohumulone    0.35
-                   :type          "Aroma"
-                   :myrcene       0.5
-                   :humulene      0.12
-                   :hsi           0.5
-                   :notes         "Floral, with elements of citrus."
-                   :caryophyllene 0.05
-                   :alpha         0.07
-                   :substitutes   "Centennial, Amarillo, Columbus"}))
+                  {cbf/beta          0.07
+                   cbf/name          "Cascade"
+                   cbf/cohumulone    0.35
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.5
+                   cbf/humulene      0.12
+                   cbf/hsi           0.5
+                   cbf/notes         "Floral, with elements of citrus."
+                   cbf/caryophyllene 0.05
+                   cbf/alpha         0.07
+                   cbf/substitutes   "Centennial, Amarillo, Columbus"}))
 
 
 (def willamette
   "Herbal spiciness with floral notes."
   (hops/build-hop :willamette
-                  {:beta          0.045
-                   :name          "Willamette"
-                   :cohumulone    0.3
-                   :type          "Aroma"
-                   :myrcene       0.45
-                   :humulene      0.25
-                   :hsi           0.6
-                   :notes         "Herbal spiciness with floral notes."
-                   :caryophyllene 0.07
-                   :alpha         0.06
-                   :substitutes   "Fuggle, Glacier"}))
+                  {cbf/beta          0.045
+                   cbf/name          "Willamette"
+                   cbf/cohumulone    0.3
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.45
+                   cbf/humulene      0.25
+                   cbf/hsi           0.6
+                   cbf/notes         "Herbal spiciness with floral notes."
+                   cbf/caryophyllene 0.07
+                   cbf/alpha         0.06
+                   cbf/substitutes   "Fuggle, Glacier"}))
 
 
 (def spalt
   "Earthen and spice notes."
   (hops/build-hop :spalt
-                  {:beta          0.04
-                   :name          "Spalt"
-                   :cohumulone    0.25
-                   :type          "Aroma"
-                   :myrcene       0.3
-                   :humulene      0.025
-                   :hsi           0.55
-                   :notes         "Earthen and spice notes."
-                   :caryophyllene 0.1
-                   :alpha         0.041
-                   :substitutes   "Saaz, Hallertau, Sterling"}))
+                  {cbf/beta          0.04
+                   cbf/name          "Spalt"
+                   cbf/cohumulone    0.25
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.3
+                   cbf/humulene      0.025
+                   cbf/hsi           0.55
+                   cbf/notes         "Earthen and spice notes."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.041
+                   cbf/substitutes   "Saaz, Hallertau, Sterling"}))
 
 
 (def sterling
@@ -156,81 +158,81 @@
    
    Similar earthen and spice notes."
   (hops/build-hop :sterling
-                  {:beta          0.06
-                   :name          "Sterling"
-                   :cohumulone    0.25
-                   :type          "Aroma"
-                   :myrcene       0.45
-                   :humulene      0.2
-                   :hsi           0.65
-                   :notes         "Derivant of Saaz. Similar earthen and spice notes."
-                   :caryophyllene 0.06
-                   :alpha         0.05
-                   :substitutes   "Saaz"}))
+                  {cbf/beta          0.06
+                   cbf/name          "Sterling"
+                   cbf/cohumulone    0.25
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.45
+                   cbf/humulene      0.2
+                   cbf/hsi           0.65
+                   cbf/notes         "Derivant of Saaz. Similar earthen and spice notes."
+                   cbf/caryophyllene 0.06
+                   cbf/alpha         0.05
+                   cbf/substitutes   "Saaz"}))
 
 
 (def santiam
   "Soft, herbal, floral, fruity aromas with hints of pepper and spice."
   (hops/build-hop :santiam
-                  {:beta          0.08
-                   :name          "Santiam"
-                   :cohumulone    0.2
-                   :type          "Aroma"
-                   :myrcene       0.3
-                   :humulene      0.25
-                   :hsi           0.45
-                   :notes         "Soft, herbal, floral, fruity aromas with hints of pepper and spice."
-                   :caryophyllene 0.055
-                   :alpha         0.07
-                   :substitutes   "Spalt, Hallertau, Liberty"}))
+                  {cbf/beta          0.08
+                   cbf/name          "Santiam"
+                   cbf/cohumulone    0.2
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.3
+                   cbf/humulene      0.25
+                   cbf/hsi           0.45
+                   cbf/notes         "Soft, herbal, floral, fruity aromas with hints of pepper and spice."
+                   cbf/caryophyllene 0.055
+                   cbf/alpha         0.07
+                   cbf/substitutes   "Spalt, Hallertau, Liberty"}))
 
 
 (def ultra
   "Mild spice aroma and flavor."
   (hops/build-hop :ultra
-                  {:beta          0.045
-                   :name          "Ultra"
-                   :cohumulone    0.3
-                   :type          "Aroma"
-                   :myrcene       0.3
-                   :humulene      0.35
-                   :hsi           0.65
-                   :notes         "Mild spice aroma and flavor."
-                   :caryophyllene 0.1
-                   :alpha         0.035
-                   :substitutes   "Hallertau, Saaz"}))
+                  {cbf/beta          0.045
+                   cbf/name          "Ultra"
+                   cbf/cohumulone    0.3
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.3
+                   cbf/humulene      0.35
+                   cbf/hsi           0.65
+                   cbf/notes         "Mild spice aroma and flavor."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.035
+                   cbf/substitutes   "Hallertau, Saaz"}))
 
 
 (def ahtanum
   "Distinct grapefruit scent and flavor."
   (hops/build-hop :ahtanum
-                  {:beta          0.05
-                   :name          "Ahtanum"
-                   :cohumulone    0.3
-                   :type          "Aroma"
-                   :myrcene       0.5
-                   :humulene      0.18
-                   :hsi           0.5
-                   :notes         "Distinct grapefruit scent and flavor."
-                   :caryophyllene 0.1
-                   :alpha         0.057
-                   :substitutes   "Willamette, Centennial, Cascade"}))
+                  {cbf/beta          0.05
+                   cbf/name          "Ahtanum"
+                   cbf/cohumulone    0.3
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.5
+                   cbf/humulene      0.18
+                   cbf/hsi           0.5
+                   cbf/notes         "Distinct grapefruit scent and flavor."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.057
+                   cbf/substitutes   "Willamette, Centennial, Cascade"}))
 
 
 (def mosaic
   "Complex flavor reminiscent of stone fruit."
   (hops/build-hop :mosaic
-                  {:beta          0.04
-                   :name          "Mosaic"
-                   :cohumulone    0.22
-                   :type          "Aroma"
-                   :myrcene       0.5
-                   :humulene      0.1
-                   :hsi           0.75
-                   :notes         "Complex flavor reminiscent of stone fruit."
-                   :caryophyllene 0.05
-                   :alpha         0.135
-                   :substitutes   "Citra"}))
+                  {cbf/beta          0.04
+                   cbf/name          "Mosaic"
+                   cbf/cohumulone    0.22
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.5
+                   cbf/humulene      0.1
+                   cbf/hsi           0.75
+                   cbf/notes         "Complex flavor reminiscent of stone fruit."
+                   cbf/caryophyllene 0.05
+                   cbf/alpha         0.135
+                   cbf/substitutes   "Citra"}))
 
 
 (def golding-us
@@ -238,65 +240,65 @@
    
    Delicate fruit and herbal aromas."
   (hops/build-hop :golding-us
-                  {:beta          0.03
-                   :name          "Golding US"
-                   :cohumulone    0.2
-                   :type          "Aroma"
-                   :myrcene       0.3
-                   :humulene      0.4
-                   :hsi           0.65
-                   :notes         "Direct descendants of East Kent Golding. Delicate fruit and herbal aromas."
-                   :caryophyllene 0.15
-                   :alpha         0.06
-                   :substitutes   "Fuggle, East Kent Golding"}))
+                  {cbf/beta          0.03
+                   cbf/name          "Golding US"
+                   cbf/cohumulone    0.2
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.3
+                   cbf/humulene      0.4
+                   cbf/hsi           0.65
+                   cbf/notes         "Direct descendants of East Kent Golding. Delicate fruit and herbal aromas."
+                   cbf/caryophyllene 0.15
+                   cbf/alpha         0.06
+                   cbf/substitutes   "Fuggle, East Kent Golding"}))
 
 
 (def east-kent-golding
   "Delicate fruit and herbal aromas."
   (hops/build-hop :east-kent-golding
-                  {:beta          0.03
-                   :name          "East Kent Golding"
-                   :cohumulone    0.3
-                   :type          "Aroma"
-                   :myrcene       0.3
-                   :humulene      0.3
-                   :hsi           0.75
-                   :notes         "Delicate fruit and herbal aromas."
-                   :caryophyllene 0.1
-                   :alpha         0.06
-                   :substitutes   "Fuggle, Golding"}))
+                  {cbf/beta          0.03
+                   cbf/name          "East Kent Golding"
+                   cbf/cohumulone    0.3
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.3
+                   cbf/humulene      0.3
+                   cbf/hsi           0.75
+                   cbf/notes         "Delicate fruit and herbal aromas."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.06
+                   cbf/substitutes   "Fuggle, Golding"}))
 
 
 (def fuggle-us
   "A slight, fruity flavor."
   (hops/build-hop :fuggle-us
-                  {:beta          0.02
-                   :name          "Fuggle US"
-                   :cohumulone    0.27
-                   :type          "Aroma"
-                   :myrcene       0.4
-                   :humulene      0.25
-                   :hsi           0.5
-                   :notes         "A slight, fruity flavor."
-                   :caryophyllene 0.09
-                   :alpha         0.055
-                   :substitutes   "Willamette, Newport"}))
+                  {cbf/beta          0.02
+                   cbf/name          "Fuggle US"
+                   cbf/cohumulone    0.27
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.4
+                   cbf/humulene      0.25
+                   cbf/hsi           0.5
+                   cbf/notes         "A slight, fruity flavor."
+                   cbf/caryophyllene 0.09
+                   cbf/alpha         0.055
+                   cbf/substitutes   "Willamette, Newport"}))
 
 
 (def delta
   "Spicy citrus and summer melon notes."
   (hops/build-hop :delta
-                  {:beta          0.07
-                   :name          "Delta"
-                   :cohumulone    0.23
-                   :type          "Aroma"
-                   :myrcene       0.35
-                   :humulene      0.3
-                   :hsi           0.85
-                   :notes         "Spicy citrus and summer melon notes."
-                   :caryophyllene 0.12
-                   :alpha         0.07
-                   :substitutes   "Fuggle, Willamette"}))
+                  {cbf/beta          0.07
+                   cbf/name          "Delta"
+                   cbf/cohumulone    0.23
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.35
+                   cbf/humulene      0.3
+                   cbf/hsi           0.85
+                   cbf/notes         "Spicy citrus and summer melon notes."
+                   cbf/caryophyllene 0.12
+                   cbf/alpha         0.07
+                   cbf/substitutes   "Fuggle, Willamette"}))
 
 
 (def saaz-us
@@ -304,17 +306,17 @@
    
    Strong herbal character."
   (hops/build-hop :saaz-us
-                  {:beta          0.045
-                   :name          "Saaz US"
-                   :cohumulone    0.25
-                   :type          "Aroma"
-                   :myrcene       0.3
-                   :humulene      0.2
-                   :hsi           0.5
-                   :notes         "Also called Saazer. Strong herbal character."
-                   :caryophyllene 0.06
-                   :alpha         0.045
-                   :substitutes   "Centennial, Amarillo"}))
+                  {cbf/beta          0.045
+                   cbf/name          "Saaz US"
+                   cbf/cohumulone    0.25
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.3
+                   cbf/humulene      0.2
+                   cbf/hsi           0.5
+                   cbf/notes         "Also called Saazer. Strong herbal character."
+                   cbf/caryophyllene 0.06
+                   cbf/alpha         0.045
+                   cbf/substitutes   "Centennial, Amarillo"}))
 
 
 (def palisade
@@ -322,17 +324,17 @@
    
    Aromas that are floral, herbaceous, and grassy."
   (hops/build-hop :palisade
-                  {:beta          0.08
-                   :name          "Palisade"
-                   :cohumulone    0.25
-                   :type          "Aroma"
-                   :myrcene       0.09
-                   :humulene      0.2
-                   :hsi           0.65
-                   :notes         "Flavors of nectar fruits and citrus. Aromas that are floral, herbaceous, and grassy."
-                   :caryophyllene 0.17
-                   :alpha         0.095
-                   :substitutes   "Golding, Chinook"}))
+                  {cbf/beta          0.08
+                   cbf/name          "Palisade"
+                   cbf/cohumulone    0.25
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.09
+                   cbf/humulene      0.2
+                   cbf/hsi           0.65
+                   cbf/notes         "Flavors of nectar fruits and citrus. Aromas that are floral, herbaceous, and grassy."
+                   cbf/caryophyllene 0.17
+                   cbf/alpha         0.095
+                   cbf/substitutes   "Golding, Chinook"}))
 
 
 (def centennial
@@ -340,17 +342,17 @@
    
    Earthy and floral flavor with faint citrues notes."
   (hops/build-hop :centennial
-                  {:beta          0.045
-                   :name          "Centennial"
-                   :cohumulone    0.3
-                   :type          "Aroma"
-                   :myrcene       0.5
-                   :humulene      0.14
-                   :hsi           0.6
-                   :notes         "Also sold as Super Cascade. Earthy and floral flavor with faint citrues notes."
-                   :caryophyllene 0.05
-                   :alpha         0.115
-                   :substitutes   "Chinook, Galena, CTZ"}))
+                  {cbf/beta          0.045
+                   cbf/name          "Centennial"
+                   cbf/cohumulone    0.3
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.5
+                   cbf/humulene      0.14
+                   cbf/hsi           0.6
+                   cbf/notes         "Also sold as Super Cascade. Earthy and floral flavor with faint citrues notes."
+                   cbf/caryophyllene 0.05
+                   cbf/alpha         0.115
+                   cbf/substitutes   "Chinook, Galena, CTZ"}))
 
 
 (def hallertau-us
@@ -358,17 +360,17 @@
    
    Light aroma of spice and floral notes."
   (hops/build-hop :hallertau-us
-                  {:beta          0.055
-                   :name          "Hallertau US"
-                   :cohumulone    0.23
-                   :type          "Aroma"
-                   :myrcene       0.4
-                   :humulene      0.45
-                   :hsi           0.55
-                   :notes         "Sometimes sold as Mittelfrüher. Light aroma of spice and floral notes."
-                   :caryophyllene 0.1
-                   :alpha         0.055
-                   :substitutes   "Liberty"}))
+                  {cbf/beta          0.055
+                   cbf/name          "Hallertau US"
+                   cbf/cohumulone    0.23
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.4
+                   cbf/humulene      0.45
+                   cbf/hsi           0.55
+                   cbf/notes         "Sometimes sold as Mittelfrüher. Light aroma of spice and floral notes."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.055
+                   cbf/substitutes   "Liberty"}))
 
 
 (def amarillo
@@ -376,33 +378,33 @@
    
    Strong orange flavor."
   (hops/build-hop :amarillo
-                  {:beta          0.07
-                   :name          "Amarillo"
-                   :cohumulone    0.2
-                   :type          "Aroma"
-                   :myrcene       0.7
-                   :humulene      0.1
-                   :hsi           0.95
-                   :notes         "Known as VGXP01. Strong orange flavor."
-                   :caryophyllene 0.03
-                   :alpha         0.11
-                   :substitutes   "Cascade, Chinook"}))
+                  {cbf/beta          0.07
+                   cbf/name          "Amarillo"
+                   cbf/cohumulone    0.2
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.7
+                   cbf/humulene      0.1
+                   cbf/hsi           0.95
+                   cbf/notes         "Known as VGXP01. Strong orange flavor."
+                   cbf/caryophyllene 0.03
+                   cbf/alpha         0.11
+                   cbf/substitutes   "Cascade, Chinook"}))
 
 
 (def vanguard
   "Floral and spice notes."
   (hops/build-hop :vanguard
-                  {:beta          0.07
-                   :name          "Vanguard"
-                   :cohumulone    0.15
-                   :type          "Aroma"
-                   :myrcene       0.25
-                   :humulene      0.45
-                   :hsi           0.75
-                   :notes         "Floral and spice notes."
-                   :caryophyllene 0.13
-                   :alpha         0.06
-                   :substitutes   "Hallertau, Saaz, Mt Hood"}))
+                  {cbf/beta          0.07
+                   cbf/name          "Vanguard"
+                   cbf/cohumulone    0.15
+                   cbf/type          "Aroma"
+                   cbf/myrcene       0.25
+                   cbf/humulene      0.45
+                   cbf/hsi           0.75
+                   cbf/notes         "Floral and spice notes."
+                   cbf/caryophyllene 0.13
+                   cbf/alpha         0.06
+                   cbf/substitutes   "Hallertau, Saaz, Mt Hood"}))
 
 
 (def aroma

--- a/src/common_beer_data/hops/bittering.cljc
+++ b/src/common_beer_data/hops/bittering.cljc
@@ -1,134 +1,136 @@
 (ns common-beer-data.hops.bittering
-  "Data for bitter hops"
-  (:require [common-beer-data.hops.hops :as hops]))
+  "Data for bitter hops."
+  {:added "1.0"}
+  (:require [common-beer-data.hops.hops :as hops]
+            [common-beer-format.hops :as cbf]))
 
 
 (def summit
   "Summit boasts citric aromas of tangerine, grapefruit and orange along with an impressive alpha content giving it a wide spectrum of potential use."
   (hops/build-hop :summit
-                  {:beta          0.06
-                   :name          "Summit"
-                   :cohumulone    0.3
-                   :type          "Bittering"
-                   :myrcene       0.4
-                   :humulene      0.2
-                   :hsi           0.85
-                   :notes         "Summit boasts citric aromas of tangerine, grapefruit and orange along with an impressive alpha content giving it a wide spectrum of potential use."
-                   :caryophyllene 0.13
-                   :alpha         0.18
-                   :substitutes   "Columbus, Simcoe, Apollo"}))
+                  {cbf/beta          0.06
+                   cbf/name          "Summit"
+                   cbf/cohumulone    0.3
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.4
+                   cbf/humulene      0.2
+                   cbf/hsi           0.85
+                   cbf/notes         "Summit boasts citric aromas of tangerine, grapefruit and orange along with an impressive alpha content giving it a wide spectrum of potential use."
+                   cbf/caryophyllene 0.13
+                   cbf/alpha         0.18
+                   cbf/substitutes   "Columbus, Simcoe, Apollo"}))
 
 
 (def chelan
   "Despite being comparable in style, Chelan enjoys higher yields and a higher alpha percentage than its parent Galena."
   (hops/build-hop :chelan
-                  {:beta          0.098
-                   :name          "Chelan"
-                   :cohumulone    0.34
-                   :type          "Bittering"
-                   :myrcene       0.5
-                   :humulene      0.13
-                   :hsi           0.8
-                   :notes         "Despite being comparable in style, Chelan enjoys higher yields and a higher alpha percentage than its parent Galena."
-                   :caryophyllene 0.11
-                   :alpha         0.15
-                   :substitutes   "Galena, Nugget"}))
+                  {cbf/beta          0.098
+                   cbf/name          "Chelan"
+                   cbf/cohumulone    0.34
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.5
+                   cbf/humulene      0.13
+                   cbf/hsi           0.8
+                   cbf/notes         "Despite being comparable in style, Chelan enjoys higher yields and a higher alpha percentage than its parent Galena."
+                   cbf/caryophyllene 0.11
+                   cbf/alpha         0.15
+                   cbf/substitutes   "Galena, Nugget"}))
 
 
 (def cluster
   "Clean, neutral, and slightly floral in taste."
   (hops/build-hop :cluster
-                  {:beta          0.055
-                   :name          "Cluster"
-                   :cohumulone    0.39
-                   :type          "Bittering"
-                   :myrcene       0.45
-                   :humulene      0.17
-                   :hsi           0.83
-                   :notes         "Clean, neutral, and slightly floral in taste."
-                   :caryophyllene 0.08
-                   :alpha         0.085
-                   :substitutes   "Galena, Eroica"}))
+                  {cbf/beta          0.055
+                   cbf/name          "Cluster"
+                   cbf/cohumulone    0.39
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.45
+                   cbf/humulene      0.17
+                   cbf/hsi           0.83
+                   cbf/notes         "Clean, neutral, and slightly floral in taste."
+                   cbf/caryophyllene 0.08
+                   cbf/alpha         0.085
+                   cbf/substitutes   "Galena, Eroica"}))
 
 
 (def eroica
   "Possesses a sharp fruity essence."
   (hops/build-hop :eroica
-                  {:beta          0.045
-                   :name          "Eroica"
-                   :cohumulone    0.4
-                   :type          "Bittering"
-                   :myrcene       0.6
-                   :humulene      0.005
-                   :hsi           0.8
-                   :notes         "Possesses a sharp fruity essence."
-                   :caryophyllene 0.09
-                   :alpha         0.12
-                   :substitutes   "Galena, Cluster, Brewer's Gold"}))
+                  {cbf/beta          0.045
+                   cbf/name          "Eroica"
+                   cbf/cohumulone    0.4
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.6
+                   cbf/humulene      0.005
+                   cbf/hsi           0.8
+                   cbf/notes         "Possesses a sharp fruity essence."
+                   cbf/caryophyllene 0.09
+                   cbf/alpha         0.12
+                   cbf/substitutes   "Galena, Cluster, Brewer's Gold"}))
 
 
 (def tillicum
   "Elements of citrus and peach."
   (hops/build-hop :tillicum
-                  {:beta          0.11
-                   :name          "Tillicum"
-                   :cohumulone    0.34
-                   :type          "Bittering"
-                   :myrcene       0.39
-                   :humulene      0.15
-                   :hsi           0.8
-                   :notes         "Elements of citrus and peach."
-                   :caryophyllene 0.07
-                   :alpha         0.15
-                   :substitutes   "Galena, Chelan"}))
+                  {cbf/beta          0.11
+                   cbf/name          "Tillicum"
+                   cbf/cohumulone    0.34
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.39
+                   cbf/humulene      0.15
+                   cbf/hsi           0.8
+                   cbf/notes         "Elements of citrus and peach."
+                   cbf/caryophyllene 0.07
+                   cbf/alpha         0.15
+                   cbf/substitutes   "Galena, Chelan"}))
 
 
 (def brewers-gold-us
   "An incredibly sharp bittering flavor."
   (hops/build-hop :brewers-gold-us
-                  {:beta          0.045
-                   :name          "Brewer's Gold US"
-                   :cohumulone    0.4
-                   :type          "Bittering"
-                   :myrcene       0.4
-                   :humulene      0.35
-                   :hsi           0.1
-                   :notes         "An incredibly sharp bittering flavor."
-                   :caryophyllene 0.35
-                   :alpha         0.1
-                   :substitutes   "Cascade, Galena"}))
+                  {cbf/beta          0.045
+                   cbf/name          "Brewer's Gold US"
+                   cbf/cohumulone    0.4
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.4
+                   cbf/humulene      0.35
+                   cbf/hsi           0.1
+                   cbf/notes         "An incredibly sharp bittering flavor."
+                   cbf/caryophyllene 0.35
+                   cbf/alpha         0.1
+                   cbf/substitutes   "Cascade, Galena"}))
 
 
 (def nugget
   "Solid bittering, light flavor, herbal aroma."
   (hops/build-hop :nugget
-                  {:beta          0.06
-                   :name          "Nugget"
-                   :cohumulone    0.26
-                   :type          "Bittering"
-                   :myrcene       0.54
-                   :humulene      0.17
-                   :hsi           0.75
-                   :notes         "Solid bittering, light flavor, herbal aroma."
-                   :caryophyllene 0.08
-                   :alpha         0.14
-                   :substitutes   "Galena"}))
+                  {cbf/beta          0.06
+                   cbf/name          "Nugget"
+                   cbf/cohumulone    0.26
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.54
+                   cbf/humulene      0.17
+                   cbf/hsi           0.75
+                   cbf/notes         "Solid bittering, light flavor, herbal aroma."
+                   cbf/caryophyllene 0.08
+                   cbf/alpha         0.14
+                   cbf/substitutes   "Galena"}))
 
 
 (def bravo
   "Spicy, earthy, and lightly floral aroma."
   (hops/build-hop :bravo
-                  {:beta          0.05
-                   :name          "Bravo"
-                   :cohumulone    0.32
-                   :type          "Bittering"
-                   :myrcene       0.38
-                   :humulene      0.2
-                   :hsi           0.7
-                   :notes         "Spicy, earthy, and lightly floral aroma."
-                   :caryophyllene 0.1
-                   :alpha         0.18
-                   :substitutes   "Columbus, CTZ, Nugget"}))
+                  {cbf/beta          0.05
+                   cbf/name          "Bravo"
+                   cbf/cohumulone    0.32
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.38
+                   cbf/humulene      0.2
+                   cbf/hsi           0.7
+                   cbf/notes         "Spicy, earthy, and lightly floral aroma."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.18
+                   cbf/substitutes   "Columbus, CTZ, Nugget"}))
 
 
 (def magnum-us
@@ -136,161 +138,161 @@
    
    Genetically indistinguishable from the German variety"
   (hops/build-hop :magnum-us
-                  {:beta          0.06
-                   :name          "Magnum US"
-                   :cohumulone    0.25
-                   :type          "Bittering"
-                   :myrcene       0.3
-                   :humulene      0.35
-                   :hsi           0.85
-                   :notes         "Excellent bittering profile and a nice, hoppy, floral aroma and subtle characters of citrus. Genetically indistinguishable from the German variety."
-                   :caryophyllene 0.1
-                   :alpha         0.14
-                   :substitutes   "Hallertau, Columbus, Nugget"}))
+                  {cbf/beta          0.06
+                   cbf/name          "Magnum US"
+                   cbf/cohumulone    0.25
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.3
+                   cbf/humulene      0.35
+                   cbf/hsi           0.85
+                   cbf/notes         "Excellent bittering profile and a nice, hoppy, floral aroma and subtle characters of citrus. Genetically indistinguishable from the German variety."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.14
+                   cbf/substitutes   "Hallertau, Columbus, Nugget"}))
 
 
 (def apollo
   "Sharp, clean bittering with grapefruit notes."
   (hops/build-hop :apollo
-                  {:beta          0.08
-                   :name          "Apollo"
-                   :cohumulone    0.25
-                   :type          "Bittering"
-                   :myrcene       0.4
-                   :humulene      0.3
-                   :hsi           0.85
-                   :notes         "Sharp, clean bittering with grapefruit notes."
-                   :caryophyllene 0.18
-                   :alpha         0.2
-                   :substitutes   "Nugget, Columbus, CTZ"}))
+                  {cbf/beta          0.08
+                   cbf/name          "Apollo"
+                   cbf/cohumulone    0.25
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.4
+                   cbf/humulene      0.3
+                   cbf/hsi           0.85
+                   cbf/notes         "Sharp, clean bittering with grapefruit notes."
+                   cbf/caryophyllene 0.18
+                   cbf/alpha         0.2
+                   cbf/substitutes   "Nugget, Columbus, CTZ"}))
 
 
 (def ctz
   "Also known as Zeus. Sweet citrus notes with an herbal aroma."
   (hops/build-hop :ctz
-                  {:beta          0.05
-                   :name          "CTZ"
-                   :cohumulone    0.35
-                   :type          "Bittering"
-                   :myrcene       0.5
-                   :humulene      0.12
-                   :hsi           0.8
-                   :notes         "Also known as Zeus. Sweet citrus notes with an herbal aroma."
-                   :caryophyllene 0.07
-                   :alpha         0.17
-                   :substitutes   "Columbus, Apollo"}))
+                  {cbf/beta          0.05
+                   cbf/name          "CTZ"
+                   cbf/cohumulone    0.35
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.5
+                   cbf/humulene      0.12
+                   cbf/hsi           0.8
+                   cbf/notes         "Also known as Zeus. Sweet citrus notes with an herbal aroma."
+                   cbf/caryophyllene 0.07
+                   cbf/alpha         0.17
+                   cbf/substitutes   "Columbus, Apollo"}))
 
 
 (def super-galena
   "A far more potent variety of Galena with great bittering potential and citrus notes."
   (hops/build-hop :super-galena
-                  {:beta          0.1
-                   :name          "Super Galena"
-                   :cohumulone    0.4
-                   :type          "Bittering"
-                   :myrcene       0.5
-                   :humulene      0.35
-                   :hsi           0.7
-                   :notes         "A far more potent variety of Galena with great bittering potential and citrus notes."
-                   :caryophyllene 0.1
-                   :alpha         0.16
-                   :substitutes   "Galena, Columbus, CTZ, Eroica"}))
+                  {cbf/beta          0.1
+                   cbf/name          "Super Galena"
+                   cbf/cohumulone    0.4
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.5
+                   cbf/humulene      0.35
+                   cbf/hsi           0.7
+                   cbf/notes         "A far more potent variety of Galena with great bittering potential and citrus notes."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.16
+                   cbf/substitutes   "Galena, Columbus, CTZ, Eroica"}))
 
 
 (def warrior
   "Strong aroma of spice and citrus."
   (hops/build-hop :warrior
-                  {:beta          0.055
-                   :name          "Warrior"
-                   :cohumulone    0.26
-                   :type          "Bittering"
-                   :myrcene       0.45
-                   :humulene      0.17
-                   :hsi           0.76
-                   :notes         "Strong aroma of spice and citrus."
-                   :caryophyllene 0.1
-                   :alpha         0.18
-                   :substitutes   "Nugget, Columbus"}))
+                  {cbf/beta          0.055
+                   cbf/name          "Warrior"
+                   cbf/cohumulone    0.26
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.45
+                   cbf/humulene      0.17
+                   cbf/hsi           0.76
+                   cbf/notes         "Strong aroma of spice and citrus."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.18
+                   cbf/substitutes   "Nugget, Columbus"}))
 
 
 (def millennium
   "Mild herbal notes with elements of resin."
   (hops/build-hop :millennium
-                  {:beta          0.053
-                   :name          "Millennium"
-                   :cohumulone    0.3
-                   :type          "Bittering"
-                   :myrcene       0.35
-                   :humulene      0.25
-                   :hsi           0.75
-                   :notes         "Mild herbal notes with elements of resin."
-                   :caryophyllene 0.1
-                   :alpha         0.165
-                   :substitutes   "CTZ, Nugget"}))
+                  {cbf/beta          0.053
+                   cbf/name          "Millennium"
+                   cbf/cohumulone    0.3
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.35
+                   cbf/humulene      0.25
+                   cbf/hsi           0.75
+                   cbf/notes         "Mild herbal notes with elements of resin."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.165
+                   cbf/substitutes   "CTZ, Nugget"}))
 
 
 (def chinook
   "Powerful notes of pine and spice."
   (hops/build-hop :chinook
-                  {:beta          0.04
-                   :name          "Chinook"
-                   :cohumulone    0.3
-                   :type          "Bittering"
-                   :myrcene       0.35
-                   :humulene      0.2
-                   :hsi           0.7
-                   :notes         "Powerful notes of pine and spice."
-                   :caryophyllene 0.1
-                   :alpha         0.14
-                   :substitutes   "Galena, Eroica, Nugget"}))
+                  {cbf/beta          0.04
+                   cbf/name          "Chinook"
+                   cbf/cohumulone    0.3
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.35
+                   cbf/humulene      0.2
+                   cbf/hsi           0.7
+                   cbf/notes         "Powerful notes of pine and spice."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.14
+                   cbf/substitutes   "Galena, Eroica, Nugget"}))
 
 
 (def newport
   "Derived from the Magnum genus. Provides clean bitterness."
   (hops/build-hop :newport
-                  {:beta          0.09
-                   :name          "Newport"
-                   :cohumulone    0.37
-                   :type          "Bittering"
-                   :myrcene       0.5
-                   :humulene      0.09
-                   :hsi           0.6
-                   :notes         "Derived from the Magnum genus. Provides clean bitterness."
-                   :caryophyllene 0.5
-                   :alpha         0.17
-                   :substitutes   "Galena, Nugget"}))
+                  {cbf/beta          0.09
+                   cbf/name          "Newport"
+                   cbf/cohumulone    0.37
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.5
+                   cbf/humulene      0.09
+                   cbf/hsi           0.6
+                   cbf/notes         "Derived from the Magnum genus. Provides clean bitterness."
+                   cbf/caryophyllene 0.5
+                   cbf/alpha         0.17
+                   cbf/substitutes   "Galena, Nugget"}))
 
 
 (def galena
   "One of the most commonly used bittering hops with a pleasant fruity aroma."
   (hops/build-hop :galena
-                  {:beta          0.09
-                   :name          "Galena"
-                   :cohumulone    0.4
-                   :type          "Bittering"
-                   :myrcene       0.55
-                   :humulene      0.12
-                   :hsi           0.75
-                   :notes         "One of the most commonly used bittering hops with a pleasant fruity aroma."
-                   :caryophyllene 0.04
-                   :alpha         0.135
-                   :substitutes   "Galena, Columbus, CTZ, Eroica"}))
+                  {cbf/beta          0.09
+                   cbf/name          "Galena"
+                   cbf/cohumulone    0.4
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.55
+                   cbf/humulene      0.12
+                   cbf/hsi           0.75
+                   cbf/notes         "One of the most commonly used bittering hops with a pleasant fruity aroma."
+                   cbf/caryophyllene 0.04
+                   cbf/alpha         0.135
+                   cbf/substitutes   "Galena, Columbus, CTZ, Eroica"}))
 
 
 (def bullion
   "Scents of dark fruit and spice."
   (hops/build-hop :bullion
-                  {:beta          0.06
-                   :name          "Bullion"
-                   :cohumulone    0.4
-                   :type          "Bittering"
-                   :myrcene       0.5
-                   :humulene      0.25
-                   :hsi           0.45
-                   :notes         "Scents of dark fruit and spice."
-                   :caryophyllene 0.1
-                   :alpha         0.08
-                   :substitutes   "Columbus, Chinook, Galena"}))
+                  {cbf/beta          0.06
+                   cbf/name          "Bullion"
+                   cbf/cohumulone    0.4
+                   cbf/type          "Bittering"
+                   cbf/myrcene       0.5
+                   cbf/humulene      0.25
+                   cbf/hsi           0.45
+                   cbf/notes         "Scents of dark fruit and spice."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.08
+                   cbf/substitutes   "Columbus, Chinook, Galena"}))
 
 
 (def bittering

--- a/src/common_beer_data/hops/both.cljc
+++ b/src/common_beer_data/hops/both.cljc
@@ -1,6 +1,8 @@
 (ns common-beer-data.hops.both
   "Data for multi-purpose hops."
-  (:require [common-beer-data.hops.hops :as hops]))
+  {:added "1.0"}
+  (:require [common-beer-data.hops.hops :as hops]
+            [common-beer-format.hops :as cbf]))
 
 
 (def el-dorado
@@ -8,193 +10,193 @@
    
    Aromas of pear, watermelon, stone fruit and candy."
   (hops/build-hop :el-dorado
-                  {:beta          0.08
-                   :name          "El Dorado"
-                   :cohumulone    0.3
-                   :type          "Both"
-                   :myrcene       0.57
-                   :humulene      0.1
-                   :hsi           0.75
-                   :notes         "Flavors of tropical fruit, pineapple, mango. Aromas of pear, watermelon, stone fruit and candy."
-                   :caryophyllene 0.06
-                   :alpha         0.16
-                   :substitutes   "Galena, Simcoe"}))
+                  {cbf/beta          0.08
+                   cbf/name          "El Dorado"
+                   cbf/cohumulone    0.3
+                   cbf/type          "Both"
+                   cbf/myrcene       0.57
+                   cbf/humulene      0.1
+                   cbf/hsi           0.75
+                   cbf/notes         "Flavors of tropical fruit, pineapple, mango. Aromas of pear, watermelon, stone fruit and candy."
+                   cbf/caryophyllene 0.06
+                   cbf/alpha         0.16
+                   cbf/substitutes   "Galena, Simcoe"}))
 
 
 (def celeia
   "Floral and citrus aroma."
   (hops/build-hop :celeia
-                  {:beta          0.035
-                   :name          "Celeia"
-                   :cohumulone    0.25
-                   :type          "Both"
-                   :myrcene       0.5
-                   :humulene      0.17
-                   :hsi           0.56
-                   :notes         "Floral and citrus aroma."
-                   :caryophyllene 0.07
-                   :alpha         0.055
-                   :substitutes   "Saaz US"}))
+                  {cbf/beta          0.035
+                   cbf/name          "Celeia"
+                   cbf/cohumulone    0.25
+                   cbf/type          "Both"
+                   cbf/myrcene       0.5
+                   cbf/humulene      0.17
+                   cbf/hsi           0.56
+                   cbf/notes         "Floral and citrus aroma."
+                   cbf/caryophyllene 0.07
+                   cbf/alpha         0.055
+                   cbf/substitutes   "Saaz US"}))
 
 
 (def perle-us
   "Faint spicy aroma."
   (hops/build-hop :perle-us
-                  {:beta          0.05
-                   :name          "Perle US"
-                   :cohumulone    0.28
-                   :type          "Both"
-                   :myrcene       0.45
-                   :humulene      0.3
-                   :hsi           0.7
-                   :notes         "Faint spicy aroma."
-                   :caryophyllene 0.1
-                   :alpha         0.095
-                   :substitutes   "Northern Brewer"}))
+                  {cbf/beta          0.05
+                   cbf/name          "Perle US"
+                   cbf/cohumulone    0.28
+                   cbf/type          "Both"
+                   cbf/myrcene       0.45
+                   cbf/humulene      0.3
+                   cbf/hsi           0.7
+                   cbf/notes         "Faint spicy aroma."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.095
+                   cbf/substitutes   "Northern Brewer"}))
 
 
 (def northdown
   "Fresh, flowery, piney, berry and spice."
   (hops/build-hop :northdown
-                  {:beta          0.048
-                   :name          "Northdown"
-                   :cohumulone    0.3
-                   :type          "Both"
-                   :myrcene       0.25
-                   :humulene      0.4
-                   :hsi           0.65
-                   :notes         "Fresh, flowery, piney, berry and spice."
-                   :caryophyllene 0.15
-                   :alpha         0.085
-                   :substitutes   "Challenger"}))
+                  {cbf/beta          0.048
+                   cbf/name          "Northdown"
+                   cbf/cohumulone    0.3
+                   cbf/type          "Both"
+                   cbf/myrcene       0.25
+                   cbf/humulene      0.4
+                   cbf/hsi           0.65
+                   cbf/notes         "Fresh, flowery, piney, berry and spice."
+                   cbf/caryophyllene 0.15
+                   cbf/alpha         0.085
+                   cbf/substitutes   "Challenger"}))
 
 
 (def horizon
   "Floral, citrusy flavors and aromas."
   (hops/build-hop :horizon
-                  {:beta          0.05
-                   :name          "Horizon"
-                   :cohumulone    0.2
-                   :type          "Both"
-                   :myrcene       0.65
-                   :humulene      0.12
-                   :hsi           0.85
-                   :notes         "Floral, citrusy flavors and aromas."
-                   :caryophyllene 0.1
-                   :alpha         0.1
-                   :substitutes   "Magnum"}))
+                  {cbf/beta          0.05
+                   cbf/name          "Horizon"
+                   cbf/cohumulone    0.2
+                   cbf/type          "Both"
+                   cbf/myrcene       0.65
+                   cbf/humulene      0.12
+                   cbf/hsi           0.85
+                   cbf/notes         "Floral, citrusy flavors and aromas."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.1
+                   cbf/substitutes   "Magnum"}))
 
 
 (def northern-brewer
   "Minty and resinous."
   (hops/build-hop :northern-brewer
-                  {:beta          0.04
-                   :name          "Northern Brewer"
-                   :cohumulone    0.25
-                   :type          "Both"
-                   :myrcene       0.55
-                   :humulene      0.2
-                   :hsi           0.75
-                   :notes         "Minty and resinous."
-                   :caryophyllene 0.07
-                   :alpha         0.095
-                   :substitutes   "Perle US, Columbus"}))
+                  {cbf/beta          0.04
+                   cbf/name          "Northern Brewer"
+                   cbf/cohumulone    0.25
+                   cbf/type          "Both"
+                   cbf/myrcene       0.55
+                   cbf/humulene      0.2
+                   cbf/hsi           0.75
+                   cbf/notes         "Minty and resinous."
+                   cbf/caryophyllene 0.07
+                   cbf/alpha         0.095
+                   cbf/substitutes   "Perle US, Columbus"}))
 
 
 (def columbus
   "It features a punchy hoppiness and deep, pensive aroma with understated citrus notes—perfect as a dual use hop."
   (hops/build-hop :columbus
-                  {:beta          0.053
-                   :name          "Columbus"
-                   :cohumulone    0.32
-                   :type          "Both"
-                   :myrcene       0.34
-                   :humulene      0.17
-                   :hsi           0.55
-                   :notes         "It features a punchy hoppiness and deep, pensive aroma with understated citrus notes—perfect as a dual use hop."
-                   :caryophyllene 0.09
-                   :alpha         0.16
-                   :substitutes   "Chinook, Northern Brewer, Nugget"}))
+                  {cbf/beta          0.053
+                   cbf/name          "Columbus"
+                   cbf/cohumulone    0.32
+                   cbf/type          "Both"
+                   cbf/myrcene       0.34
+                   cbf/humulene      0.17
+                   cbf/hsi           0.55
+                   cbf/notes         "It features a punchy hoppiness and deep, pensive aroma with understated citrus notes—perfect as a dual use hop."
+                   cbf/caryophyllene 0.09
+                   cbf/alpha         0.16
+                   cbf/substitutes   "Chinook, Northern Brewer, Nugget"}))
 
 
 (def challenger
   "Challenger features decent bitterness and a floral aroma."
   (hops/build-hop :challenger
-                  {:beta          0.037
-                   :name          "Challenger"
-                   :cohumulone    0.2
-                   :type          "aroma"
-                   :myrcene       0.36
-                   :humulene      0.3
-                   :hsi           0.8
-                   :notes         "Challenger features decent bitterness and a floral aroma."
-                   :caryophyllene 0.09
-                   :alpha         0.021
-                   :substitutes   "Admiral, Perle"}))
+                  {cbf/beta          0.037
+                   cbf/name          "Challenger"
+                   cbf/cohumulone    0.2
+                   cbf/type          "aroma"
+                   cbf/myrcene       0.36
+                   cbf/humulene      0.3
+                   cbf/hsi           0.8
+                   cbf/notes         "Challenger features decent bitterness and a floral aroma."
+                   cbf/caryophyllene 0.09
+                   cbf/alpha         0.021
+                   cbf/substitutes   "Admiral, Perle"}))
 
 
 (def citra
   "HBC# 394cv. Strong notes of tropical fruits with a harsh bitterness."
   (hops/build-hop :citra
-                  {:beta          0.045
-                   :name          "Citra"
-                   :cohumulone    0.3
-                   :type          "aroma"
-                   :myrcene       0.65
-                   :humulene      0.1
-                   :hsi           0.75
-                   :notes         "HBC# 394cv. Strong notes of tropical fruits with a harsh bitterness."
-                   :caryophyllene 0.05
-                   :alpha         0.13
-                   :substitutes   "Cascade, Simcoe"}))
+                  {cbf/beta          0.045
+                   cbf/name          "Citra"
+                   cbf/cohumulone    0.3
+                   cbf/type          "aroma"
+                   cbf/myrcene       0.65
+                   cbf/humulene      0.1
+                   cbf/hsi           0.75
+                   cbf/notes         "HBC# 394cv. Strong notes of tropical fruits with a harsh bitterness."
+                   cbf/caryophyllene 0.05
+                   cbf/alpha         0.13
+                   cbf/substitutes   "Cascade, Simcoe"}))
 
 
 (def tettnanger
   "Floral and herbal notes with a mild spiciness."
   (hops/build-hop :tettnanger
-                  {:beta          0.04
-                   :name          "Tettnanger"
-                   :cohumulone    0.2
-                   :type          "aroma"
-                   :myrcene       0.24
-                   :humulene      0.2
-                   :hsi           0.55
-                   :notes         "Floral and herbal notes with a mild spiciness."
-                   :caryophyllene 0.06
-                   :alpha         0.05
-                   :substitutes   "Spalt, Saaz"}))
+                  {cbf/beta          0.04
+                   cbf/name          "Tettnanger"
+                   cbf/cohumulone    0.2
+                   cbf/type          "aroma"
+                   cbf/myrcene       0.24
+                   cbf/humulene      0.2
+                   cbf/hsi           0.55
+                   cbf/notes         "Floral and herbal notes with a mild spiciness."
+                   cbf/caryophyllene 0.06
+                   cbf/alpha         0.05
+                   cbf/substitutes   "Spalt, Saaz"}))
 
 
 (def galaxy
   "Stone fruit aroma with citrus notes."
   (hops/build-hop :galaxy
-                  {:beta          0.055
-                   :name          "Galaxy"
-                   :cohumulone    0.36
-                   :type          "aroma"
-                   :myrcene       0.5
-                   :humulene      0.01
-                   :hsi           0.55
-                   :notes         "Stone fruit aroma with citrus notes."
-                   :caryophyllene 0.06
-                   :alpha         0.13
-                   :substitutes   "Topaz, Citra, Cascade"}))
+                  {cbf/beta          0.055
+                   cbf/name          "Galaxy"
+                   cbf/cohumulone    0.36
+                   cbf/type          "aroma"
+                   cbf/myrcene       0.5
+                   cbf/humulene      0.01
+                   cbf/hsi           0.55
+                   cbf/notes         "Stone fruit aroma with citrus notes."
+                   cbf/caryophyllene 0.06
+                   cbf/alpha         0.13
+                   cbf/substitutes   "Topaz, Citra, Cascade"}))
 
 
 (def topaz
   "Stone fruit aroma with citrus notes."
   (hops/build-hop :topaz
-                  {:beta          0.07
-                   :name          "Topaz"
-                   :cohumulone    0.5
-                   :type          "aroma"
-                   :myrcene       0.4
-                   :humulene      0.1
-                   :hsi           0.55
-                   :notes         "Stone fruit aroma with citrus notes."
-                   :caryophyllene 0.1
-                   :alpha         0.15
-                   :substitutes   "Galaxy, Citra, Amarillo"}))
+                  {cbf/beta          0.07
+                   cbf/name          "Topaz"
+                   cbf/cohumulone    0.5
+                   cbf/type          "aroma"
+                   cbf/myrcene       0.4
+                   cbf/humulene      0.1
+                   cbf/hsi           0.55
+                   cbf/notes         "Stone fruit aroma with citrus notes."
+                   cbf/caryophyllene 0.1
+                   cbf/alpha         0.15
+                   cbf/substitutes   "Galaxy, Citra, Amarillo"}))
 
 
 (def both

--- a/src/common_beer_data/hops/hops.cljc
+++ b/src/common_beer_data/hops/hops.cljc
@@ -1,17 +1,19 @@
 (ns ^:no-doc common-beer-data.hops.hops
-  "Function to help minimize repeated data in hop entry.")
+  "Function to help minimize repeated data in hop entry."
+  {:added "1.0"}
+  (:require [common-beer-format.hops :as cbf]))
 
 
 (def ^:private hop-defaults
   "To generate complete records that match the ::hop spec, we have defaulted the following:
    :use  - 'boil'
-   :form - 'pellet'
+   cbf/form - 'pellet'
    :time - 0"
-  {:version 1
-   :amount  0.0
-   :time    0.0
-   :use     "Boil"
-   :form    "Pellet"})
+  {cbf/version 1
+   cbf/amount  0.0
+   cbf/time    0.0
+   cbf/use     "Boil"
+   cbf/form    "Pellet"})
 
 
 (defn build-hop

--- a/src/common_beer_data/styles/bjcp_2015/alternative_fermentables_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/alternative_fermentables_beer.cljc
@@ -1,33 +1,34 @@
 (ns common-beer-data.styles.bjcp-2015.alternative-fermentables-beer
   "2015 BJCP guidelines on Beers with alternative (non-barley, non-wheat) fermentables."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def alternative-grain-beer
   "A base beer enhanced by or featuring the character of additional grain or grains.
    The specific character depends greatly on the character of the added grains."
   (styles/build-style :alternative-grain-beer
-                      {:category        "Alternative Fermentables Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Alternative Grain Beer"
-                       :type            "Mixed"
-                       :style-letter    "A"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "31"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Generally ales, although some dark strong lagers exist. Spices are required, and often include those evocative of the Christmas season (e.g., allspice, nutmeg, cinnamon, cloves, ginger) but any combination is possible and creativity is encouraged. Fruit peel (e.g., oranges, lemon) may be used, as may subtle additions of other fruits. Flavorful adjuncts are often used (e.g., molasses, treacle, invert sugar, brown sugar, honey, maple syrup, etc.)."
-                       :examples        "Green's Indian Pale Ale, Lakefront New Grist, New Planet Pale Ale"
-                       :notes           "A base beer enhanced by or featuring the character of additional grain or grains. The specific character depends greatly on the character of the added grains."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: Same as base beer style. The added grain will lend a particular character, although with some grains the beer will simply seem a bit more grainy or nutty. The alternative grain should provide the major aroma profile for this beer. Appearance: Same as base beer style, although some additional haze may be noticeable. Flavor: Same as base beer style. The additional grain should be noticeable in flavor, although it may not be necessarily identifiable. However, the alternative grain should provide the major flavor profile for this beer. Different grains have different characters; the additional grain should enhance the flavor of the base beer. Many will add an additional grainy, bready, or nutty flavor. Mouthfeel: Same as the base beer, although many additional grains will tend to increase the body (oats, rye) and increase the viscosity, while some may decrease the body (GF grains) resulting in thinness."
-                       :ibu-min         7}))
+                      {cbf/category        "Alternative Fermentables Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Alternative Grain Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "31"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Generally ales, although some dark strong lagers exist. Spices are required, and often include those evocative of the Christmas season (e.g., allspice, nutmeg, cinnamon, cloves, ginger) but any combination is possible and creativity is encouraged. Fruit peel (e.g., oranges, lemon) may be used, as may subtle additions of other fruits. Flavorful adjuncts are often used (e.g., molasses, treacle, invert sugar, brown sugar, honey, maple syrup, etc.)."
+                       cbf/examples        "Green's Indian Pale Ale, Lakefront New Grist, New Planet Pale Ale"
+                       cbf/notes           "A base beer enhanced by or featuring the character of additional grain or grains. The specific character depends greatly on the character of the added grains."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Same as base beer style. The added grain will lend a particular character, although with some grains the beer will simply seem a bit more grainy or nutty. The alternative grain should provide the major aroma profile for this beer. Appearance: Same as base beer style, although some additional haze may be noticeable. Flavor: Same as base beer style. The additional grain should be noticeable in flavor, although it may not be necessarily identifiable. However, the alternative grain should provide the major flavor profile for this beer. Different grains have different characters; the additional grain should enhance the flavor of the base beer. Many will add an additional grainy, bready, or nutty flavor. Mouthfeel: Same as the base beer, although many additional grains will tend to increase the body (oats, rye) and increase the viscosity, while some may decrease the body (GF grains) resulting in thinness."
+                       cbf/ibu-min         7}))
 
 
 (def alternative-sugar-beer
@@ -35,27 +36,27 @@
    
    The sugar character should both be evident but in balance with the beer, not so forward as to suggest an artificial product."
   (styles/build-style :alternative-sugar-beer
-                      {:category        "Alternative Fermentables Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Alternative Sugar Beer"
-                       :type            "Mixed"
-                       :style-letter    "B"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "31"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Generally ales, although some dark strong lagers exist. Spices are required, and often include those evocative of the Christmas season (e.g., allspice, nutmeg, cinnamon, cloves, ginger) but any combination is possible and creativity is encouraged. Fruit peel (e.g., oranges, lemon) may be used, as may subtle additions of other fruits. Flavorful adjuncts are often used (e.g., molasses, treacle, invert sugar, brown sugar, honey, maple syrup, etc.)."
-                       :examples        "Bell's Hopslam, Fullers Honey Dew, Lagunitas Brown Shugga'"
-                       :notes           "A harmonious marriage of sugar and beer, but still recognizable as a beer. The sugar character should both be evident but in balance with the beer, not so forward as to suggest an artificial product."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: Same as the base beer, except that some additional fermentables (honey, molasses, etc.) may add an aroma component. Whatever additional aroma component is present should be in balance with the beer components, and be a pleasant combination. Appearance: Same as the base beer, although some sugars will bring additional colors. Flavor: Same as the base beer, except that some additional fermentables (honey, molasses, etc.) may add a flavor component. Whatever additional flavor component is present should be in balance with the beer components, and be a pleasant combination. Added sugars should not have a raw, unfermented flavor. Some added sugars will have unfermentable elements that may provide a fuller finish; fully fermentable sugars may thin out the finish. Mouthfeel: Same as the base beer, although depending on the type of sugar added, could increase or decrease the body."
-                       :ibu-min         7}))
+                      {cbf/category        "Alternative Fermentables Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Alternative Sugar Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "31"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Generally ales, although some dark strong lagers exist. Spices are required, and often include those evocative of the Christmas season (e.g., allspice, nutmeg, cinnamon, cloves, ginger) but any combination is possible and creativity is encouraged. Fruit peel (e.g., oranges, lemon) may be used, as may subtle additions of other fruits. Flavorful adjuncts are often used (e.g., molasses, treacle, invert sugar, brown sugar, honey, maple syrup, etc.)."
+                       cbf/examples        "Bell's Hopslam, Fullers Honey Dew, Lagunitas Brown Shugga'"
+                       cbf/notes           "A harmonious marriage of sugar and beer, but still recognizable as a beer. The sugar character should both be evident but in balance with the beer, not so forward as to suggest an artificial product."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Same as the base beer, except that some additional fermentables (honey, molasses, etc.) may add an aroma component. Whatever additional aroma component is present should be in balance with the beer components, and be a pleasant combination. Appearance: Same as the base beer, although some sugars will bring additional colors. Flavor: Same as the base beer, except that some additional fermentables (honey, molasses, etc.) may add a flavor component. Whatever additional flavor component is present should be in balance with the beer components, and be a pleasant combination. Added sugars should not have a raw, unfermented flavor. Some added sugars will have unfermentable elements that may provide a fuller finish; fully fermentable sugars may thin out the finish. Mouthfeel: Same as the base beer, although depending on the type of sugar added, could increase or decrease the body."
+                       cbf/ibu-min         7}))
 
 
 (def alternative-fermentables-beer

--- a/src/common_beer_data/styles/bjcp_2015/amber_and_brown_american_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/amber_and_brown_american_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.amber-and-brown-american-beer
   "2015 BJCP guidelines on American Amber and Brown Beers"
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def american-amber-ale
@@ -9,53 +10,53 @@
    The balance can vary quite a bit, with some versions being fairly malty and others being aggressively hoppy.
    Hoppy and bitter versions should not have clashing flavors with the caramel malt profile."
   (styles/build-style :american-amber-ale
-                      {:category        "Amber And Brown American Beer"
-                       :carb-min        1.5
-                       :fg-max          1.015
-                       :og-min          1.045
-                       :name            "American Amber Ale"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.045
-                       :fg-min          1.01
-                       :category-number "19"
-                       :carb-max        3.0
-                       :ibu-max         40
-                       :ingredients     "Pale ale malt, typically North American two-row. Medium to dark crystal malts. May also contain specialty grains which add additional character and uniqueness. American or New World hops, often with citrusy flavors, are common but others may also be used."
-                       :examples        "Deschutes Cinder Cone Red, Full Sail Amber, Kona Lavaman Red Ale, North Coast Ruedrich's Red Seal Ale, Rogue American Amber Ale, Tröegs HopBack Amber Ale"
-                       :notes           "An amber, hoppy, moderate-strength American craft beer with a caramel malty flavor. The balance can vary quite a bit, with some versions being fairly malty and others being aggressively hoppy. Hoppy and bitter versions should not have clashing flavors with the caramel malt profile."
-                       :og-max          1.06
-                       :color-min       10.0
-                       :abv-max         0.062
-                       :color-max       17.0
-                       :profile         "Aroma: Low to moderate hop aroma with characteristics typical of American or New World hop varieties (citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, or melon). A citrusy hop character is common, but not required. Moderately-low to moderately-high maltiness (usually with a moderate caramel character), which can either support, balance, or sometimes mask the hop presentation. Esters vary from moderate to none. Appearance: Amber to coppery-brown in color. Moderately large off-white head with good retention. Generally quite clear, although dry-hopped versions may be slightly hazy. Flavor: Moderate to high hop flavor with characteristics typical of American or New World hop varieties (citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, or melon). A citrusy hop character is common, but not required. Malt flavors are moderate to strong, and usually show an initial malty sweetness followed by a moderate caramel flavor (and sometimes other character malts in lesser amounts). Malt and hop bitterness are usually balanced and mutually supportive, but can vary either way. Fruity esters can be moderate to none. Caramel sweetness and hop flavor/bitterness can linger somewhat into the medium to full finish. Mouthfeel: Medium to medium-full body. Medium to high carbonation. Overall smooth finish without astringency. Stronger versions may have a slight alcohol warmth."
-                       :ibu-min         25}))
+                      {cbf/category        "Amber And Brown American Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.015
+                       cbf/og-min          1.045
+                       cbf/name            "American Amber Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.045
+                       cbf/fg-min          1.01
+                       cbf/category-number "19"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         40
+                       cbf/ingredients     "Pale ale malt, typically North American two-row. Medium to dark crystal malts. May also contain specialty grains which add additional character and uniqueness. American or New World hops, often with citrusy flavors, are common but others may also be used."
+                       cbf/examples        "Deschutes Cinder Cone Red, Full Sail Amber, Kona Lavaman Red Ale, North Coast Ruedrich's Red Seal Ale, Rogue American Amber Ale, Tröegs HopBack Amber Ale"
+                       cbf/notes           "An amber, hoppy, moderate-strength American craft beer with a caramel malty flavor. The balance can vary quite a bit, with some versions being fairly malty and others being aggressively hoppy. Hoppy and bitter versions should not have clashing flavors with the caramel malt profile."
+                       cbf/og-max          1.06
+                       cbf/color-min       10.0
+                       cbf/abv-max         0.062
+                       cbf/color-max       17.0
+                       cbf/profile         "Aroma: Low to moderate hop aroma with characteristics typical of American or New World hop varieties (citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, or melon). A citrusy hop character is common, but not required. Moderately-low to moderately-high maltiness (usually with a moderate caramel character), which can either support, balance, or sometimes mask the hop presentation. Esters vary from moderate to none. Appearance: Amber to coppery-brown in color. Moderately large off-white head with good retention. Generally quite clear, although dry-hopped versions may be slightly hazy. Flavor: Moderate to high hop flavor with characteristics typical of American or New World hop varieties (citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, or melon). A citrusy hop character is common, but not required. Malt flavors are moderate to strong, and usually show an initial malty sweetness followed by a moderate caramel flavor (and sometimes other character malts in lesser amounts). Malt and hop bitterness are usually balanced and mutually supportive, but can vary either way. Fruity esters can be moderate to none. Caramel sweetness and hop flavor/bitterness can linger somewhat into the medium to full finish. Mouthfeel: Medium to medium-full body. Medium to high carbonation. Overall smooth finish without astringency. Stronger versions may have a slight alcohol warmth."
+                       cbf/ibu-min         25}))
 
 
 (def california-common
   "A lightly fruity beer with firm, grainy maltiness, interesting toasty and caramel flavors, and showcasing rustic, traditional American hop characteristics."
   (styles/build-style :california-common
-                      {:category        "Amber And Brown American Beer"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.048
-                       :name            "California Common"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.045
-                       :fg-min          1.011
-                       :category-number "19"
-                       :carb-max        3.0
-                       :ibu-max         45
-                       :ingredients     "Pale ale malt, non-citrusy hops (often Northern Brewer), small amounts of toasted malt and/or crystal malts. Lager yeast; however, some strains (often with the mention of \"California\" in the name) work better than others at the warmer fermentation temperatures (55 to 60 °F) typically used. Note that some German yeast strains produce inappropriate sulfury character."
-                       :examples        "Anchor Steam, Flying Dog Old Scratch Amber Lager, Schlafly Pi Common, Steamworks Steam Engine Lager"
-                       :notes           "A lightly fruity beer with firm, grainy maltiness, interesting toasty and caramel flavors, and showcasing rustic, traditional American hop characteristics."
-                       :og-max          1.054
-                       :color-min       10.0
-                       :abv-max         0.055
-                       :color-max       14.0
-                       :profile         "Aroma: Typically showcases rustic, traditional American hops (often with woody, rustic or minty qualities) in moderate to high strength. Light fruitiness acceptable. Low to moderate caramel and/or toasty malt aromatics support the hops. Appearance: Medium amber to light copper color. Generally clear. Moderate off-white head with good retention. Flavor: Moderately malty with a pronounced hop bitterness. The malt character is usually toasty (not roasted) and caramelly. Low to moderately high hop flavor, usually showing rustic, traditional American hop qualities (often woody, rustic, minty). Finish fairly dry and crisp, with a lingering hop bitterness and a firm, grainy malt flavor. Light fruity esters are acceptable, but otherwise clean. Mouthfeel: Medium-bodied. Medium to medium-high carbonation."
-                       :ibu-min         30}))
+                      {cbf/category        "Amber And Brown American Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.048
+                       cbf/name            "California Common"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.045
+                       cbf/fg-min          1.011
+                       cbf/category-number "19"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         45
+                       cbf/ingredients     "Pale ale malt, non-citrusy hops (often Northern Brewer), small amounts of toasted malt and/or crystal malts. Lager yeast; however, some strains (often with the mention of \"California\" in the name) work better than others at the warmer fermentation temperatures (55 to 60 °F) typically used. Note that some German yeast strains produce inappropriate sulfury character."
+                       cbf/examples        "Anchor Steam, Flying Dog Old Scratch Amber Lager, Schlafly Pi Common, Steamworks Steam Engine Lager"
+                       cbf/notes           "A lightly fruity beer with firm, grainy maltiness, interesting toasty and caramel flavors, and showcasing rustic, traditional American hop characteristics."
+                       cbf/og-max          1.054
+                       cbf/color-min       10.0
+                       cbf/abv-max         0.055
+                       cbf/color-max       14.0
+                       cbf/profile         "Aroma: Typically showcases rustic, traditional American hops (often with woody, rustic or minty qualities) in moderate to high strength. Light fruitiness acceptable. Low to moderate caramel and/or toasty malt aromatics support the hops. Appearance: Medium amber to light copper color. Generally clear. Moderate off-white head with good retention. Flavor: Moderately malty with a pronounced hop bitterness. The malt character is usually toasty (not roasted) and caramelly. Low to moderately high hop flavor, usually showing rustic, traditional American hop qualities (often woody, rustic, minty). Finish fairly dry and crisp, with a lingering hop bitterness and a firm, grainy malt flavor. Light fruity esters are acceptable, but otherwise clean. Mouthfeel: Medium-bodied. Medium to medium-high carbonation."
+                       cbf/ibu-min         30}))
 
 
 (def american-brown-ale
@@ -63,27 +64,27 @@
    
    The hop flavor and aroma complements and enhances the malt rather than clashing with it."
   (styles/build-style :american-brown-ale
-                      {:category        "Amber And Brown American Beer"
-                       :carb-min        1.5
-                       :fg-max          1.016
-                       :og-min          1.045
-                       :name            "American Brown Ale"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.043
-                       :fg-min          1.01
-                       :category-number "19"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "Well-modified pale malt, plus crystal and darker malts (typically chocolate). American hops are typical, but continental or New World hops can also be used."
-                       :examples        "Anchor Brekle's Brown, Big Sky Moose Drool Brown Ale, Brooklyn Brown Ale, Bell's Best Brown, Cigar City Maduro Brown Ale, Smuttynose Old Brown Dog Ale, Telluride Face Down Brown"
-                       :notes           "A malty but hoppy beer frequently with chocolate and caramel flavors. The hop flavor and aroma complements and enhances the malt rather than clashing with it."
-                       :og-max          1.06
-                       :color-min       18.0
-                       :abv-max         0.062
-                       :color-max       35.0
-                       :profile         "Aroma: Moderate malty-sweet to malty-rich aroma with chocolate, caramel, nutty, and/or toasty qualities. Hop aroma is typically low to moderate, of almost any variety that complements the malt. Some interpretations of the style may feature a stronger hop aroma, an American or New World hop character (citrusy, fruity, tropical, etc.), and/or a fresh dry-hopped aroma (all are optional). Fruity esters are moderate to very low. The dark malt character is more robust than other brown ales, yet stops short of being overly porter-like. The malt and hops are generally balanced. Appearance: Light to very dark brown color. Clear. Low to moderate off-white to light tan head. Flavor: Medium to moderately-high malty-sweet or malty-rich flavor with chocolate, caramel, nutty, and/or toasty malt complexity, with medium to medium-high bitterness. The medium to medium-dry finish provides an aftertaste having both malt and hops. Hop flavor can be light to moderate, and may optionally have a citrusy, fruity, or tropical character, although any hop flavor that complements the malt is acceptable. Very low to moderate fruity esters. Mouthfeel: Medium to medium-full body. More bitter versions may have a dry, resiny impression. Moderate to moderately-high carbonation."
-                       :ibu-min         20}))
+                      {cbf/category        "Amber And Brown American Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.016
+                       cbf/og-min          1.045
+                       cbf/name            "American Brown Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.043
+                       cbf/fg-min          1.01
+                       cbf/category-number "19"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "Well-modified pale malt, plus crystal and darker malts (typically chocolate). American hops are typical, but continental or New World hops can also be used."
+                       cbf/examples        "Anchor Brekle's Brown, Big Sky Moose Drool Brown Ale, Brooklyn Brown Ale, Bell's Best Brown, Cigar City Maduro Brown Ale, Smuttynose Old Brown Dog Ale, Telluride Face Down Brown"
+                       cbf/notes           "A malty but hoppy beer frequently with chocolate and caramel flavors. The hop flavor and aroma complements and enhances the malt rather than clashing with it."
+                       cbf/og-max          1.06
+                       cbf/color-min       18.0
+                       cbf/abv-max         0.062
+                       cbf/color-max       35.0
+                       cbf/profile         "Aroma: Moderate malty-sweet to malty-rich aroma with chocolate, caramel, nutty, and/or toasty qualities. Hop aroma is typically low to moderate, of almost any variety that complements the malt. Some interpretations of the style may feature a stronger hop aroma, an American or New World hop character (citrusy, fruity, tropical, etc.), and/or a fresh dry-hopped aroma (all are optional). Fruity esters are moderate to very low. The dark malt character is more robust than other brown ales, yet stops short of being overly porter-like. The malt and hops are generally balanced. Appearance: Light to very dark brown color. Clear. Low to moderate off-white to light tan head. Flavor: Medium to moderately-high malty-sweet or malty-rich flavor with chocolate, caramel, nutty, and/or toasty malt complexity, with medium to medium-high bitterness. The medium to medium-dry finish provides an aftertaste having both malt and hops. Hop flavor can be light to moderate, and may optionally have a citrusy, fruity, or tropical character, although any hop flavor that complements the malt is acceptable. Very low to moderate fruity esters. Mouthfeel: Medium to medium-full body. More bitter versions may have a dry, resiny impression. Moderate to moderately-high carbonation."
+                       cbf/ibu-min         20}))
 
 
 (def amber-and-brown-american-beer

--- a/src/common_beer_data/styles/bjcp_2015/amber_bitter_european_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/amber_bitter_european_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.amber-bitter-european-beer
   "2015 BJCP guidelines on Amber Bitter European Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def vienna-lager
@@ -8,27 +9,27 @@
    
    The malt flavor is clean, bready-rich, and somewhat toasty, with an elegant impression derived from quality base malts and process, not specialty malts and adjuncts."
   (styles/build-style :vienna-lager
-                      {:category        "Amber Bitter European Beer"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.048
-                       :name            "Vienna Lager"
-                       :type            "Lager"
-                       :style-letter    "A"
-                       :abv-min         0.047
-                       :fg-min          1.01
-                       :category-number "7"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "Vienna malt provides a lightly toasty and complex, Maillard-rich malt profile. As with Märzens, only the finest quality malt should be used, along with Continental hops (preferably Saazer types or Styrians). Can use some caramel malts and/or darker malts to add color and sweetness, but caramel malts shouldn't add significant aroma and flavor and dark malts shouldn't provide any roasted character."
-                       :examples        "Cuauhtémoc Noche Buena, Chuckanut Vienna Lager, Devils Backbone Vienna Lager, Figueroa Mountain Danish-style Red Lager, Heavy Seas Cutlass Amber Lager, Schell's Firebrick"
-                       :notes           "A moderate-strength amber lager with a soft, smooth maltiness and moderate bitterness, yet finishing relatively dry. The malt flavor is clean, bready-rich, and somewhat toasty, with an elegant impression derived from quality base malts and process, not specialty malts and adjuncts."
-                       :og-max          1.055
-                       :color-min       9.0
-                       :abv-max         0.055
-                       :color-max       15.0
-                       :profile         "Aroma: Moderately-intense malt aroma, with toasty and malty-rich aromatics. Clean lager character. Floral, spicy hop aroma may be low to none. A significant caramel or roasted aroma is inappropriate. Appearance: Light reddish amber to copper color. Bright clarity. Large, off-white, persistent head. Flavor: Soft, elegant malt complexity is in the forefront, with a firm enough hop bitterness to provide a balanced finish. The malt flavor tends towards a rich, toasty character, without significant caramel or roast flavors. Fairly dry, crisp finish, with both rich malt and hop bitterness present in the aftertaste. Floral, spicy hop flavor may be low to none. Clean lager fermentation character. Mouthfeel: Medium-light to medium body, with a gentle creaminess. Moderate carbonation. Smooth."
-                       :ibu-min         18}))
+                      {cbf/category        "Amber Bitter European Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.048
+                       cbf/name            "Vienna Lager"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.047
+                       cbf/fg-min          1.01
+                       cbf/category-number "7"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "Vienna malt provides a lightly toasty and complex, Maillard-rich malt profile. As with Märzens, only the finest quality malt should be used, along with Continental hops (preferably Saazer types or Styrians). Can use some caramel malts and/or darker malts to add color and sweetness, but caramel malts shouldn't add significant aroma and flavor and dark malts shouldn't provide any roasted character."
+                       cbf/examples        "Cuauhtémoc Noche Buena, Chuckanut Vienna Lager, Devils Backbone Vienna Lager, Figueroa Mountain Danish-style Red Lager, Heavy Seas Cutlass Amber Lager, Schell's Firebrick"
+                       cbf/notes           "A moderate-strength amber lager with a soft, smooth maltiness and moderate bitterness, yet finishing relatively dry. The malt flavor is clean, bready-rich, and somewhat toasty, with an elegant impression derived from quality base malts and process, not specialty malts and adjuncts."
+                       cbf/og-max          1.055
+                       cbf/color-min       9.0
+                       cbf/abv-max         0.055
+                       cbf/color-max       15.0
+                       cbf/profile         "Aroma: Moderately-intense malt aroma, with toasty and malty-rich aromatics. Clean lager character. Floral, spicy hop aroma may be low to none. A significant caramel or roasted aroma is inappropriate. Appearance: Light reddish amber to copper color. Bright clarity. Large, off-white, persistent head. Flavor: Soft, elegant malt complexity is in the forefront, with a firm enough hop bitterness to provide a balanced finish. The malt flavor tends towards a rich, toasty character, without significant caramel or roast flavors. Fairly dry, crisp finish, with both rich malt and hop bitterness present in the aftertaste. Floral, spicy hop flavor may be low to none. Clean lager fermentation character. Mouthfeel: Medium-light to medium body, with a gentle creaminess. Moderate carbonation. Smooth."
+                       cbf/ibu-min         18}))
 
 
 (def altbier
@@ -36,27 +37,27 @@
    
    The bitterness is balanced by the malt richness, but the malt intensity and character can range from moderate to high (the bitterness increases with the malt richness)."
   (styles/build-style :altbier
-                      {:category        "Amber Bitter European Beer"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.044
-                       :name            "Altbier"
-                       :type            "Lager"
-                       :style-letter    "B"
-                       :abv-min         0.043
-                       :fg-min          1.008
-                       :category-number "7"
-                       :carb-max        3.0
-                       :ibu-max         50
-                       :ingredients     "Grists vary, but usually consist of German base malts (usually Pils, sometimes Munich) with small amounts of crystal, chocolate, and/or black malts used to adjust color. Occasionally will include some wheat, including roasted wheat. Spalt hops are traditional, but other Saazer-type hops can also be used. Clean, highly attenuative ale yeast. A step mash or decoction mash program is traditional."
-                       :examples        "Bolten Alt, Diebels Alt, Füchschen Alt, Original Schlüssel Alt, Schlösser Alt, Schumacher Alt, Uerige Altbier"
-                       :notes           "A well-balanced, well-attenuated, bitter yet malty, clean, and smooth, amber- to copper-colored German beer. The bitterness is balanced by the malt richness, but the malt intensity and character can range from moderate to high (the bitterness increases with the malt richness)."
-                       :og-max          1.052
-                       :color-min       11.0
-                       :abv-max         0.055
-                       :color-max       17.0
-                       :profile         "Aroma: Clean yet robust and complex aroma of grainy-rich malt and spicy hops with restrained (low to medium-low) fruity esters. The malt character reflects German base malt varieties, with rich baked bread and nutty-toasty bread crust notes. The hop aroma may vary from moderate to low, and can have a peppery, spicy, floral, herbal or perfumy character associated with Saazer-type hops. Appearance: The color ranges from light amber to deep copper color, stopping short of brown; bronze-orange is most common. Brilliant clarity. Thick, creamy, long-lasting off-white head. Flavor: Assertive hop bitterness well balanced by a sturdy yet clean and crisp malt character. The malt presence is moderated by medium-high to high attenuation, but considerable rich, complex, and somewhat grainy malt flavors can remain. Some fruity esters (especially cherry-like) may survive the lagering period. A long-lasting, medium-dry to dry, bittersweet or nutty finish reflects both the hop bitterness and malt complexity. Spicy, peppery or floral hop flavor can be moderate to low. No roasted malt flavors or harshness. The apparent bitterness level is sometimes masked by the malt character; the bitterness can seem as low as moderate if the finish is not very dry. Light sulfury or minerally character optional. Mouthfeel: Medium-bodied. Smooth. Medium to medium-high carbonation, although can be lower when served from the cask. Astringency low to none. Despite being very full of flavor, is light-bodied enough to be consumed as a gravity-fed session beer in its home brewpubs in Düsseldorf."
-                       :ibu-min         25}))
+                      {cbf/category        "Amber Bitter European Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.044
+                       cbf/name            "Altbier"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.043
+                       cbf/fg-min          1.008
+                       cbf/category-number "7"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         50
+                       cbf/ingredients     "Grists vary, but usually consist of German base malts (usually Pils, sometimes Munich) with small amounts of crystal, chocolate, and/or black malts used to adjust color. Occasionally will include some wheat, including roasted wheat. Spalt hops are traditional, but other Saazer-type hops can also be used. Clean, highly attenuative ale yeast. A step mash or decoction mash program is traditional."
+                       cbf/examples        "Bolten Alt, Diebels Alt, Füchschen Alt, Original Schlüssel Alt, Schlösser Alt, Schumacher Alt, Uerige Altbier"
+                       cbf/notes           "A well-balanced, well-attenuated, bitter yet malty, clean, and smooth, amber- to copper-colored German beer. The bitterness is balanced by the malt richness, but the malt intensity and character can range from moderate to high (the bitterness increases with the malt richness)."
+                       cbf/og-max          1.052
+                       cbf/color-min       11.0
+                       cbf/abv-max         0.055
+                       cbf/color-max       17.0
+                       cbf/profile         "Aroma: Clean yet robust and complex aroma of grainy-rich malt and spicy hops with restrained (low to medium-low) fruity esters. The malt character reflects German base malt varieties, with rich baked bread and nutty-toasty bread crust notes. The hop aroma may vary from moderate to low, and can have a peppery, spicy, floral, herbal or perfumy character associated with Saazer-type hops. Appearance: The color ranges from light amber to deep copper color, stopping short of brown; bronze-orange is most common. Brilliant clarity. Thick, creamy, long-lasting off-white head. Flavor: Assertive hop bitterness well balanced by a sturdy yet clean and crisp malt character. The malt presence is moderated by medium-high to high attenuation, but considerable rich, complex, and somewhat grainy malt flavors can remain. Some fruity esters (especially cherry-like) may survive the lagering period. A long-lasting, medium-dry to dry, bittersweet or nutty finish reflects both the hop bitterness and malt complexity. Spicy, peppery or floral hop flavor can be moderate to low. No roasted malt flavors or harshness. The apparent bitterness level is sometimes masked by the malt character; the bitterness can seem as low as moderate if the finish is not very dry. Light sulfury or minerally character optional. Mouthfeel: Medium-bodied. Smooth. Medium to medium-high carbonation, although can be lower when served from the cask. Astringency low to none. Despite being very full of flavor, is light-bodied enough to be consumed as a gravity-fed session beer in its home brewpubs in Düsseldorf."
+                       cbf/ibu-min         25}))
 
 
 (def kellerbier
@@ -67,27 +68,27 @@
    This style is above all a method of producing simple drinkable beers for neighbors out of local ingredients to be served fresh. 
    Balance with a focus on drinkability and digestibility is important."
   (styles/build-style :kellerbier
-                      {:category        "Amber Bitter European Beer"
-                       :carb-min        1.5
-                       :fg-max          1.016
-                       :og-min          1.048
-                       :name            "Kellerbier"
-                       :type            "Lager"
-                       :style-letter    "C"
-                       :abv-min         0.048
-                       :fg-min          1.012
-                       :category-number "7"
-                       :carb-max        3.0
-                       :ibu-max         40
-                       :ingredients     "Grist varies, although traditional German versions emphasized Franconian pale and color malt. The notion of elegance is derived from the high-quality local ingredients, particularly the malts. Spalt or other typically spicy local hops are most common. Frugal Franconian brewers rarely used decoction brewing due to the cost of energy."
-                       :examples        "Eichhorn, Nederkeller, Hebendanz (bottled) Buttenheimer Kaiserdom Kellerbier, Kulmbacher Monchshof Kellerbier, Leikeim Kellerbier, Löwenbräu Kellerbier, Mahr's Kellerbier, St. Georgen Kellerbier, Tucher Kellerbier Naturtrub"
-                       :notes           "A young, unfiltered, and unpasteurized beer that is between a Helles and Märzen in color, spicier in the hops with greater attenuation. Interpretations range in color and balance, but remain in the drinkable 4.8% ABV neighborhood. Balance ranges from the dry, spicy and pale-colored interpretations by St. Georgen and Löwenbräu of Buttenheim, to darker and maltier interpretations in the Fränkische Schweiz. This style is above all a method of producing simple drinkable beers for neighbors out of local ingredients to be served fresh. Balance with a focus on drinkability and digestibility is important."
-                       :og-max          1.054
-                       :color-min       7.0
-                       :abv-max         0.054
-                       :color-max       17.0
-                       :profile         "Aroma: Moderate intensity of German malt, typically rich, bready, somewhat toasty, with light bread crust notes. Moderately-low to moderate spicy peppery hop aroma. Very low to low diacetyl, occasionally low to moderately-low sulfur and very low green apple or other yeast-derived notes. Caramel, biscuity, or roasted malt aroma is inappropriate. Appearance: Moderately cloudy to clear depending on age, but never extremely cloudy or murky. Gold to deep reddish-amber color. Off-white, creamy head. When served on cask, can have low carbonation and very low head. Flavor: Initial malt flavor may suggest sweetness, but finish is moderately dry to dry, and slightly bitter. Distinctive and complex maltiness often includes a bready-toasty aspect. Hop bitterness is moderate to moderately high, and spicy or herbal hop flavor is low to moderately high. Balance can be either on the malt or hop side, but the finish is not sweet. Noticeable caramel or roasted malt flavors are inappropriate. Very low to low diacetyl. Possible very low green apple or other yeast-derived notes. Smooth, malty aftertaste. Mouthfeel: Medium body, with a creamy texture and medium carbonation. Fully fermented, without a sweet or cloying impression."
-                       :ibu-min         25}))
+                      {cbf/category        "Amber Bitter European Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.016
+                       cbf/og-min          1.048
+                       cbf/name            "Kellerbier"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.048
+                       cbf/fg-min          1.012
+                       cbf/category-number "7"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         40
+                       cbf/ingredients     "Grist varies, although traditional German versions emphasized Franconian pale and color malt. The notion of elegance is derived from the high-quality local ingredients, particularly the malts. Spalt or other typically spicy local hops are most common. Frugal Franconian brewers rarely used decoction brewing due to the cost of energy."
+                       cbf/examples        "Eichhorn, Nederkeller, Hebendanz (bottled) Buttenheimer Kaiserdom Kellerbier, Kulmbacher Monchshof Kellerbier, Leikeim Kellerbier, Löwenbräu Kellerbier, Mahr's Kellerbier, St. Georgen Kellerbier, Tucher Kellerbier Naturtrub"
+                       cbf/notes           "A young, unfiltered, and unpasteurized beer that is between a Helles and Märzen in color, spicier in the hops with greater attenuation. Interpretations range in color and balance, but remain in the drinkable 4.8% ABV neighborhood. Balance ranges from the dry, spicy and pale-colored interpretations by St. Georgen and Löwenbräu of Buttenheim, to darker and maltier interpretations in the Fränkische Schweiz. This style is above all a method of producing simple drinkable beers for neighbors out of local ingredients to be served fresh. Balance with a focus on drinkability and digestibility is important."
+                       cbf/og-max          1.054
+                       cbf/color-min       7.0
+                       cbf/abv-max         0.054
+                       cbf/color-max       17.0
+                       cbf/profile         "Aroma: Moderate intensity of German malt, typically rich, bready, somewhat toasty, with light bread crust notes. Moderately-low to moderate spicy peppery hop aroma. Very low to low diacetyl, occasionally low to moderately-low sulfur and very low green apple or other yeast-derived notes. Caramel, biscuity, or roasted malt aroma is inappropriate. Appearance: Moderately cloudy to clear depending on age, but never extremely cloudy or murky. Gold to deep reddish-amber color. Off-white, creamy head. When served on cask, can have low carbonation and very low head. Flavor: Initial malt flavor may suggest sweetness, but finish is moderately dry to dry, and slightly bitter. Distinctive and complex maltiness often includes a bready-toasty aspect. Hop bitterness is moderate to moderately high, and spicy or herbal hop flavor is low to moderately high. Balance can be either on the malt or hop side, but the finish is not sweet. Noticeable caramel or roasted malt flavors are inappropriate. Very low to low diacetyl. Possible very low green apple or other yeast-derived notes. Smooth, malty aftertaste. Mouthfeel: Medium body, with a creamy texture and medium carbonation. Fully fermented, without a sweet or cloying impression."
+                       cbf/ibu-min         25}))
 
 
 (def amber-bitter-european-beer

--- a/src/common_beer_data/styles/bjcp_2015/amber_malty_european_lager.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/amber_malty_european_lager.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.amber-malty-european-lager
   "2015 BJCP guidelines on Amber Malty European Lagers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def märzen
@@ -8,27 +9,27 @@
    
    The overall malt impression is soft, elegant, and complex, with a rich aftertaste that is never cloying or heavy."
   (styles/build-style :märzen
-                      {:category        "Amber Malty European Lager"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.054
-                       :name            "Märzen"
-                       :type            "Lager"
-                       :style-letter    "A"
-                       :abv-min         0.058
-                       :fg-min          1.01
-                       :category-number "6"
-                       :carb-max        3.0
-                       :ibu-max         24
-                       :ingredients     "Grist varies, although traditional German versions emphasized Munich malt. The notion of elegance is derived from the finest quality ingredients, particularly the base malts. A decoction mash was traditionally used to develop the rich malt profile."
-                       :examples        "Buergerliches Ur-Saalfelder, Hacker-Pschorr Original Oktoberfest, Paulaner Oktoberfest, Weltenburg Kloster Anno 1050"
-                       :notes           "An elegant, malty German amber lager with a clean, rich, toasty and bready malt flavor, restrained bitterness, and a dry finish that encourages another drink. The overall malt impression is soft, elegant, and complex, with a rich aftertaste that is never cloying or heavy."
-                       :og-max          1.06
-                       :color-min       8.0
-                       :abv-max         0.063
-                       :color-max       17.0
-                       :profile         "Aroma: Moderate intensity aroma of German malt, typically rich, bready, somewhat toasty, with light bread crust notes. Clean lager fermentation character. No hop aroma. Caramel, dry-biscuity, or roasted malt aromas inappropriate. Very light alcohol might be detected, but should never be sharp. Clean, elegant malt richness should be the primary aroma. Appearance: Amber-orange to deep reddish-copper color; should not be golden. Bright clarity, with persistent, off-white foam stand. Flavor: Initial malt flavor often suggests sweetness, but finish is moderately-dry to dry. Distinctive and complex maltiness often includes a bready, toasty aspect. Hop bitterness is moderate, and the hop flavor is low to none (German types: complex, floral, herbal, or spicy). Hops provide sufficient balance that the malty palate and finish do not seem sweet. The aftertaste is malty, with the same elegant, rich malt flavors lingering. Noticeable caramel, biscuit, or roasted flavors are inappropriate. Clean lager fermentation profile. Mouthfeel: Medium body, with a smooth, creamy texture that often suggests a fuller mouthfeel. Medium carbonation. Fully attenuated, without a sweet or cloying impression. May be slightly warming, but the strength should be relatively hidden."
-                       :ibu-min         18}))
+                      {cbf/category        "Amber Malty European Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.054
+                       cbf/name            "Märzen"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.058
+                       cbf/fg-min          1.01
+                       cbf/category-number "6"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         24
+                       cbf/ingredients     "Grist varies, although traditional German versions emphasized Munich malt. The notion of elegance is derived from the finest quality ingredients, particularly the base malts. A decoction mash was traditionally used to develop the rich malt profile."
+                       cbf/examples        "Buergerliches Ur-Saalfelder, Hacker-Pschorr Original Oktoberfest, Paulaner Oktoberfest, Weltenburg Kloster Anno 1050"
+                       cbf/notes           "An elegant, malty German amber lager with a clean, rich, toasty and bready malt flavor, restrained bitterness, and a dry finish that encourages another drink. The overall malt impression is soft, elegant, and complex, with a rich aftertaste that is never cloying or heavy."
+                       cbf/og-max          1.06
+                       cbf/color-min       8.0
+                       cbf/abv-max         0.063
+                       cbf/color-max       17.0
+                       cbf/profile         "Aroma: Moderate intensity aroma of German malt, typically rich, bready, somewhat toasty, with light bread crust notes. Clean lager fermentation character. No hop aroma. Caramel, dry-biscuity, or roasted malt aromas inappropriate. Very light alcohol might be detected, but should never be sharp. Clean, elegant malt richness should be the primary aroma. Appearance: Amber-orange to deep reddish-copper color; should not be golden. Bright clarity, with persistent, off-white foam stand. Flavor: Initial malt flavor often suggests sweetness, but finish is moderately-dry to dry. Distinctive and complex maltiness often includes a bready, toasty aspect. Hop bitterness is moderate, and the hop flavor is low to none (German types: complex, floral, herbal, or spicy). Hops provide sufficient balance that the malty palate and finish do not seem sweet. The aftertaste is malty, with the same elegant, rich malt flavors lingering. Noticeable caramel, biscuit, or roasted flavors are inappropriate. Clean lager fermentation profile. Mouthfeel: Medium body, with a smooth, creamy texture that often suggests a fuller mouthfeel. Medium carbonation. Fully attenuated, without a sweet or cloying impression. May be slightly warming, but the strength should be relatively hidden."
+                       cbf/ibu-min         18}))
 
 
 (def rauchbier
@@ -36,53 +37,53 @@
    
    Toasty-rich malt in aroma and flavor, restrained bitterness, low to high smoke flavor, clean fermentation profile, and an attenuated finish are characteristic."
   (styles/build-style :rauchbier
-                      {:category        "Amber Malty European Lager"
-                       :carb-min        1.5
-                       :fg-max          1.016
-                       :og-min          1.05
-                       :name            "Rauchbier"
-                       :type            "Lager"
-                       :style-letter    "B"
-                       :abv-min         0.048
-                       :fg-min          1.012
-                       :category-number "6"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "German Rauchmalz (beechwood-smoked Vienna-type malt) typically makes up 20-100% of the grain bill, with the remainder being German malts typically used in a Märzen. Some breweries adjust the color slightly with a bit of roasted malt. German lager yeast. German or Czech hops."
-                       :examples        "Eisenbahn Rauchbier, Kaiserdom Rauchbier, Schlenkerla Rauchbier Märzen, Spezial Rauchbier Märzen Victory Scarlet Fire Rauchbier"
-                       :notes           "An elegant, malty German amber lager with a balanced, complementary beechwood smoke character. Toasty-rich malt in aroma and flavor, restrained bitterness, low to high smoke flavor, clean fermentation profile, and an attenuated finish are characteristic."
-                       :og-max          1.057
-                       :color-min       12.0
-                       :abv-max         0.06
-                       :color-max       22.0
-                       :profile         "Aroma: Blend of smoke and malt, with a varying balance and intensity. The beechwood smoke character can range from subtle to fairly strong, and can seem smoky, woody, or bacon-like. The malt character can be low to moderate, and be somewhat rich, toasty, or malty-sweet. The malt and smoke components are often inversely proportional (i.e., when smoke increases, malt decreases, and vice versa). Hop aroma may be very low to none. Clean lager fermentation character. Appearance: This should be a very clear beer, with a large, creamy, rich, tan- to cream-colored head. Medium amber/light copper to dark brown color. Flavor: Generally follows the aroma profile, with a blend of smoke and malt in varying balance and intensity, yet always complementary. Märzen-like qualities should be noticeable, particularly a malty, toasty richness, but the beechwood smoke flavor can be low to high. At higher levels, the smoke can take on a ham- or bacon-like character, which is acceptable as long as it doesn't veer into the greasy range. The palate can be somewhat malty, rich, and sweet, yet the finish tends to be medium-dry to dry with the smoke character sometimes enhancing the dryness of the finish. The aftertaste can reflect both malt richness and smoke flavors, with a balanced presentation desirable. Moderate, balanced, hop bitterness. Moderate to none hop flavor with spicy, floral, or herbal notes. Clean lager fermentation character. Harsh, bitter, burnt, charred, rubbery, sulfury or phenolic smoky characteristics are inappropriate. Mouthfeel: Medium body. Medium to medium-high carbonation. Smooth lager character. Significant astringent, phenolic harshness is inappropriate."
-                       :ibu-min         20}))
+                      {cbf/category        "Amber Malty European Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.016
+                       cbf/og-min          1.05
+                       cbf/name            "Rauchbier"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.048
+                       cbf/fg-min          1.012
+                       cbf/category-number "6"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "German Rauchmalz (beechwood-smoked Vienna-type malt) typically makes up 20-100% of the grain bill, with the remainder being German malts typically used in a Märzen. Some breweries adjust the color slightly with a bit of roasted malt. German lager yeast. German or Czech hops."
+                       cbf/examples        "Eisenbahn Rauchbier, Kaiserdom Rauchbier, Schlenkerla Rauchbier Märzen, Spezial Rauchbier Märzen Victory Scarlet Fire Rauchbier"
+                       cbf/notes           "An elegant, malty German amber lager with a balanced, complementary beechwood smoke character. Toasty-rich malt in aroma and flavor, restrained bitterness, low to high smoke flavor, clean fermentation profile, and an attenuated finish are characteristic."
+                       cbf/og-max          1.057
+                       cbf/color-min       12.0
+                       cbf/abv-max         0.06
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Blend of smoke and malt, with a varying balance and intensity. The beechwood smoke character can range from subtle to fairly strong, and can seem smoky, woody, or bacon-like. The malt character can be low to moderate, and be somewhat rich, toasty, or malty-sweet. The malt and smoke components are often inversely proportional (i.e., when smoke increases, malt decreases, and vice versa). Hop aroma may be very low to none. Clean lager fermentation character. Appearance: This should be a very clear beer, with a large, creamy, rich, tan- to cream-colored head. Medium amber/light copper to dark brown color. Flavor: Generally follows the aroma profile, with a blend of smoke and malt in varying balance and intensity, yet always complementary. Märzen-like qualities should be noticeable, particularly a malty, toasty richness, but the beechwood smoke flavor can be low to high. At higher levels, the smoke can take on a ham- or bacon-like character, which is acceptable as long as it doesn't veer into the greasy range. The palate can be somewhat malty, rich, and sweet, yet the finish tends to be medium-dry to dry with the smoke character sometimes enhancing the dryness of the finish. The aftertaste can reflect both malt richness and smoke flavors, with a balanced presentation desirable. Moderate, balanced, hop bitterness. Moderate to none hop flavor with spicy, floral, or herbal notes. Clean lager fermentation character. Harsh, bitter, burnt, charred, rubbery, sulfury or phenolic smoky characteristics are inappropriate. Mouthfeel: Medium body. Medium to medium-high carbonation. Smooth lager character. Significant astringent, phenolic harshness is inappropriate."
+                       cbf/ibu-min         20}))
 
 
 (def dunkles-bock
   "A dark, strong, malty German lager beer that emphasizes the malty-rich and somewhat toasty qualities of continental malts without being sweet in the finish."
   (styles/build-style :dunkles-bock
-                      {:category        "Amber Malty European Lager"
-                       :carb-min        1.5
-                       :fg-max          1.019
-                       :og-min          1.064
-                       :name            "Dunkles Bock"
-                       :type            "Lager"
-                       :style-letter    "C"
-                       :abv-min         0.063
-                       :fg-min          1.013
-                       :category-number "6"
-                       :carb-max        3.0
-                       :ibu-max         27
-                       :ingredients     "Munich and Vienna malts, rarely a tiny bit of dark roasted malts for color adjustment, never any non-malt adjuncts. Continental European hop varieties are used. Clean German lager yeast."
-                       :examples        "Aass Bock, Einbecker Ur-Bock Dunkel, Great Lakes Rockefeller Bock, Kneitinger Bock, New Glarus Uff-da Bock, Penn Brewery St. Nikolaus Bock"
-                       :notes           "A dark, strong, malty German lager beer that emphasizes the malty-rich and somewhat toasty qualities of continental malts without being sweet in the finish."
-                       :og-max          1.072
-                       :color-min       14.0
-                       :abv-max         0.072
-                       :color-max       22.0
-                       :profile         "Aroma: Medium to medium-high bready-malty-rich aroma, often with moderate amounts of rich Maillard products and/or toasty overtones. Virtually no hop aroma. Some alcohol may be noticeable. Clean lager character, although the malts can provide a slight (low to none) dark fruit character, particularly in aged examples. Appearance: Light copper to brown color, often with attractive garnet highlights. Lagering should provide good clarity despite the dark color. Large, creamy, persistent, off-white head. Flavor: Complex, rich maltiness is dominated by the toasty-rich Maillard products. Some caramel notes may be present. Hop bitterness is generally only high enough to support the malt flavors, allowing a bit of sweetness to linger into the finish. Well-attenuated, not cloying. Clean fermentation profile, although the malt can provide a slight dark fruit character. No hop flavor. No roasted or burnt character. Mouthfeel: Medium to medium-full bodied. Moderate to moderately low carbonation. Some alcohol warmth may be found, but should never be hot. Smooth, without harshness or astringency."
-                       :ibu-min         20}))
+                      {cbf/category        "Amber Malty European Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.019
+                       cbf/og-min          1.064
+                       cbf/name            "Dunkles Bock"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.063
+                       cbf/fg-min          1.013
+                       cbf/category-number "6"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         27
+                       cbf/ingredients     "Munich and Vienna malts, rarely a tiny bit of dark roasted malts for color adjustment, never any non-malt adjuncts. Continental European hop varieties are used. Clean German lager yeast."
+                       cbf/examples        "Aass Bock, Einbecker Ur-Bock Dunkel, Great Lakes Rockefeller Bock, Kneitinger Bock, New Glarus Uff-da Bock, Penn Brewery St. Nikolaus Bock"
+                       cbf/notes           "A dark, strong, malty German lager beer that emphasizes the malty-rich and somewhat toasty qualities of continental malts without being sweet in the finish."
+                       cbf/og-max          1.072
+                       cbf/color-min       14.0
+                       cbf/abv-max         0.072
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Medium to medium-high bready-malty-rich aroma, often with moderate amounts of rich Maillard products and/or toasty overtones. Virtually no hop aroma. Some alcohol may be noticeable. Clean lager character, although the malts can provide a slight (low to none) dark fruit character, particularly in aged examples. Appearance: Light copper to brown color, often with attractive garnet highlights. Lagering should provide good clarity despite the dark color. Large, creamy, persistent, off-white head. Flavor: Complex, rich maltiness is dominated by the toasty-rich Maillard products. Some caramel notes may be present. Hop bitterness is generally only high enough to support the malt flavors, allowing a bit of sweetness to linger into the finish. Well-attenuated, not cloying. Clean fermentation profile, although the malt can provide a slight dark fruit character. No hop flavor. No roasted or burnt character. Mouthfeel: Medium to medium-full bodied. Moderate to moderately low carbonation. Some alcohol warmth may be found, but should never be hot. Smooth, without harshness or astringency."
+                       cbf/ibu-min         20}))
 
 
 (def amber-malty-european-lager

--- a/src/common_beer_data/styles/bjcp_2015/american_porter_and_stout.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/american_porter_and_stout.cljc
@@ -1,32 +1,33 @@
 (ns common-beer-data.styles.bjcp-2015.american-porter-and-stout
   "2015 BJCP guidelines on American Porters and Stouts."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def american-porter
   "A substantial, malty dark beer with a complex and flavorful dark malt character."
   (styles/build-style :american-porter
-                      {:category        "American Porter And Stout"
-                       :carb-min        1.5
-                       :fg-max          1.018
-                       :og-min          1.05
-                       :name            "American Porter"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.048
-                       :fg-min          1.012
-                       :category-number "20"
-                       :carb-max        3.0
-                       :ibu-max         50
-                       :ingredients     "May contain several malts, prominently dark malts, which often include black malt (chocolate malt is also often used). American hops typically used for bittering, but US or UK finishing hops can be used; a clashing citrus quality is generally undesirable. Ale yeast can either be clean US versions or characterful English varieties."
-                       :examples        "Anchor Porter, Boulevard Bully! Porter, Deschutes Black Butte Porter, Founders Porter, Great Lakes Edmund Fitzgerald Porter, Smuttynose Robust Porter, Sierra Nevada Porter"
-                       :notes           "A substantial, malty dark beer with a complex and flavorful dark malt character."
-                       :og-max          1.07
-                       :color-min       22.0
-                       :abv-max         0.065
-                       :color-max       40.0
-                       :profile         "Aroma: Medium-light to medium-strong dark malt aroma, often with a lightly burnt character. Optionally may also show some additional malt character in support (grainy, bready, toffee-like, caramelly, chocolate, coffee, rich, and/or sweet). Hop aroma low to high, often with a resiny, earthy, or floral character. May be dry-hopped. Fruity esters are moderate to none. Appearance: Medium brown to very dark brown, often with ruby- or garnet-like highlights. Can approach black in color. Clarity may be difficult to discern in such a dark beer, but when not opaque will be clear (particularly when held up to the light). Full, tan-colored head with moderately good head retention. Flavor: Moderately strong malt flavor usually features a lightly burnt malt character (and sometimes chocolate and/or coffee flavors) with a bit of grainy, dark malt dryness in the finish. Overall flavor may finish from dry to medium-sweet. May have a sharp character from dark roasted grains, but should not be overly acrid, burnt or harsh. Medium to high bitterness, which can be accentuated by the dark malt. Hop flavor can vary from low to high with a resiny, earthy, or floral character, and balances the dark malt flavors. The dark malt and hops should not clash. Dry-hopped versions may have a resiny flavor. Fruity esters moderate to none. Mouthfeel: Medium to medium-full body. Moderately low to moderately high carbonation. Stronger versions may have a slight alcohol warmth. May have a slight astringency from dark malts, although this character should not be strong."
-                       :ibu-min         25}))
+                      {cbf/category        "American Porter And Stout"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.018
+                       cbf/og-min          1.05
+                       cbf/name            "American Porter"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.048
+                       cbf/fg-min          1.012
+                       cbf/category-number "20"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         50
+                       cbf/ingredients     "May contain several malts, prominently dark malts, which often include black malt (chocolate malt is also often used). American hops typically used for bittering, but US or UK finishing hops can be used; a clashing citrus quality is generally undesirable. Ale yeast can either be clean US versions or characterful English varieties."
+                       cbf/examples        "Anchor Porter, Boulevard Bully! Porter, Deschutes Black Butte Porter, Founders Porter, Great Lakes Edmund Fitzgerald Porter, Smuttynose Robust Porter, Sierra Nevada Porter"
+                       cbf/notes           "A substantial, malty dark beer with a complex and flavorful dark malt character."
+                       cbf/og-max          1.07
+                       cbf/color-min       22.0
+                       cbf/abv-max         0.065
+                       cbf/color-max       40.0
+                       cbf/profile         "Aroma: Medium-light to medium-strong dark malt aroma, often with a lightly burnt character. Optionally may also show some additional malt character in support (grainy, bready, toffee-like, caramelly, chocolate, coffee, rich, and/or sweet). Hop aroma low to high, often with a resiny, earthy, or floral character. May be dry-hopped. Fruity esters are moderate to none. Appearance: Medium brown to very dark brown, often with ruby- or garnet-like highlights. Can approach black in color. Clarity may be difficult to discern in such a dark beer, but when not opaque will be clear (particularly when held up to the light). Full, tan-colored head with moderately good head retention. Flavor: Moderately strong malt flavor usually features a lightly burnt malt character (and sometimes chocolate and/or coffee flavors) with a bit of grainy, dark malt dryness in the finish. Overall flavor may finish from dry to medium-sweet. May have a sharp character from dark roasted grains, but should not be overly acrid, burnt or harsh. Medium to high bitterness, which can be accentuated by the dark malt. Hop flavor can vary from low to high with a resiny, earthy, or floral character, and balances the dark malt flavors. The dark malt and hops should not clash. Dry-hopped versions may have a resiny flavor. Fruity esters moderate to none. Mouthfeel: Medium to medium-full body. Moderately low to moderately high carbonation. Stronger versions may have a slight alcohol warmth. May have a slight astringency from dark malts, although this character should not be strong."
+                       cbf/ibu-min         25}))
 
 
 (def american-stout
@@ -34,27 +35,27 @@
    
    Has the body and dark flavors typical of stouts with a more aggressive American hop character and bitterness."
   (styles/build-style :american-stout
-                      {:category        "American Porter And Stout"
-                       :carb-min        1.5
-                       :fg-max          1.022
-                       :og-min          1.05
-                       :name            "American Stout"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.05
-                       :fg-min          1.01
-                       :category-number "20"
-                       :carb-max        3.0
-                       :ibu-max         75
-                       :ingredients     "Common American base malts and yeast. Varied use of dark and roasted malts, as well as caramel-type malts. Adjuncts such as oatmeal may be present in low quantities. American hop varieties."
-                       :examples        "Avery Out of Bounds Stout, Deschutes Obsidian Stout, North Coast Old No. 38, Rogue Shakespeare Stout, Sierra Nevada Stout"
-                       :notes           "A fairly strong, highly roasted, bitter, hoppy dark stout. Has the body and dark flavors typical of stouts with a more aggressive American hop character and bitterness."
-                       :og-max          1.075
-                       :color-min       30.0
-                       :abv-max         0.07
-                       :color-max       40.0
-                       :profile         "Aroma: Moderate to strong aroma of roasted malts, often having a roasted coffee or dark chocolate quality. Burnt or charcoal aromas are acceptable at low levels. Medium to very low hop aroma, often with a citrusy or resiny character. Medium to no esters. Light alcohol-derived aromatics are also optional. Appearance: Generally a jet black color, although some may appear very dark brown. Large, persistent head of light tan to light brown in color. Usually opaque. Flavor: Moderate to very high roasted malt flavors, often tasting of coffee, roasted coffee beans, dark or bittersweet chocolate. May have the flavor of slightly burnt coffee grounds, but this character should not be prominent. Low to medium malt sweetness, often with rich chocolate or caramel flavors. Medium to high bitterness. Low to high hop flavor, generally citrusy or resiny. Low to no esters. Medium to dry finish, occasionally with a lightly burnt quality. Alcohol flavors can be present up to medium levels, but smooth. Mouthfeel: Medium to full body. Can be somewhat creamy, particularly if a small amount of oats have been used to enhance mouthfeel. Can have a bit of roast-derived astringency, but this character should not be excessive. Medium-high to high carbonation. Light to moderately strong alcohol warmth, but smooth and not excessively hot."
-                       :ibu-min         35}))
+                      {cbf/category        "American Porter And Stout"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.022
+                       cbf/og-min          1.05
+                       cbf/name            "American Stout"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.05
+                       cbf/fg-min          1.01
+                       cbf/category-number "20"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         75
+                       cbf/ingredients     "Common American base malts and yeast. Varied use of dark and roasted malts, as well as caramel-type malts. Adjuncts such as oatmeal may be present in low quantities. American hop varieties."
+                       cbf/examples        "Avery Out of Bounds Stout, Deschutes Obsidian Stout, North Coast Old No. 38, Rogue Shakespeare Stout, Sierra Nevada Stout"
+                       cbf/notes           "A fairly strong, highly roasted, bitter, hoppy dark stout. Has the body and dark flavors typical of stouts with a more aggressive American hop character and bitterness."
+                       cbf/og-max          1.075
+                       cbf/color-min       30.0
+                       cbf/abv-max         0.07
+                       cbf/color-max       40.0
+                       cbf/profile         "Aroma: Moderate to strong aroma of roasted malts, often having a roasted coffee or dark chocolate quality. Burnt or charcoal aromas are acceptable at low levels. Medium to very low hop aroma, often with a citrusy or resiny character. Medium to no esters. Light alcohol-derived aromatics are also optional. Appearance: Generally a jet black color, although some may appear very dark brown. Large, persistent head of light tan to light brown in color. Usually opaque. Flavor: Moderate to very high roasted malt flavors, often tasting of coffee, roasted coffee beans, dark or bittersweet chocolate. May have the flavor of slightly burnt coffee grounds, but this character should not be prominent. Low to medium malt sweetness, often with rich chocolate or caramel flavors. Medium to high bitterness. Low to high hop flavor, generally citrusy or resiny. Low to no esters. Medium to dry finish, occasionally with a lightly burnt quality. Alcohol flavors can be present up to medium levels, but smooth. Mouthfeel: Medium to full body. Can be somewhat creamy, particularly if a small amount of oats have been used to enhance mouthfeel. Can have a bit of roast-derived astringency, but this character should not be excessive. Medium-high to high carbonation. Light to moderately strong alcohol warmth, but smooth and not excessively hot."
+                       cbf/ibu-min         35}))
 
 
 (def imperial-stout
@@ -63,27 +64,27 @@
    Roasty-burnt malt with deep dark or dried fruit flavors, and a warming, bittersweet finish. 
    Despite the intense flavors, the components need to meld together to create a complex, harmonious beer, not a hot mess."
   (styles/build-style :imperial-stout
-                      {:category        "American Porter And Stout"
-                       :carb-min        1.5
-                       :fg-max          1.03
-                       :og-min          1.075
-                       :name            "Imperial Stout"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.08
-                       :fg-min          1.018
-                       :category-number "20"
-                       :carb-max        3.0
-                       :ibu-max         90
-                       :ingredients     "Well-modified pale malt, with generous quantities of roasted malts and/or grain. May have a complex grain bill using virtually any variety of malt. Any type of hops may be used. American or English ale yeast."
-                       :examples        "American Bell's Expedition Stout, Cigar City Marshal Zhukov's Imperial Stout, Great Divide Yeti Imperial Stout, North Coast Old Rasputin Imperial Stout, Sierra Nevada Narwhal Imperial Stout; English - Courage Imperial Russian Stout, Le Coq Imperial Extra Double Stout, Samuel Smith Imperial Stout"
-                       :notes           "An intensely-flavored, big, dark ale with a wide range of flavor balances and regional interpretations. Roasty-burnt malt with deep dark or dried fruit flavors, and a warming, bittersweet finish. Despite the intense flavors, the components need to meld together to create a complex, harmonious beer, not a hot mess."
-                       :og-max          1.115
-                       :color-min       30.0
-                       :abv-max         0.12
-                       :color-max       40.0
-                       :profile         "Aroma: Rich and complex, with variable amounts of roasted grains, maltiness, fruity esters, hops, and alcohol. The roasted malt character can take on coffee, dark chocolate, or slightly burnt tones and can be light to moderately strong. The malt aroma can be subtle to rich and barleywine-like. May optionally show a slight specialty malt character (e.g., caramel), but this should only add complexity and not dominate. Fruity esters may be low to moderately strong, and may take on a complex, dark fruit (e.g., plums, prunes, raisins) character. Hop aroma can be very low to quite aggressive, and may contain any hop variety. An alcohol character may be present, but shouldn't be sharp, hot, or solventy. Aged versions may have a slight vinous or port-like quality, but shouldn't be sour. The balance can vary with any of the aroma elements taking center stage. Not all possible aromas described need be present; many interpretations are possible. Aging affects the intensity, balance and smoothness of aromatics. Appearance: Color may range from very dark reddish-brown to jet black. Opaque. Deep tan to dark brown head. Generally has a well-formed head, although head retention may be low to moderate. High alcohol and viscosity may be visible in \"legs\" when beer is swirled in a glass. Flavor: Rich, deep, complex and frequently quite intense, with variable amounts of roasted malt/grains, maltiness, fruity esters, hop bitterness and flavor, and alcohol. Medium to aggressively high bitterness. Medium-low to high hop flavor (any variety). Moderate to aggressively high roasted malt/grain flavors can suggest bittersweet or unsweetened chocolate, cocoa, and/or strong coffee. A slightly burnt grain, burnt currant or tarry character may be evident. Fruity esters may be low to intense, and can take on a dark fruit character (raisins, plums, or prunes). Malt backbone can be balanced and supportive to rich and barleywine-like, and may optionally show some supporting caramel, bready or toasty flavors. The palate and finish can vary from relatively dry to moderately sweet, usually with some lingering roastiness, hop bitterness and warming character. The balance and intensity of flavors can be affected by aging, with some flavors becoming more subdued over time and some aged, vinous or port-like qualities developing. Mouthfeel: Full to very full-bodied and chewy, with a velvety, luscious texture (although the body may decline with long conditioning). Gentle smooth warmth from alcohol should be present and noticeable, but not a primary characteristic; in well-conditioned versions, the alcohol can be deceptive. Should not be syrupy or under-attenuated. Carbonation may be low to moderate, depending on age and conditioning."
-                       :ibu-min         50}))
+                      {cbf/category        "American Porter And Stout"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.03
+                       cbf/og-min          1.075
+                       cbf/name            "Imperial Stout"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.08
+                       cbf/fg-min          1.018
+                       cbf/category-number "20"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         90
+                       cbf/ingredients     "Well-modified pale malt, with generous quantities of roasted malts and/or grain. May have a complex grain bill using virtually any variety of malt. Any type of hops may be used. American or English ale yeast."
+                       cbf/examples        "American Bell's Expedition Stout, Cigar City Marshal Zhukov's Imperial Stout, Great Divide Yeti Imperial Stout, North Coast Old Rasputin Imperial Stout, Sierra Nevada Narwhal Imperial Stout; English - Courage Imperial Russian Stout, Le Coq Imperial Extra Double Stout, Samuel Smith Imperial Stout"
+                       cbf/notes           "An intensely-flavored, big, dark ale with a wide range of flavor balances and regional interpretations. Roasty-burnt malt with deep dark or dried fruit flavors, and a warming, bittersweet finish. Despite the intense flavors, the components need to meld together to create a complex, harmonious beer, not a hot mess."
+                       cbf/og-max          1.115
+                       cbf/color-min       30.0
+                       cbf/abv-max         0.12
+                       cbf/color-max       40.0
+                       cbf/profile         "Aroma: Rich and complex, with variable amounts of roasted grains, maltiness, fruity esters, hops, and alcohol. The roasted malt character can take on coffee, dark chocolate, or slightly burnt tones and can be light to moderately strong. The malt aroma can be subtle to rich and barleywine-like. May optionally show a slight specialty malt character (e.g., caramel), but this should only add complexity and not dominate. Fruity esters may be low to moderately strong, and may take on a complex, dark fruit (e.g., plums, prunes, raisins) character. Hop aroma can be very low to quite aggressive, and may contain any hop variety. An alcohol character may be present, but shouldn't be sharp, hot, or solventy. Aged versions may have a slight vinous or port-like quality, but shouldn't be sour. The balance can vary with any of the aroma elements taking center stage. Not all possible aromas described need be present; many interpretations are possible. Aging affects the intensity, balance and smoothness of aromatics. Appearance: Color may range from very dark reddish-brown to jet black. Opaque. Deep tan to dark brown head. Generally has a well-formed head, although head retention may be low to moderate. High alcohol and viscosity may be visible in \"legs\" when beer is swirled in a glass. Flavor: Rich, deep, complex and frequently quite intense, with variable amounts of roasted malt/grains, maltiness, fruity esters, hop bitterness and flavor, and alcohol. Medium to aggressively high bitterness. Medium-low to high hop flavor (any variety). Moderate to aggressively high roasted malt/grain flavors can suggest bittersweet or unsweetened chocolate, cocoa, and/or strong coffee. A slightly burnt grain, burnt currant or tarry character may be evident. Fruity esters may be low to intense, and can take on a dark fruit character (raisins, plums, or prunes). Malt backbone can be balanced and supportive to rich and barleywine-like, and may optionally show some supporting caramel, bready or toasty flavors. The palate and finish can vary from relatively dry to moderately sweet, usually with some lingering roastiness, hop bitterness and warming character. The balance and intensity of flavors can be affected by aging, with some flavors becoming more subdued over time and some aged, vinous or port-like qualities developing. Mouthfeel: Full to very full-bodied and chewy, with a velvety, luscious texture (although the body may decline with long conditioning). Gentle smooth warmth from alcohol should be present and noticeable, but not a primary characteristic; in well-conditioned versions, the alcohol can be deceptive. Should not be syrupy or under-attenuated. Carbonation may be low to moderate, depending on age and conditioning."
+                       cbf/ibu-min         50}))
 
 
 (def american-porter-and-stout

--- a/src/common_beer_data/styles/bjcp_2015/american_wild_ale.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/american_wild_ale.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.american-wild-ale
   "2015 BJCP guidelines on Wild American Ales."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def brett-beer
@@ -10,53 +11,53 @@
    Funkiness is generally restrained in younger 100% Brett examples, but tends to increase with age. 
    May possess a light acidity, although this does not come from Brett."
   (styles/build-style :brett-beer
-                      {:category        "American Wild Ale"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Brett Beer"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "28"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Virtually any style of beer, fermented in any manner, then finished with one or more strains of Brett. Alternatively, a beer made with Brett as the sole fermentation strain."
-                       :examples        "Boulevard Saison Brett, Hill Farmstead Arthur, Logsdon Seizoen Bretta, Russian River Sanctification, The Bruery Saison Rue, Victory Helios"
-                       :notes           "Most often drier and fruitier than the base style suggests. Funky notes range from low to high, depending on the age of the beer and strain(s) of Brett used. Funkiness is generally restrained in younger 100% Brett examples, but tends to increase with age. May possess a light acidity, although this does not come from Brett."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: Variable by base style. Young Brett-fermented beers will possess more fruity notes (e.g., tropical fruit, stone fruit, or citrus), but this is variable by the strain(s) of Brett used. For 100% Brett beers heavily hopped with American hop varieties, the fermentation-derived flavors are often difficult to tease from the hop aromatics. Older 100% Brett beers may start to develop a little funk (e.g., barnyard, wet hay, or slightly earthy or smoky notes), but this character should not dominate. If the beer is fermented with a brewer's yeast in addition to Brett, some of the character of the primary yeast may remain. A faint sourness is acceptable but should not be a prominent character. Appearance: Variable by base style. Clarity can be variable, and depends on the base style and ingredients used. Some haze is not necessarily a fault. Flavor: Variable by base style. Brett character may range from minimal to aggressive. Can be quite fruity (e.g., tropical fruit, berry, stone fruit, citrus), or have some smoky, earthy, or barnyard character. Should not be unpleasantly funky, such as Band-Aid, fetid, nail polish remover, cheese, etc. Light sourness is acceptable with the beer being lightly tart, but should not be truly sour. Always fruitier when young, gaining more funk with age. May not be acetic or lactic. Malt flavors are often less pronounced than in the base style, leaving a beer most often dry and crisp due to high attenuation by the Brett. Mouthfeel: Variable by base style. Generally a light body, lighter than what might be expected from the base style but an overly thin body is a fault. Generally moderate to high carbonation. Head retention is variable."
-                       :ibu-min         7}))
+                      {cbf/category        "American Wild Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Brett Beer"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "28"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Virtually any style of beer, fermented in any manner, then finished with one or more strains of Brett. Alternatively, a beer made with Brett as the sole fermentation strain."
+                       cbf/examples        "Boulevard Saison Brett, Hill Farmstead Arthur, Logsdon Seizoen Bretta, Russian River Sanctification, The Bruery Saison Rue, Victory Helios"
+                       cbf/notes           "Most often drier and fruitier than the base style suggests. Funky notes range from low to high, depending on the age of the beer and strain(s) of Brett used. Funkiness is generally restrained in younger 100% Brett examples, but tends to increase with age. May possess a light acidity, although this does not come from Brett."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Variable by base style. Young Brett-fermented beers will possess more fruity notes (e.g., tropical fruit, stone fruit, or citrus), but this is variable by the strain(s) of Brett used. For 100% Brett beers heavily hopped with American hop varieties, the fermentation-derived flavors are often difficult to tease from the hop aromatics. Older 100% Brett beers may start to develop a little funk (e.g., barnyard, wet hay, or slightly earthy or smoky notes), but this character should not dominate. If the beer is fermented with a brewer's yeast in addition to Brett, some of the character of the primary yeast may remain. A faint sourness is acceptable but should not be a prominent character. Appearance: Variable by base style. Clarity can be variable, and depends on the base style and ingredients used. Some haze is not necessarily a fault. Flavor: Variable by base style. Brett character may range from minimal to aggressive. Can be quite fruity (e.g., tropical fruit, berry, stone fruit, citrus), or have some smoky, earthy, or barnyard character. Should not be unpleasantly funky, such as Band-Aid, fetid, nail polish remover, cheese, etc. Light sourness is acceptable with the beer being lightly tart, but should not be truly sour. Always fruitier when young, gaining more funk with age. May not be acetic or lactic. Malt flavors are often less pronounced than in the base style, leaving a beer most often dry and crisp due to high attenuation by the Brett. Mouthfeel: Variable by base style. Generally a light body, lighter than what might be expected from the base style but an overly thin body is a fault. Generally moderate to high carbonation. Head retention is variable."
+                       cbf/ibu-min         7}))
 
 
 (def mixed-fermentation-sour-beer
   "A sour and/or funky version of a base style of beer."
   (styles/build-style :mixed-fermentation-sour-beer
-                      {:category        "American Wild Ale"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Mixed-Fermentation Sour Beer"
-                       :type            "Mixed"
-                       :style-letter    "B"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "28"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Virtually any style of beer. Usually fermented by Lactobacillus and/or Pediococcus, often in conjunction with Saccharomyces and/or Brettanomyces. Can also be a blend of styles. Wood or barrel aging is very common, but not required."
-                       :examples        "Boulevard Love Child, Cascade Vlad the Imp Aler, Jester King Le Petit Prince, Jolly Pumpkin Calabaza Blanca, Russian River Temptation, The Bruery Rueuze, The Bruery Tart of Darkness"
-                       :notes           "A sour and/or funky version of a base style of beer."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: Variable by base style. The contribution of non-Saccharomyces microbes should be noticeable to strong, and often contribute a sour and/or funky, wild note. The best examples will display a range of aromatics, rather than a single dominant character. The aroma should be inviting, not harsh or unpleasant. Appearance: Variable by base style. Clarity can be variable; some haze is not a fault. Head retention can be poor due to high levels of acid or anti-foam properties of some lactobacillus strains. Flavor: Variable by base style. Look for an agreeable balance between the base beer and the fermentation character. A range of results is possible from fairly high acidity/funk to a subtle, pleasant, harmonious beer. The best examples are pleasurable to drink with the esters and phenols complementing the malt and/or hops. The wild character can be prominent, but does not need to be dominating in a style with an otherwise strong malt/hop profile. Acidity should be firm yet enjoyable, but should not be biting or vinegary; prominent or objectionable/offensive acetic acid is a fault. Bitterness tends to be low, especially as sourness increases. Mouthfeel: Variable by base style. Generally a light body, almost always lighter than what might be expected from the base style. Generally moderate to high carbonation, although often lower in higher alcohol examples."
-                       :ibu-min         7}))
+                      {cbf/category        "American Wild Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Mixed-Fermentation Sour Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "28"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Virtually any style of beer. Usually fermented by Lactobacillus and/or Pediococcus, often in conjunction with Saccharomyces and/or Brettanomyces. Can also be a blend of styles. Wood or barrel aging is very common, but not required."
+                       cbf/examples        "Boulevard Love Child, Cascade Vlad the Imp Aler, Jester King Le Petit Prince, Jolly Pumpkin Calabaza Blanca, Russian River Temptation, The Bruery Rueuze, The Bruery Tart of Darkness"
+                       cbf/notes           "A sour and/or funky version of a base style of beer."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Variable by base style. The contribution of non-Saccharomyces microbes should be noticeable to strong, and often contribute a sour and/or funky, wild note. The best examples will display a range of aromatics, rather than a single dominant character. The aroma should be inviting, not harsh or unpleasant. Appearance: Variable by base style. Clarity can be variable; some haze is not a fault. Head retention can be poor due to high levels of acid or anti-foam properties of some lactobacillus strains. Flavor: Variable by base style. Look for an agreeable balance between the base beer and the fermentation character. A range of results is possible from fairly high acidity/funk to a subtle, pleasant, harmonious beer. The best examples are pleasurable to drink with the esters and phenols complementing the malt and/or hops. The wild character can be prominent, but does not need to be dominating in a style with an otherwise strong malt/hop profile. Acidity should be firm yet enjoyable, but should not be biting or vinegary; prominent or objectionable/offensive acetic acid is a fault. Bitterness tends to be low, especially as sourness increases. Mouthfeel: Variable by base style. Generally a light body, almost always lighter than what might be expected from the base style. Generally moderate to high carbonation, although often lower in higher alcohol examples."
+                       cbf/ibu-min         7}))
 
 
 (def wild-specialty-beer
@@ -64,27 +65,27 @@
    
    If wood-aged, the wood should not be the primary or dominant character."
   (styles/build-style :wild-specialty-beer
-                      {:category        "American Wild Ale"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Wild Specialty Beer"
-                       :type            "Mixed"
-                       :style-letter    "C"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "28"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Virtually any style of beer. Any combination of Saccharomyces, Brettanomyces, Lactobacillus, Pediococcus, or other similar fermenters. Can also be a blend of styles. While cherries, raspberries, and peaches are most common, other fruits can be used as well. Vegetables with fruit-like characteristics (chile, rhubarb, pumpkin, etc.) may also be used. Wood or barrel aging is very common, but not required."
-                       :examples        "Cascade Bourbonic Plague, Jester King Atrial Rubicite, New Belgium Eric's Ale, New Glarus Belgian Red, Russian River Supplication, The Lost Abbey Cuvee de Tomme"
-                       :notes           "A sour and/or funky version of a fruit, herb, or spice beer, or a wild beer aged in wood. If wood-aged, the wood should not be the primary or dominant character."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: Variable by base style. Should show the fruit, sour and/or funk of a wild fermentation, as well as the characteristics of the special ingredients used. The best examples will blend the aromatics from the fermentation with the special ingredients, creating an aroma that may be difficult to attribute precisely. Appearance: Variable by base style, generally showing a color, tint, or hue from any fruit (if used) in both the beer and the head. Clarity can be variable; some haze is not a fault. Head retention is often poor. Flavor: Variable by base style. Should show the fruit, sour and/or funk of a wild fermentation, as well as the characteristics of the special ingredients used. Any fruit sweetness is generally gone, so only the esters typically remain from the fruit. The sour character from the fruit and wild fermentation could be prominent, but should not be overwhelming. The acidity and tannin from any fruit can both enhance the dryness of the beer, so care must be taken with the balance. The acidity should enhance the perception of the fruit flavor, not detract from it. Wood notes, if present, add flavor but should be balanced. Mouthfeel: Variable by base style. Generally a light body, lighter than what might be expected from the base style. Generally moderate to high carbonation; carbonation should balance the base style if one is declared. The presence of tannin from some fruit or wood can provide a slight astringency, enhance the body, or make the beer seem drier than it is."
-                       :ibu-min         7}))
+                      {cbf/category        "American Wild Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Wild Specialty Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "28"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Virtually any style of beer. Any combination of Saccharomyces, Brettanomyces, Lactobacillus, Pediococcus, or other similar fermenters. Can also be a blend of styles. While cherries, raspberries, and peaches are most common, other fruits can be used as well. Vegetables with fruit-like characteristics (chile, rhubarb, pumpkin, etc.) may also be used. Wood or barrel aging is very common, but not required."
+                       cbf/examples        "Cascade Bourbonic Plague, Jester King Atrial Rubicite, New Belgium Eric's Ale, New Glarus Belgian Red, Russian River Supplication, The Lost Abbey Cuvee de Tomme"
+                       cbf/notes           "A sour and/or funky version of a fruit, herb, or spice beer, or a wild beer aged in wood. If wood-aged, the wood should not be the primary or dominant character."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Variable by base style. Should show the fruit, sour and/or funk of a wild fermentation, as well as the characteristics of the special ingredients used. The best examples will blend the aromatics from the fermentation with the special ingredients, creating an aroma that may be difficult to attribute precisely. Appearance: Variable by base style, generally showing a color, tint, or hue from any fruit (if used) in both the beer and the head. Clarity can be variable; some haze is not a fault. Head retention is often poor. Flavor: Variable by base style. Should show the fruit, sour and/or funk of a wild fermentation, as well as the characteristics of the special ingredients used. Any fruit sweetness is generally gone, so only the esters typically remain from the fruit. The sour character from the fruit and wild fermentation could be prominent, but should not be overwhelming. The acidity and tannin from any fruit can both enhance the dryness of the beer, so care must be taken with the balance. The acidity should enhance the perception of the fruit flavor, not detract from it. Wood notes, if present, add flavor but should be balanced. Mouthfeel: Variable by base style. Generally a light body, lighter than what might be expected from the base style. Generally moderate to high carbonation; carbonation should balance the base style if one is declared. The presence of tannin from some fruit or wood can provide a slight astringency, enhance the body, or make the beer seem drier than it is."
+                       cbf/ibu-min         7}))
 
 
 (def american-wild-ale

--- a/src/common_beer_data/styles/bjcp_2015/belgian_ale.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/belgian_ale.cljc
@@ -1,32 +1,33 @@
 (ns common-beer-data.styles.bjcp-2015.belgian-ale
   "2015 BJCP guidelines on Belgian Ales."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def witbier
   "A refreshing, elegant, tasty, moderate-strength wheat-based ale."
   (styles/build-style :witbier
-                      {:category        "Belgian Ale"
-                       :carb-min        1.5
-                       :fg-max          1.012
-                       :og-min          1.044
-                       :name            "Witbier"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.045
-                       :fg-min          1.008
-                       :category-number "24"
-                       :carb-max        3.0
-                       :ibu-max         20
-                       :ingredients     "About 50% unmalted wheat and 50% pale barley malt (usually Pils malt) constitute the grist. In some versions, up to 5-10% raw oats may be used. Spices of freshly-ground coriander and Curaçao or sometimes sweet orange peel complement the sweet aroma and are quite characteristic. Other spices (e.g., chamomile, cumin, cinnamon, Grains of Paradise) may be used for complexity but are much less prominent. Ale yeast prone to the production of mild, spicy flavors is very characteristic. In some instances a very limited lactic fermentation, or the actual addition of lactic acid, is done."
-                       :examples        "Allagash White, Blanche de Bruxelles, Celis White, Hoegaarden Wit, Ommegang Witte, St. Bernardus Witbier, Wittekerke"
-                       :notes           "A refreshing, elegant, tasty, moderate-strength wheat-based ale."
-                       :og-max          1.052
-                       :color-min       2.0
-                       :abv-max         0.055
-                       :color-max       4.0
-                       :profile         "Aroma: Moderate malty sweetness (often with light notes of honey and/or vanilla) with light, grainy, spicy wheat aromatics, often with a bit of tartness. Moderate perfumy coriander, often with a complex herbal, spicy, or peppery note in the background. Moderate zesty, citrusy-orangey fruitiness. A low spicy-herbal hop aroma is optional, but should never overpower the other characteristics. Vegetal, celery-like, or ham-like aromas are inappropriate. Spices should blend in with fruity, floral and sweet aromas and should not be overly strong. Appearance: Very pale straw to very light gold in color. The beer will be very cloudy from starch haze and/or yeast, which gives it a milky, whitish-yellow appearance. Dense, white, moussy head. Head retention should be quite good. Flavor: Pleasant malty-sweet grain flavor (often with a honey and/or vanilla character) and a zesty, orange-citrusy fruitiness. Refreshingly crisp with a dry, often tart, finish. Can have a low bready wheat flavor. Optionally has a very light lactic-tasting sourness. Herbal-spicy flavors, which may include coriander and other spices, are common should be subtle and balanced, not overpowering. A spicy-earthy hop flavor is low to none, and if noticeable, never gets in the way of the spices. Hop bitterness is low to medium-low, and doesn't interfere with refreshing flavors of fruit and spice, nor does it persist into the finish. Bitterness from orange pith should not be present. Vegetal, celery-like, ham-like, or soapy flavors are inappropriate. Mouthfeel: Medium-light to medium body, often having a smoothness and light creaminess from unmalted wheat and the occasional oats. Despite body and creaminess, finishes dry and often a bit tart. Effervescent character from high carbonation. Refreshing, from carbonation, light acidity, and lack of bitterness in finish. No harshness or astringency from orange pith. Should not be overly dry and thin, nor should it be thick and heavy."
-                       :ibu-min         8}))
+                      {cbf/category        "Belgian Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.012
+                       cbf/og-min          1.044
+                       cbf/name            "Witbier"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.045
+                       cbf/fg-min          1.008
+                       cbf/category-number "24"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         20
+                       cbf/ingredients     "About 50% unmalted wheat and 50% pale barley malt (usually Pils malt) constitute the grist. In some versions, up to 5-10% raw oats may be used. Spices of freshly-ground coriander and Curaçao or sometimes sweet orange peel complement the sweet aroma and are quite characteristic. Other spices (e.g., chamomile, cumin, cinnamon, Grains of Paradise) may be used for complexity but are much less prominent. Ale yeast prone to the production of mild, spicy flavors is very characteristic. In some instances a very limited lactic fermentation, or the actual addition of lactic acid, is done."
+                       cbf/examples        "Allagash White, Blanche de Bruxelles, Celis White, Hoegaarden Wit, Ommegang Witte, St. Bernardus Witbier, Wittekerke"
+                       cbf/notes           "A refreshing, elegant, tasty, moderate-strength wheat-based ale."
+                       cbf/og-max          1.052
+                       cbf/color-min       2.0
+                       cbf/abv-max         0.055
+                       cbf/color-max       4.0
+                       cbf/profile         "Aroma: Moderate malty sweetness (often with light notes of honey and/or vanilla) with light, grainy, spicy wheat aromatics, often with a bit of tartness. Moderate perfumy coriander, often with a complex herbal, spicy, or peppery note in the background. Moderate zesty, citrusy-orangey fruitiness. A low spicy-herbal hop aroma is optional, but should never overpower the other characteristics. Vegetal, celery-like, or ham-like aromas are inappropriate. Spices should blend in with fruity, floral and sweet aromas and should not be overly strong. Appearance: Very pale straw to very light gold in color. The beer will be very cloudy from starch haze and/or yeast, which gives it a milky, whitish-yellow appearance. Dense, white, moussy head. Head retention should be quite good. Flavor: Pleasant malty-sweet grain flavor (often with a honey and/or vanilla character) and a zesty, orange-citrusy fruitiness. Refreshingly crisp with a dry, often tart, finish. Can have a low bready wheat flavor. Optionally has a very light lactic-tasting sourness. Herbal-spicy flavors, which may include coriander and other spices, are common should be subtle and balanced, not overpowering. A spicy-earthy hop flavor is low to none, and if noticeable, never gets in the way of the spices. Hop bitterness is low to medium-low, and doesn't interfere with refreshing flavors of fruit and spice, nor does it persist into the finish. Bitterness from orange pith should not be present. Vegetal, celery-like, ham-like, or soapy flavors are inappropriate. Mouthfeel: Medium-light to medium body, often having a smoothness and light creaminess from unmalted wheat and the occasional oats. Despite body and creaminess, finishes dry and often a bit tart. Effervescent character from high carbonation. Refreshing, from carbonation, light acidity, and lack of bitterness in finish. No harshness or astringency from orange pith. Should not be overly dry and thin, nor should it be thick and heavy."
+                       cbf/ibu-min         8}))
 
 
 (def belgian-pale-ale
@@ -35,27 +36,27 @@
    The malt character tends to be a bit biscuity with light toasty, honey-like, or caramelly components; the fruit character is noticeable and complementary to the malt. 
    The bitterness level is generally moderate, but may not seem as high due to the flavorful malt profile."
   (styles/build-style :belgian-pale-ale
-                      {:category        "Belgian Ale"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.048
-                       :name            "Belgian Pale Ale"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.048
-                       :fg-min          1.01
-                       :category-number "24"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "Pilsner or pale ale malt contributes the bulk of the grist with (cara) Vienna and Munich malts adding color, body and complexity. Sugar is not commonly used as high gravity is not desired. Saazer-type hops, Styrian Goldings, East Kent Goldings or Fuggles are commonly used. Yeasts prone to moderate production of phenols are often used but fermentation temperatures should be kept moderate to limit this character."
-                       :examples        "De Koninck, De Ryck Special, Palm Dobble, Palm Speciale"
-                       :notes           "A moderately malty, somewhat fruity, easy-drinking, copper-colored Belgian ale that is somewhat less aggressive in flavor profile than many other Belgian beers. The malt character tends to be a bit biscuity with light toasty, honey-like, or caramelly components; the fruit character is noticeable and complementary to the malt. The bitterness level is generally moderate, but may not seem as high due to the flavorful malt profile."
-                       :og-max          1.054
-                       :color-min       8.0
-                       :abv-max         0.055
-                       :color-max       14.0
-                       :profile         "Aroma: Moderate malt aroma, which can be a combination of toasty, biscuity, or nutty, possibly with a touch of light caramel or honey. Moderate to moderately high fruitiness with an orange- or pear-like character. Low to moderate strength hop character (spicy, herbal, or floral) optionally blended with background level peppery, spicy phenols. The hop character is lower in balance than the malt and fruitiness. Appearance: Amber to copper in color. Clarity is very good. Creamy, rocky, white head often fades more quickly than other Belgian beers. Flavor: Has an initial soft, smooth, moderately malty flavor with a variable profile of toasty, biscuity, nutty, light caramel and/or honey notes. Moderate to moderately high fruitiness, sometimes orange- or pear-like. Relatively light (medium-low to low) spicy, herbal, or floral hop character. The hop bitterness is medium-high to medium-low, and is optionally enhanced by low to very low amounts of peppery phenols. There is a dry to balanced finish, with hops becoming more pronounced in the aftertaste of those with a drier finish. Fairly well balanced overall, with no single component being high in intensity; malt and fruitiness are more forward initially with a supportive bitterness and drying character coming on late. Mouthfeel: Medium to medium-light body. Smooth palate. Alcohol level is restrained, and any warming character should be low if present. Medium to medium-high carbonation."
-                       :ibu-min         20}))
+                      {cbf/category        "Belgian Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.048
+                       cbf/name            "Belgian Pale Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.048
+                       cbf/fg-min          1.01
+                       cbf/category-number "24"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "Pilsner or pale ale malt contributes the bulk of the grist with (cara) Vienna and Munich malts adding color, body and complexity. Sugar is not commonly used as high gravity is not desired. Saazer-type hops, Styrian Goldings, East Kent Goldings or Fuggles are commonly used. Yeasts prone to moderate production of phenols are often used but fermentation temperatures should be kept moderate to limit this character."
+                       cbf/examples        "De Koninck, De Ryck Special, Palm Dobble, Palm Speciale"
+                       cbf/notes           "A moderately malty, somewhat fruity, easy-drinking, copper-colored Belgian ale that is somewhat less aggressive in flavor profile than many other Belgian beers. The malt character tends to be a bit biscuity with light toasty, honey-like, or caramelly components; the fruit character is noticeable and complementary to the malt. The bitterness level is generally moderate, but may not seem as high due to the flavorful malt profile."
+                       cbf/og-max          1.054
+                       cbf/color-min       8.0
+                       cbf/abv-max         0.055
+                       cbf/color-max       14.0
+                       cbf/profile         "Aroma: Moderate malt aroma, which can be a combination of toasty, biscuity, or nutty, possibly with a touch of light caramel or honey. Moderate to moderately high fruitiness with an orange- or pear-like character. Low to moderate strength hop character (spicy, herbal, or floral) optionally blended with background level peppery, spicy phenols. The hop character is lower in balance than the malt and fruitiness. Appearance: Amber to copper in color. Clarity is very good. Creamy, rocky, white head often fades more quickly than other Belgian beers. Flavor: Has an initial soft, smooth, moderately malty flavor with a variable profile of toasty, biscuity, nutty, light caramel and/or honey notes. Moderate to moderately high fruitiness, sometimes orange- or pear-like. Relatively light (medium-low to low) spicy, herbal, or floral hop character. The hop bitterness is medium-high to medium-low, and is optionally enhanced by low to very low amounts of peppery phenols. There is a dry to balanced finish, with hops becoming more pronounced in the aftertaste of those with a drier finish. Fairly well balanced overall, with no single component being high in intensity; malt and fruitiness are more forward initially with a supportive bitterness and drying character coming on late. Mouthfeel: Medium to medium-light body. Smooth palate. Alcohol level is restrained, and any warming character should be low if present. Medium to medium-high carbonation."
+                       cbf/ibu-min         20}))
 
 
 (def bière-de-garde
@@ -63,27 +64,27 @@
    
    All are malty yet dry, with clean flavors and a smooth character."
   (styles/build-style :bière-de-garde
-                      {:category        "Belgian Ale"
-                       :carb-min        1.5
-                       :fg-max          1.016
-                       :og-min          1.06
-                       :name            "Bière de Garde"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.06
-                       :fg-min          1.008
-                       :category-number "24"
-                       :carb-max        3.0
-                       :ibu-max         28
-                       :ingredients     "The \"cellar\" character commonly described in literature is more of a feature of mishandled commercial exports than fresh, authentic products. The somewhat moldy character comes from the corks and/or oxidation in commercial versions, and is incorrectly identified as \"musty\" or \"cellar-like.\" Base malts vary by beer color, but usually include pale, Vienna and Munich types. Darker versions will have richer malt complexity and sweetness from crystal-type malts. Sugar may be used to add flavor and aid in the dry finish. Lager or ale yeast fermented at cool ale temperatures, followed by long cold conditioning. Floral, herbal or spicy continental hops."
-                       :examples        "Ch'Ti (brown and blond), Jenlain (amber and blond), La Choulette (all 3 versions), St. Amand (brown), Russian River Perdition"
-                       :notes           "A fairly strong, malt-accentuated, lagered artisanal beer with a range of malt flavors appropriate for the color. All are malty yet dry, with clean flavors and a smooth character."
-                       :og-max          1.08
-                       :color-min       6.0
-                       :abv-max         0.085
-                       :color-max       19.0
-                       :profile         "Aroma: Prominent malty sweetness, often with a complex, light to moderate intensity toasty-bready-rich malt character. Low to moderate esters. Little to no hop aroma (may be a bit spicy, peppery, or herbal). Paler versions will still be malty but will lack richer, deeper aromatics and may have a bit more hops. Generally quite clean, although stronger versions may have a light, spicy alcohol note as it warms. Appearance: Three main variations exist (blond, amber and brown), so color can range from golden-blonde to reddish-bronze to chestnut brown. Clarity is brilliant to fair, although haze is not unexpected in this type of often unfiltered beer. Well-formed head, generally white to off-white (varies by beer color), average persistence. Flavor: Medium to high malt flavor often with a toasty-rich, biscuity, toffee-like or light caramel-sweet character. Malt flavors and complexity tend to increase with beer color. Low to moderate esters and alcohol flavors. Medium-low hop bitterness provides some support, but the balance is always tilted toward the malt. Darker versions will have more of an initial malty-sweet impression than paler versions, but all should be malty in the palate and finish. The malt flavor lasts into the finish, which is medium-dry to dry, never cloying. Low to no hop flavor (spicy, peppery, or herbal), although paler versions can have slightly higher levels of herbal or spicy hop flavor (which can also come from the yeast). Smooth, well-lagered character, even if made with ale yeast. Aftertaste of malt (character appropriate for the color) with some dryness and light alcohol. Mouthfeel: Medium to medium-light (lean) body, often with a smooth, creamy-silky character. Moderate to high carbonation. Moderate alcohol warming, but should be very smooth and never hot."
-                       :ibu-min         18}))
+                      {cbf/category        "Belgian Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.016
+                       cbf/og-min          1.06
+                       cbf/name            "Bière de Garde"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.06
+                       cbf/fg-min          1.008
+                       cbf/category-number "24"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         28
+                       cbf/ingredients     "The \"cellar\" character commonly described in literature is more of a feature of mishandled commercial exports than fresh, authentic products. The somewhat moldy character comes from the corks and/or oxidation in commercial versions, and is incorrectly identified as \"musty\" or \"cellar-like.\" Base malts vary by beer color, but usually include pale, Vienna and Munich types. Darker versions will have richer malt complexity and sweetness from crystal-type malts. Sugar may be used to add flavor and aid in the dry finish. Lager or ale yeast fermented at cool ale temperatures, followed by long cold conditioning. Floral, herbal or spicy continental hops."
+                       cbf/examples        "Ch'Ti (brown and blond), Jenlain (amber and blond), La Choulette (all 3 versions), St. Amand (brown), Russian River Perdition"
+                       cbf/notes           "A fairly strong, malt-accentuated, lagered artisanal beer with a range of malt flavors appropriate for the color. All are malty yet dry, with clean flavors and a smooth character."
+                       cbf/og-max          1.08
+                       cbf/color-min       6.0
+                       cbf/abv-max         0.085
+                       cbf/color-max       19.0
+                       cbf/profile         "Aroma: Prominent malty sweetness, often with a complex, light to moderate intensity toasty-bready-rich malt character. Low to moderate esters. Little to no hop aroma (may be a bit spicy, peppery, or herbal). Paler versions will still be malty but will lack richer, deeper aromatics and may have a bit more hops. Generally quite clean, although stronger versions may have a light, spicy alcohol note as it warms. Appearance: Three main variations exist (blond, amber and brown), so color can range from golden-blonde to reddish-bronze to chestnut brown. Clarity is brilliant to fair, although haze is not unexpected in this type of often unfiltered beer. Well-formed head, generally white to off-white (varies by beer color), average persistence. Flavor: Medium to high malt flavor often with a toasty-rich, biscuity, toffee-like or light caramel-sweet character. Malt flavors and complexity tend to increase with beer color. Low to moderate esters and alcohol flavors. Medium-low hop bitterness provides some support, but the balance is always tilted toward the malt. Darker versions will have more of an initial malty-sweet impression than paler versions, but all should be malty in the palate and finish. The malt flavor lasts into the finish, which is medium-dry to dry, never cloying. Low to no hop flavor (spicy, peppery, or herbal), although paler versions can have slightly higher levels of herbal or spicy hop flavor (which can also come from the yeast). Smooth, well-lagered character, even if made with ale yeast. Aftertaste of malt (character appropriate for the color) with some dryness and light alcohol. Mouthfeel: Medium to medium-light (lean) body, often with a smooth, creamy-silky character. Moderate to high carbonation. Moderate alcohol warming, but should be very smooth and never hot."
+                       cbf/ibu-min         18}))
 
 
 (def belgian-ale

--- a/src/common_beer_data/styles/bjcp_2015/british_bitter.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/british_bitter.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.british-bitter
   "2015 BJCP guidelines on British Bitter."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def ordinary-bitter
@@ -9,27 +10,27 @@
    The malt profile can vary in flavor and intensity, but should never override the overall bitter impression. 
    Drinkability is a critical component of the style."
   (styles/build-style :ordinary-bitter
-                      {:category        "British Bitter"
-                       :carb-min        1.5
-                       :fg-max          1.011
-                       :og-min          1.03
-                       :name            "Ordinary Bitter"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.032
-                       :fg-min          1.007
-                       :category-number "11"
-                       :carb-max        3.0
-                       :ibu-max         35
-                       :ingredients     "Pale ale, amber, and/or crystal malts. May use a touch of dark malt for color adjustment. May use sugar adjuncts, corn, or wheat. English finishing hops are most traditional, but any hops are fair game; if American hops are used, a light touch is required. Characterful British yeast."
-                       :examples        "Adnams Southwold Bitter, Brains Bitter, Fuller's Chiswick Bitter, Greene King IPA, Tetley's Original Bitter, Young's Bitter"
-                       :notes           "Low gravity, low alcohol levels, and low carbonation make this an easy-drinking session beer. The malt profile can vary in flavor and intensity, but should never override the overall bitter impression. Drinkability is a critical component of the style."
-                       :og-max          1.039
-                       :color-min       8.0
-                       :abv-max         0.038
-                       :color-max       14.0
-                       :profile         "Aroma: Low to moderate malt aroma, often (but not always) with a light caramel quality. Bready, biscuity, or lightly toasty malt complexity is common. Mild to moderate fruitiness. Hop aroma can range from moderate to none, typically with a floral, earthy, resiny, and/or fruity character. Generally no diacetyl, although very low levels are allowed. Appearance: Pale amber to light copper color. Good to brilliant clarity. Low to moderate white to off-white head. May have very little head due to low carbonation. Flavor: Medium to moderately high bitterness. Moderately low to moderately high fruity esters. Moderate to low hop flavor, typically with an earthy, resiny, fruity, and/or floral character. Low to medium maltiness with a dry finish. The malt profile is typically bready, biscuity, or lightly toasty. Low to moderate caramel or toffee flavors are optional. Balance is often decidedly bitter, although the bitterness should not completely overpower the malt flavor, esters and hop flavor. Generally no diacetyl, although very low levels are allowed. Mouthfeel: Light to medium-light body. Low carbonation, although bottled examples can have moderate carbonation."
-                       :ibu-min         25}))
+                      {cbf/category        "British Bitter"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.011
+                       cbf/og-min          1.03
+                       cbf/name            "Ordinary Bitter"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.032
+                       cbf/fg-min          1.007
+                       cbf/category-number "11"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         35
+                       cbf/ingredients     "Pale ale, amber, and/or crystal malts. May use a touch of dark malt for color adjustment. May use sugar adjuncts, corn, or wheat. English finishing hops are most traditional, but any hops are fair game; if American hops are used, a light touch is required. Characterful British yeast."
+                       cbf/examples        "Adnams Southwold Bitter, Brains Bitter, Fuller's Chiswick Bitter, Greene King IPA, Tetley's Original Bitter, Young's Bitter"
+                       cbf/notes           "Low gravity, low alcohol levels, and low carbonation make this an easy-drinking session beer. The malt profile can vary in flavor and intensity, but should never override the overall bitter impression. Drinkability is a critical component of the style."
+                       cbf/og-max          1.039
+                       cbf/color-min       8.0
+                       cbf/abv-max         0.038
+                       cbf/color-max       14.0
+                       cbf/profile         "Aroma: Low to moderate malt aroma, often (but not always) with a light caramel quality. Bready, biscuity, or lightly toasty malt complexity is common. Mild to moderate fruitiness. Hop aroma can range from moderate to none, typically with a floral, earthy, resiny, and/or fruity character. Generally no diacetyl, although very low levels are allowed. Appearance: Pale amber to light copper color. Good to brilliant clarity. Low to moderate white to off-white head. May have very little head due to low carbonation. Flavor: Medium to moderately high bitterness. Moderately low to moderately high fruity esters. Moderate to low hop flavor, typically with an earthy, resiny, fruity, and/or floral character. Low to medium maltiness with a dry finish. The malt profile is typically bready, biscuity, or lightly toasty. Low to moderate caramel or toffee flavors are optional. Balance is often decidedly bitter, although the bitterness should not completely overpower the malt flavor, esters and hop flavor. Generally no diacetyl, although very low levels are allowed. Mouthfeel: Light to medium-light body. Low carbonation, although bottled examples can have moderate carbonation."
+                       cbf/ibu-min         25}))
 
 
 (def best-bitter
@@ -38,27 +39,27 @@
    Some examples can be more malt balanced, but this should not override the overall bitter impression. 
    Drinkability is a critical component of the style."
   (styles/build-style :best-bitter
-                      {:category        "British Bitter"
-                       :carb-min        1.5
-                       :fg-max          1.012
-                       :og-min          1.04
-                       :name            "Best Bitter"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.038
-                       :fg-min          1.008
-                       :category-number "11"
-                       :carb-max        3.0
-                       :ibu-max         40
-                       :ingredients     "Pale ale, amber, and/or crystal malts. May use a touch of dark malt for color adjustment. May use sugar adjuncts, corn or wheat. English finishing hops are most traditional, but any hops are fair game; if American hops are used, a light touch is required. Characterful British yeast."
-                       :examples        "Adnams SSB, Coniston Bluebird Bitter, Fuller's London Pride, Harvey's Sussex Best Bitter, Shepherd Neame Master Brew Kentish Ale, Timothy Taylor Landlord,Young's Special"
-                       :notes           "A flavorful, yet refreshing, session beer. Some examples can be more malt balanced, but this should not override the overall bitter impression. Drinkability is a critical component of the style."
-                       :og-max          1.048
-                       :color-min       8.0
-                       :abv-max         0.046
-                       :color-max       16.0
-                       :profile         "Aroma: Low to moderate malt aroma, often (but not always) with a low to medium-low caramel quality. Bready, biscuit, or lightly toasty malt complexity is common. Mild to moderate fruitiness. Hop aroma can range from moderate to none, typically with a floral, earthy, resiny, and/or fruity character. Generally no diacetyl, although very low levels are allowed. Appearance: Pale amber to medium copper color. Good to brilliant clarity. Low to moderate white to off-white head. May have very little head due to low carbonation. Flavor: Medium to moderately high bitterness. Moderately low to moderately high fruity esters. Moderate to low hop flavor, typically with an earthy, resiny, fruity, and/or floral character. Low to medium maltiness with a dry finish. The malt profile is typically bready, biscuity, or lightly toasty. Low to moderate caramel or toffee flavors are optional. Balance is often decidedly bitter, although the bitterness should not completely overpower the malt flavor, esters and hop flavor. Generally no diacetyl, although very low levels are allowed. Mouthfeel: Medium-light to medium body. Low carbonation, although bottled examples can have moderate carbonation."
-                       :ibu-min         25}))
+                      {cbf/category        "British Bitter"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.012
+                       cbf/og-min          1.04
+                       cbf/name            "Best Bitter"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.038
+                       cbf/fg-min          1.008
+                       cbf/category-number "11"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         40
+                       cbf/ingredients     "Pale ale, amber, and/or crystal malts. May use a touch of dark malt for color adjustment. May use sugar adjuncts, corn or wheat. English finishing hops are most traditional, but any hops are fair game; if American hops are used, a light touch is required. Characterful British yeast."
+                       cbf/examples        "Adnams SSB, Coniston Bluebird Bitter, Fuller's London Pride, Harvey's Sussex Best Bitter, Shepherd Neame Master Brew Kentish Ale, Timothy Taylor Landlord,Young's Special"
+                       cbf/notes           "A flavorful, yet refreshing, session beer. Some examples can be more malt balanced, but this should not override the overall bitter impression. Drinkability is a critical component of the style."
+                       cbf/og-max          1.048
+                       cbf/color-min       8.0
+                       cbf/abv-max         0.046
+                       cbf/color-max       16.0
+                       cbf/profile         "Aroma: Low to moderate malt aroma, often (but not always) with a low to medium-low caramel quality. Bready, biscuit, or lightly toasty malt complexity is common. Mild to moderate fruitiness. Hop aroma can range from moderate to none, typically with a floral, earthy, resiny, and/or fruity character. Generally no diacetyl, although very low levels are allowed. Appearance: Pale amber to medium copper color. Good to brilliant clarity. Low to moderate white to off-white head. May have very little head due to low carbonation. Flavor: Medium to moderately high bitterness. Moderately low to moderately high fruity esters. Moderate to low hop flavor, typically with an earthy, resiny, fruity, and/or floral character. Low to medium maltiness with a dry finish. The malt profile is typically bready, biscuity, or lightly toasty. Low to moderate caramel or toffee flavors are optional. Balance is often decidedly bitter, although the bitterness should not completely overpower the malt flavor, esters and hop flavor. Generally no diacetyl, although very low levels are allowed. Mouthfeel: Medium-light to medium body. Low carbonation, although bottled examples can have moderate carbonation."
+                       cbf/ibu-min         25}))
 
 
 (def strong-bitter
@@ -68,27 +69,27 @@
    Drinkability is a critical component of the style. 
    A rather broad style that allows for considerable interpretation by the brewer."
   (styles/build-style :strong-bitter
-                      {:category        "British Bitter"
-                       :carb-min        1.5
-                       :fg-max          1.016
-                       :og-min          1.048
-                       :name            "Strong Bitter"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.046
-                       :fg-min          1.01
-                       :category-number "11"
-                       :carb-max        3.0
-                       :ibu-max         50
-                       :ingredients     "Pale ale, amber, and/or crystal malts, may use a touch of black malt for color adjustment. May use sugar adjuncts, corn or wheat. English finishing hops are most traditional, but any hops are fair game; if American hops are used, a light touch is required. Characterful British yeast. Burton versions use medium to high sulfate water, which can increase the perception of dryness and add a minerally or sulfury aroma and flavor."
-                       :examples        "Bass Ale, Highland Orkney Blast, Samuel Smith's Old Brewery Pale Ale, Shepherd Neame Bishop's Finger, Shepherd Neame Spitfire, West Berkshire Dr. Hexter's Healer, Whitbread Pale Ale, Young's Ram Rod"
-                       :notes           "An average-strength to moderately-strong British bitter ale. The balance may be fairly even between malt and hops to somewhat bitter. Drinkability is a critical component of the style. A rather broad style that allows for considerable interpretation by the brewer."
-                       :og-max          1.06
-                       :color-min       8.0
-                       :abv-max         0.062
-                       :color-max       18.0
-                       :profile         "Aroma: Hop aroma moderately-high to moderately-low, typically with a floral, earthy, resiny, and/or fruity character. Medium to medium-high malt aroma, optionally with a low to moderate caramel component. Medium-low to medium-high fruity esters. Generally no diacetyl, although very low levels are allowed. Appearance: Light amber to deep copper color. Good to brilliant clarity. Low to moderate white to off-white head. A low head is acceptable when carbonation is also low. Flavor: Medium to medium-high bitterness with supporting malt flavors evident. The malt profile is typically bready, biscuity, nutty, or lightly toasty, and optionally has a moderately low to moderate caramel or toffee flavor. Hop flavor moderate to moderately high, typically with a floral, earthy, resiny, and/or fruity character. Hop bitterness and flavor should be noticeable, but should not totally dominate malt flavors. Moderately-low to high fruity esters. Optionally may have low amounts of alcohol. Medium-dry to dry finish. Generally no diacetyl, although very low levels are allowed. Mouthfeel: Medium-light to medium-full body. Low to moderate carbonation, although bottled versions will be higher. Stronger versions may have a slight alcohol warmth but this character should not be too high."
-                       :ibu-min         30}))
+                      {cbf/category        "British Bitter"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.016
+                       cbf/og-min          1.048
+                       cbf/name            "Strong Bitter"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.046
+                       cbf/fg-min          1.01
+                       cbf/category-number "11"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         50
+                       cbf/ingredients     "Pale ale, amber, and/or crystal malts, may use a touch of black malt for color adjustment. May use sugar adjuncts, corn or wheat. English finishing hops are most traditional, but any hops are fair game; if American hops are used, a light touch is required. Characterful British yeast. Burton versions use medium to high sulfate water, which can increase the perception of dryness and add a minerally or sulfury aroma and flavor."
+                       cbf/examples        "Bass Ale, Highland Orkney Blast, Samuel Smith's Old Brewery Pale Ale, Shepherd Neame Bishop's Finger, Shepherd Neame Spitfire, West Berkshire Dr. Hexter's Healer, Whitbread Pale Ale, Young's Ram Rod"
+                       cbf/notes           "An average-strength to moderately-strong British bitter ale. The balance may be fairly even between malt and hops to somewhat bitter. Drinkability is a critical component of the style. A rather broad style that allows for considerable interpretation by the brewer."
+                       cbf/og-max          1.06
+                       cbf/color-min       8.0
+                       cbf/abv-max         0.062
+                       cbf/color-max       18.0
+                       cbf/profile         "Aroma: Hop aroma moderately-high to moderately-low, typically with a floral, earthy, resiny, and/or fruity character. Medium to medium-high malt aroma, optionally with a low to moderate caramel component. Medium-low to medium-high fruity esters. Generally no diacetyl, although very low levels are allowed. Appearance: Light amber to deep copper color. Good to brilliant clarity. Low to moderate white to off-white head. A low head is acceptable when carbonation is also low. Flavor: Medium to medium-high bitterness with supporting malt flavors evident. The malt profile is typically bready, biscuity, nutty, or lightly toasty, and optionally has a moderately low to moderate caramel or toffee flavor. Hop flavor moderate to moderately high, typically with a floral, earthy, resiny, and/or fruity character. Hop bitterness and flavor should be noticeable, but should not totally dominate malt flavors. Moderately-low to high fruity esters. Optionally may have low amounts of alcohol. Medium-dry to dry finish. Generally no diacetyl, although very low levels are allowed. Mouthfeel: Medium-light to medium-full body. Low to moderate carbonation, although bottled versions will be higher. Stronger versions may have a slight alcohol warmth but this character should not be too high."
+                       cbf/ibu-min         30}))
 
 
 (def british-bitter

--- a/src/common_beer_data/styles/bjcp_2015/brown_british_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/brown_british_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.brown-british-beer
   "2015 BJCP guidelines on Brown British Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def dark-mild
@@ -8,53 +9,53 @@
    
    Refreshing, yet flavorful, with a wide range of dark malt or dark sugar expression."
   (styles/build-style :dark-mild
-                      {:category        "Brown British Beer"
-                       :carb-min        1.5
-                       :fg-max          1.013
-                       :og-min          1.03
-                       :name            "Dark Mild"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.03
-                       :fg-min          1.008
-                       :category-number "13"
-                       :carb-max        3.0
-                       :ibu-max         25
-                       :ingredients     "Pale British base malts (often fairly dextrinous), crystal malt, dark malts or dark sugar adjuncts, may also include adjuncts such as flaked maize, and may be colored with brewer's caramel. Characterful British ale yeast. Any type of hops, since their character is muted and rarely is noticeable."
-                       :examples        "Banks's Mild, Cain's Dark Mild, Highgate Dark Mild, Brain's Dark, Moorhouse Black Cat, Rudgate Ruby Mild, Theakston Traditional Mild"
-                       :notes           "A dark, low-gravity, malt-focused British session ale readily suited to drinking in quantity. Refreshing, yet flavorful, with a wide range of dark malt or dark sugar expression."
-                       :og-max          1.038
-                       :color-min       12.0
-                       :abv-max         0.038
-                       :color-max       25.0
-                       :profile         "Aroma: Low to moderate malt aroma, and may have some fruitiness. The malt expression can take on a wide range of character, which can include caramel, toffee, grainy, toasted, nutty, chocolate, or lightly roasted. Little to no hop aroma, earthy or floral if present. Very low to no diacetyl. Appearance: Copper to dark brown or mahogany color. A few paler examples (medium amber to light brown) exist. Generally clear, although is traditionally unfiltered. Low to moderate off-white to tan head; retention may be poor. Flavor: Generally a malty beer, although may have a very wide range of malt- and yeast-based flavors (e.g., malty, sweet, caramel, toffee, toast, nutty, chocolate, coffee, roast, fruit, licorice, plum, raisin). Can finish sweet to dry. Versions with darker malts may have a dry, roasted finish. Low to moderate bitterness, enough to provide some balance but not enough to overpower the malt. Fruity esters moderate to none. Diacetyl and hop flavor low to none. Mouthfeel: Light to medium body. Generally low to medium-low carbonation. Roast-based versions may have a light astringency. Sweeter versions may seem to have a rather full mouthfeel for the gravity."
-                       :ibu-min         10}))
+                      {cbf/category        "Brown British Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.013
+                       cbf/og-min          1.03
+                       cbf/name            "Dark Mild"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.03
+                       cbf/fg-min          1.008
+                       cbf/category-number "13"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         25
+                       cbf/ingredients     "Pale British base malts (often fairly dextrinous), crystal malt, dark malts or dark sugar adjuncts, may also include adjuncts such as flaked maize, and may be colored with brewer's caramel. Characterful British ale yeast. Any type of hops, since their character is muted and rarely is noticeable."
+                       cbf/examples        "Banks's Mild, Cain's Dark Mild, Highgate Dark Mild, Brain's Dark, Moorhouse Black Cat, Rudgate Ruby Mild, Theakston Traditional Mild"
+                       cbf/notes           "A dark, low-gravity, malt-focused British session ale readily suited to drinking in quantity. Refreshing, yet flavorful, with a wide range of dark malt or dark sugar expression."
+                       cbf/og-max          1.038
+                       cbf/color-min       12.0
+                       cbf/abv-max         0.038
+                       cbf/color-max       25.0
+                       cbf/profile         "Aroma: Low to moderate malt aroma, and may have some fruitiness. The malt expression can take on a wide range of character, which can include caramel, toffee, grainy, toasted, nutty, chocolate, or lightly roasted. Little to no hop aroma, earthy or floral if present. Very low to no diacetyl. Appearance: Copper to dark brown or mahogany color. A few paler examples (medium amber to light brown) exist. Generally clear, although is traditionally unfiltered. Low to moderate off-white to tan head; retention may be poor. Flavor: Generally a malty beer, although may have a very wide range of malt- and yeast-based flavors (e.g., malty, sweet, caramel, toffee, toast, nutty, chocolate, coffee, roast, fruit, licorice, plum, raisin). Can finish sweet to dry. Versions with darker malts may have a dry, roasted finish. Low to moderate bitterness, enough to provide some balance but not enough to overpower the malt. Fruity esters moderate to none. Diacetyl and hop flavor low to none. Mouthfeel: Light to medium body. Generally low to medium-low carbonation. Roast-based versions may have a light astringency. Sweeter versions may seem to have a rather full mouthfeel for the gravity."
+                       cbf/ibu-min         10}))
 
 
 (def british-brown-ale
   "A malty, brown caramel-centric British ale without the roasted flavors of a Porter."
   (styles/build-style :british-brown-ale
-                      {:category        "Brown British Beer"
-                       :carb-min        1.5
-                       :fg-max          1.013
-                       :og-min          1.04
-                       :name            "British Brown Ale"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.042
-                       :fg-min          1.008
-                       :category-number "13"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "British mild ale or pale ale malt base with caramel malts. May also have small amounts darker malts (e.g., chocolate) to provide color and the nutty character. English hop varieties are most authentic."
-                       :examples        "Maxim Double Maxim, Newcastle Brown Ale, Riggwelter Yorkshire Ale, Samuel Smith's Nut Brown Ale, Wychwood Hobgoblin"
-                       :notes           "A malty, brown caramel-centric British ale without the roasted flavors of a Porter."
-                       :og-max          1.052
-                       :color-min       12.0
-                       :abv-max         0.054
-                       :color-max       22.0
-                       :profile         "Aroma: Light, sweet malt aroma with toffee, nutty, or light chocolate notes, and a light to heavy caramel quality. A light but appealing floral or earthy hop aroma may also be noticed. A light fruity aroma may be evident, but should not dominate. Appearance: Dark amber to dark reddish-brown color. Clear. Low to moderate off-white to light tan head. Flavor: Gentle to moderate malt sweetness, with a light to heavy caramel character and a medium to dry finish. Malt may also have a nutty, toasted, biscuity, toffee, or light chocolate character. Medium to medium-low bitterness. Malt-hop balance ranges from even to malt-focused; hop flavor low to none (floral or earthy qualities). Low to moderate fruity esters can be present. Mouthfeel: Medium-light to medium body. Medium to medium-high carbonation."
-                       :ibu-min         20}))
+                      {cbf/category        "Brown British Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.013
+                       cbf/og-min          1.04
+                       cbf/name            "British Brown Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.042
+                       cbf/fg-min          1.008
+                       cbf/category-number "13"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "British mild ale or pale ale malt base with caramel malts. May also have small amounts darker malts (e.g., chocolate) to provide color and the nutty character. English hop varieties are most authentic."
+                       cbf/examples        "Maxim Double Maxim, Newcastle Brown Ale, Riggwelter Yorkshire Ale, Samuel Smith's Nut Brown Ale, Wychwood Hobgoblin"
+                       cbf/notes           "A malty, brown caramel-centric British ale without the roasted flavors of a Porter."
+                       cbf/og-max          1.052
+                       cbf/color-min       12.0
+                       cbf/abv-max         0.054
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Light, sweet malt aroma with toffee, nutty, or light chocolate notes, and a light to heavy caramel quality. A light but appealing floral or earthy hop aroma may also be noticed. A light fruity aroma may be evident, but should not dominate. Appearance: Dark amber to dark reddish-brown color. Clear. Low to moderate off-white to light tan head. Flavor: Gentle to moderate malt sweetness, with a light to heavy caramel character and a medium to dry finish. Malt may also have a nutty, toasted, biscuity, toffee, or light chocolate character. Medium to medium-low bitterness. Malt-hop balance ranges from even to malt-focused; hop flavor low to none (floral or earthy qualities). Low to moderate fruity esters can be present. Mouthfeel: Medium-light to medium body. Medium to medium-high carbonation."
+                       cbf/ibu-min         20}))
 
 
 (def english-porter
@@ -62,27 +63,27 @@
    
    May have a range of roasted flavors, generally without burnt qualities, and often has a chocolate-caramel-malty profile."
   (styles/build-style :english-porter
-                      {:category        "Brown British Beer"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.04
-                       :name            "English Porter"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.04
-                       :fg-min          1.008
-                       :category-number "13"
-                       :carb-max        3.0
-                       :ibu-max         35
-                       :ingredients     "Grists vary, but something producing a dark color is always involved. Chocolate or other dark-roasted malts, caramel malt, brewing sugars, and the like are common. London-type porters often use brown malt as a characteristic flavor."
-                       :examples        "Burton Bridge Burton Porter, Fuller's London Porter, Nethergate Old Growler Porter, RCH Old Slug Porter, Samuel Smith Taddy Porter"
-                       :notes           "A moderate-strength brown beer with a restrained roasty character and bitterness. May have a range of roasted flavors, generally without burnt qualities, and often has a chocolate-caramel-malty profile."
-                       :og-max          1.052
-                       :color-min       20.0
-                       :abv-max         0.054
-                       :color-max       30.0
-                       :profile         "Aroma: Moderate to moderately low bready, biscuity, and toasty malt aroma with mild roastiness, and may have a chocolate quality. May also show some non-roasted malt character in support (caramelly, nutty, toffee-like and/or sweet). May have up to a moderate level of floral or earthy hops. Fruity esters moderate to none. Diacetyl low to none. Appearance: Light brown to dark brown in color, often with ruby highlights when held up to light. Good clarity, although may approach being opaque. Moderate off-white to light tan head with good to fair retention. Flavor: Moderate bready, biscuity, and toasty malt flavor includes a mild to moderate roastiness (frequently with a chocolate character) and often a significant caramel, nutty, and/or toffee character. May have other secondary flavors such as coffee, licorice, biscuits or toast in support. Should not have a significant burnt or harsh roasted flavor, although small amounts may contribute a bitter chocolate complexity. Earthy or floral hop flavor moderate to none. Medium-low to medium hop bitterness will vary the balance from slightly malty to slightly bitter. Usually fairly well-attenuated, although can be somewhat sweet. Diacetyl moderately-low to none. Moderate to low fruity esters. Mouthfeel: Medium-light to medium body. Moderately-low to moderately-high carbonation. Light to moderate creamy texture."
-                       :ibu-min         18}))
+                      {cbf/category        "Brown British Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.04
+                       cbf/name            "English Porter"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.04
+                       cbf/fg-min          1.008
+                       cbf/category-number "13"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         35
+                       cbf/ingredients     "Grists vary, but something producing a dark color is always involved. Chocolate or other dark-roasted malts, caramel malt, brewing sugars, and the like are common. London-type porters often use brown malt as a characteristic flavor."
+                       cbf/examples        "Burton Bridge Burton Porter, Fuller's London Porter, Nethergate Old Growler Porter, RCH Old Slug Porter, Samuel Smith Taddy Porter"
+                       cbf/notes           "A moderate-strength brown beer with a restrained roasty character and bitterness. May have a range of roasted flavors, generally without burnt qualities, and often has a chocolate-caramel-malty profile."
+                       cbf/og-max          1.052
+                       cbf/color-min       20.0
+                       cbf/abv-max         0.054
+                       cbf/color-max       30.0
+                       cbf/profile         "Aroma: Moderate to moderately low bready, biscuity, and toasty malt aroma with mild roastiness, and may have a chocolate quality. May also show some non-roasted malt character in support (caramelly, nutty, toffee-like and/or sweet). May have up to a moderate level of floral or earthy hops. Fruity esters moderate to none. Diacetyl low to none. Appearance: Light brown to dark brown in color, often with ruby highlights when held up to light. Good clarity, although may approach being opaque. Moderate off-white to light tan head with good to fair retention. Flavor: Moderate bready, biscuity, and toasty malt flavor includes a mild to moderate roastiness (frequently with a chocolate character) and often a significant caramel, nutty, and/or toffee character. May have other secondary flavors such as coffee, licorice, biscuits or toast in support. Should not have a significant burnt or harsh roasted flavor, although small amounts may contribute a bitter chocolate complexity. Earthy or floral hop flavor moderate to none. Medium-low to medium hop bitterness will vary the balance from slightly malty to slightly bitter. Usually fairly well-attenuated, although can be somewhat sweet. Diacetyl moderately-low to none. Moderate to low fruity esters. Mouthfeel: Medium-light to medium body. Moderately-low to moderately-high carbonation. Light to moderate creamy texture."
+                       cbf/ibu-min         18}))
 
 
 (def brown-british-beer

--- a/src/common_beer_data/styles/bjcp_2015/czech_lager.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/czech_lager.cljc
@@ -1,32 +1,33 @@
 (ns common-beer-data.styles.bjcp-2015.czech-lager
   "2015 BJCP guidelines on Czech Lagers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def czech-pale-lager
   "A lighter-bodied, rich, refreshing, hoppy, bitter pale Czech lager having the familiar flavors of the stronger Czech Premium Pale Lager (Pilsner-type) beer but in a lower alcohol, lighter-bodied, and slightly less intense format."
   (styles/build-style :czech-pale-lager
-                      {:category        "Czech Lager"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.028
-                       :name            "Czech Pale Lager"
-                       :type            "Lager"
-                       :style-letter    "A"
-                       :abv-min         0.03
-                       :fg-min          1.008
-                       :category-number "3"
-                       :carb-max        3.0
-                       :ibu-max         35
-                       :ingredients     "Soft water with low sulfate and carbonate content, Saazer-type hops, Czech Pilsner malt, Czech lager yeast. Low ion water provides a distinctively soft, rounded hop profile despite high hopping rates."
-                       :examples        "Březňák Světlé výčepní pivo, Notch Session Pils, Pivovar Kout na Šumavě Koutská 10°, Únětické pivo 10°"
-                       :notes           "A lighter-bodied, rich, refreshing, hoppy, bitter pale Czech lager having the familiar flavors of the stronger Czech Premium Pale Lager (Pilsner-type) beer but in a lower alcohol, lighter-bodied, and slightly less intense format."
-                       :og-max          1.044
-                       :color-min       3.0
-                       :abv-max         0.041
-                       :color-max       6.0
-                       :profile         "Aroma: Light to moderate bready-rich malt combined with light to moderate spicy or herbal hop bouquet; the balance between the malt and hops may vary. Faint hint of caramel is acceptable. Light (but never intrusive) diacetyl and light, fruity hop-derived esters are acceptable, but need not be present. No sulfur. Appearance: Light gold to deep gold color. Brilliant to very clear, with a long-lasting, creamy white head. Flavor: Medium-low to medium bready-rich malt flavor with a rounded, hoppy finish. Low to medium-high spicy or herbal hop flavor. Bitterness is prominent but never harsh. Flavorful and refreshing. Diacetyl or fruity esters are acceptable at low levels, but need not be present and should never be overbearing. Mouthfeel: Medium-light to medium body. Moderate carbonation."
-                       :ibu-min         20}))
+                      {cbf/category        "Czech Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.028
+                       cbf/name            "Czech Pale Lager"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.03
+                       cbf/fg-min          1.008
+                       cbf/category-number "3"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         35
+                       cbf/ingredients     "Soft water with low sulfate and carbonate content, Saazer-type hops, Czech Pilsner malt, Czech lager yeast. Low ion water provides a distinctively soft, rounded hop profile despite high hopping rates."
+                       cbf/examples        "Březňák Světlé výčepní pivo, Notch Session Pils, Pivovar Kout na Šumavě Koutská 10°, Únětické pivo 10°"
+                       cbf/notes           "A lighter-bodied, rich, refreshing, hoppy, bitter pale Czech lager having the familiar flavors of the stronger Czech Premium Pale Lager (Pilsner-type) beer but in a lower alcohol, lighter-bodied, and slightly less intense format."
+                       cbf/og-max          1.044
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.041
+                       cbf/color-max       6.0
+                       cbf/profile         "Aroma: Light to moderate bready-rich malt combined with light to moderate spicy or herbal hop bouquet; the balance between the malt and hops may vary. Faint hint of caramel is acceptable. Light (but never intrusive) diacetyl and light, fruity hop-derived esters are acceptable, but need not be present. No sulfur. Appearance: Light gold to deep gold color. Brilliant to very clear, with a long-lasting, creamy white head. Flavor: Medium-low to medium bready-rich malt flavor with a rounded, hoppy finish. Low to medium-high spicy or herbal hop flavor. Bitterness is prominent but never harsh. Flavorful and refreshing. Diacetyl or fruity esters are acceptable at low levels, but need not be present and should never be overbearing. Mouthfeel: Medium-light to medium body. Moderate carbonation."
+                       cbf/ibu-min         20}))
 
 
 (def czech-premium-pale-lager
@@ -35,27 +36,27 @@
    Complex yet well-balanced and refreshing. 
    The malt flavors are complex for a Pilsner-type beer, and the bitterness is strong but clean and without harshness, which gives a rounded impression that enhances drinkability."
   (styles/build-style :czech-premium-pale-lager
-                      {:category        "Czech Lager"
-                       :carb-min        1.5
-                       :fg-max          1.017
-                       :og-min          1.044
-                       :name            "Czech Premium Pale Lager"
-                       :type            "Lager"
-                       :style-letter    "B"
-                       :abv-min         0.042
-                       :fg-min          1.013
-                       :category-number "3"
-                       :carb-max        3.0
-                       :ibu-max         45
-                       :ingredients     "Soft water with low sulfate and carbonate content, Saazer-type hops, Czech malt, Czech lager yeast. Low ion water provides a distinctively soft, rounded hop profile despite high hopping rates. The bitterness level of some larger commercial examples has dropped in recent years, although not as much as in many contemporary German examples."
-                       :examples        "Bernard Sváteční ležák, Gambrinus Premium, Kout na Šumavě Koutská 12°, Pilsner Urquell, Pivovar Jihlava Ježek 11°, Primátor Premium, Únětická 12°"
-                       :notes           "Rich, characterful, pale Czech lager, with considerable malt and hop character and a long, rounded finish. Complex yet well-balanced and refreshing. The malt flavors are complex for a Pilsner-type beer, and the bitterness is strong but clean and without harshness, which gives a rounded impression that enhances drinkability."
-                       :og-max          1.06
-                       :color-min       3.5
-                       :abv-max         0.058
-                       :color-max       6.0
-                       :profile         "Aroma: Medium to medium-high bready-rich malt and medium-low to medium-high spicy, floral, or herbal hop bouquet; though the balance between the malt and hops may vary, the interplay is rich and complex. Light diacetyl, or very low fruity hop-derived esters are acceptable, but need not be present. Appearance: Gold to deep gold color. Brilliant to very clear clarity. Dense, long-lasting, creamy white head. Flavor: Rich, complex, bready maltiness combined with a pronounced yet soft and rounded bitterness and floral and spicy hop flavor. Malt and hop flavors are medium to medium-high, and the malt may contain a slight impression of caramel. Bitterness is prominent but never harsh. The long finish can be balanced towards hops or malt but is never aggressively tilted either way. Light to moderate diacetyl and low hop-derived esters are acceptable, but need not be present. Mouthfeel: Medium body. Moderate to low carbonation."
-                       :ibu-min         30}))
+                      {cbf/category        "Czech Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.017
+                       cbf/og-min          1.044
+                       cbf/name            "Czech Premium Pale Lager"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.042
+                       cbf/fg-min          1.013
+                       cbf/category-number "3"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         45
+                       cbf/ingredients     "Soft water with low sulfate and carbonate content, Saazer-type hops, Czech malt, Czech lager yeast. Low ion water provides a distinctively soft, rounded hop profile despite high hopping rates. The bitterness level of some larger commercial examples has dropped in recent years, although not as much as in many contemporary German examples."
+                       cbf/examples        "Bernard Sváteční ležák, Gambrinus Premium, Kout na Šumavě Koutská 12°, Pilsner Urquell, Pivovar Jihlava Ježek 11°, Primátor Premium, Únětická 12°"
+                       cbf/notes           "Rich, characterful, pale Czech lager, with considerable malt and hop character and a long, rounded finish. Complex yet well-balanced and refreshing. The malt flavors are complex for a Pilsner-type beer, and the bitterness is strong but clean and without harshness, which gives a rounded impression that enhances drinkability."
+                       cbf/og-max          1.06
+                       cbf/color-min       3.5
+                       cbf/abv-max         0.058
+                       cbf/color-max       6.0
+                       cbf/profile         "Aroma: Medium to medium-high bready-rich malt and medium-low to medium-high spicy, floral, or herbal hop bouquet; though the balance between the malt and hops may vary, the interplay is rich and complex. Light diacetyl, or very low fruity hop-derived esters are acceptable, but need not be present. Appearance: Gold to deep gold color. Brilliant to very clear clarity. Dense, long-lasting, creamy white head. Flavor: Rich, complex, bready maltiness combined with a pronounced yet soft and rounded bitterness and floral and spicy hop flavor. Malt and hop flavors are medium to medium-high, and the malt may contain a slight impression of caramel. Bitterness is prominent but never harsh. The long finish can be balanced towards hops or malt but is never aggressively tilted either way. Light to moderate diacetyl and low hop-derived esters are acceptable, but need not be present. Mouthfeel: Medium body. Moderate to low carbonation."
+                       cbf/ibu-min         30}))
 
 
 (def czech-amber-lager
@@ -63,27 +64,27 @@
    
    The malt flavors can vary quite a bit, leading to different interpretations ranging from drier, bready, and slightly biscuity to sweeter and somewhat caramelly."
   (styles/build-style :czech-amber-lager
-                      {:category        "Czech Lager"
-                       :carb-min        1.5
-                       :fg-max          1.017
-                       :og-min          1.044
-                       :name            "Czech Amber Lager"
-                       :type            "Lager"
-                       :style-letter    "C"
-                       :abv-min         0.044
-                       :fg-min          1.013
-                       :category-number "3"
-                       :carb-max        3.0
-                       :ibu-max         35
-                       :ingredients     "Pilsner and caramel malts, but Vienna and Munich malts may also be used. Low mineral content water, Saazer-type hops, Czech lager yeast."
-                       :examples        "Bernard Jantarový ležák, Pivovar Vysoký Chlumec Démon, Primátor polotmavý 13°, Strakonický Dudák Klostermann polotmavý ležák 13°"
-                       :notes           "Malt-driven amber Czech lager with hop character that can vary from low to quite significant. The malt flavors can vary quite a bit, leading to different interpretations ranging from drier, bready, and slightly biscuity to sweeter and somewhat caramelly."
-                       :og-max          1.06
-                       :color-min       10.0
-                       :abv-max         0.058
-                       :color-max       16.0
-                       :profile         "Aroma: Moderate intensity, rich malt aroma that can be either bready and Maillard product-dominant or slightly caramelly and candy-like. Spicy, floral or herbal hop character may be moderate to none. Clean lager character, though low fruity esters (stone fruit or berries) may be present. Diacetyl is optional and can range from low to none. Appearance: Deep amber to copper color. Clear to bright clarity. Large, off-white, persistent head. Flavor: Complex malt flavor is dominant (medium to medium-high), though its nature may vary from dry and Maillard product-dominant to caramelly and almost sweet. Some examples have a candy-like to graham-cracker malt character. Low to moderate spicy hop flavor. Prominent but clean hop bitterness provides a balanced finish. Subtle plum or berry esters optional. Low diacetyl optional. No roasted malt flavor. Finish may vary from dry and hoppy to relatively sweet. Mouthfeel: Medium-full to medium body. Soft and round, often with a gentle creaminess. Moderate to low carbonation."
-                       :ibu-min         20}))
+                      {cbf/category        "Czech Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.017
+                       cbf/og-min          1.044
+                       cbf/name            "Czech Amber Lager"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.044
+                       cbf/fg-min          1.013
+                       cbf/category-number "3"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         35
+                       cbf/ingredients     "Pilsner and caramel malts, but Vienna and Munich malts may also be used. Low mineral content water, Saazer-type hops, Czech lager yeast."
+                       cbf/examples        "Bernard Jantarový ležák, Pivovar Vysoký Chlumec Démon, Primátor polotmavý 13°, Strakonický Dudák Klostermann polotmavý ležák 13°"
+                       cbf/notes           "Malt-driven amber Czech lager with hop character that can vary from low to quite significant. The malt flavors can vary quite a bit, leading to different interpretations ranging from drier, bready, and slightly biscuity to sweeter and somewhat caramelly."
+                       cbf/og-max          1.06
+                       cbf/color-min       10.0
+                       cbf/abv-max         0.058
+                       cbf/color-max       16.0
+                       cbf/profile         "Aroma: Moderate intensity, rich malt aroma that can be either bready and Maillard product-dominant or slightly caramelly and candy-like. Spicy, floral or herbal hop character may be moderate to none. Clean lager character, though low fruity esters (stone fruit or berries) may be present. Diacetyl is optional and can range from low to none. Appearance: Deep amber to copper color. Clear to bright clarity. Large, off-white, persistent head. Flavor: Complex malt flavor is dominant (medium to medium-high), though its nature may vary from dry and Maillard product-dominant to caramelly and almost sweet. Some examples have a candy-like to graham-cracker malt character. Low to moderate spicy hop flavor. Prominent but clean hop bitterness provides a balanced finish. Subtle plum or berry esters optional. Low diacetyl optional. No roasted malt flavor. Finish may vary from dry and hoppy to relatively sweet. Mouthfeel: Medium-full to medium body. Soft and round, often with a gentle creaminess. Moderate to low carbonation."
+                       cbf/ibu-min         20}))
 
 
 (def czech-dark-lager
@@ -91,27 +92,27 @@
    
    Malty with an interesting and complex flavor profile, with variable levels of hopping providing a range of possible interpretations."
   (styles/build-style :czech-dark-lager
-                      {:category        "Czech Lager"
-                       :carb-min        1.5
-                       :fg-max          1.017
-                       :og-min          1.044
-                       :name            "Czech Dark Lager"
-                       :type            "Lager"
-                       :style-letter    "D"
-                       :abv-min         0.044
-                       :fg-min          1.013
-                       :category-number "3"
-                       :carb-max        3.0
-                       :ibu-max         34
-                       :ingredients     "Pilsner and dark caramel malts with the addition of debittered roasted malts are most common, but additions of Vienna or Munich malt are also appropriate. Low mineral content water, Saazer-type hops, Czech lager yeast. Any fruity esters are typically from malt, not yeast."
-                       :examples        "Bohemian Brewery Cherny Bock 4%, Budweiser Budvar B:Dark tmavý ležák, Devils Backbone Morana, Kout na Šumavě Koutský tmavý speciál 14°, Notch Černé Pivo, Pivovar Březnice Herold, U Fleků Flekovský tmavý 13° ležák"
-                       :notes           "A rich, dark, malty Czech lager with a roast character that can vary from almost absent to quite prominent. Malty with an interesting and complex flavor profile, with variable levels of hopping providing a range of possible interpretations."
-                       :og-max          1.06
-                       :color-min       14.0
-                       :abv-max         0.058
-                       :color-max       35.0
-                       :profile         "Aroma: Medium to medium-high rich, deep, sometimes sweet maltiness, with optional qualities such as bread crusts, toast, nuts, cola, dark fruit, or caramel. Roasted malt characters such as chocolate or sweetened coffee can vary from moderate to none but should not overwhelm the base malt character. Low, spicy hop aroma is optional. Low diacetyl and low fruity esters (plums or berries) may be present. Appearance: Dark copper to almost black color, often with a red or garnet tint. Clear to bright clarity. Large, off-white to tan, persistent head. Flavor: Medium to medium-high deep, complex maltiness dominates, typically with malty-rich Maillard products and a light to moderate residual malt sweetness. Malt flavors such as caramel, toast, nuts, licorice, dried dark fruit, chocolate and coffee may also be present, with very low to moderate roast character. Spicy hop flavor can be moderately-low to none. Hop bitterness may be moderate to medium-low but should be perceptible. Balance can vary from malty to relatively well-balanced to gently hop-forward. Low to moderate diacetyl and light plum or berry esters may be present. Mouthfeel: Medium to medium-full body, considerable mouthfeel without being heavy or cloying. Moderately creamy in texture. Smooth. Moderate to low carbonation. Can have a slight alcohol warmth in stronger versions."
-                       :ibu-min         18}))
+                      {cbf/category        "Czech Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.017
+                       cbf/og-min          1.044
+                       cbf/name            "Czech Dark Lager"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "D"
+                       cbf/abv-min         0.044
+                       cbf/fg-min          1.013
+                       cbf/category-number "3"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         34
+                       cbf/ingredients     "Pilsner and dark caramel malts with the addition of debittered roasted malts are most common, but additions of Vienna or Munich malt are also appropriate. Low mineral content water, Saazer-type hops, Czech lager yeast. Any fruity esters are typically from malt, not yeast."
+                       cbf/examples        "Bohemian Brewery Cherny Bock 4%, Budweiser Budvar B:Dark tmavý ležák, Devils Backbone Morana, Kout na Šumavě Koutský tmavý speciál 14°, Notch Černé Pivo, Pivovar Březnice Herold, U Fleků Flekovský tmavý 13° ležák"
+                       cbf/notes           "A rich, dark, malty Czech lager with a roast character that can vary from almost absent to quite prominent. Malty with an interesting and complex flavor profile, with variable levels of hopping providing a range of possible interpretations."
+                       cbf/og-max          1.06
+                       cbf/color-min       14.0
+                       cbf/abv-max         0.058
+                       cbf/color-max       35.0
+                       cbf/profile         "Aroma: Medium to medium-high rich, deep, sometimes sweet maltiness, with optional qualities such as bread crusts, toast, nuts, cola, dark fruit, or caramel. Roasted malt characters such as chocolate or sweetened coffee can vary from moderate to none but should not overwhelm the base malt character. Low, spicy hop aroma is optional. Low diacetyl and low fruity esters (plums or berries) may be present. Appearance: Dark copper to almost black color, often with a red or garnet tint. Clear to bright clarity. Large, off-white to tan, persistent head. Flavor: Medium to medium-high deep, complex maltiness dominates, typically with malty-rich Maillard products and a light to moderate residual malt sweetness. Malt flavors such as caramel, toast, nuts, licorice, dried dark fruit, chocolate and coffee may also be present, with very low to moderate roast character. Spicy hop flavor can be moderately-low to none. Hop bitterness may be moderate to medium-low but should be perceptible. Balance can vary from malty to relatively well-balanced to gently hop-forward. Low to moderate diacetyl and light plum or berry esters may be present. Mouthfeel: Medium to medium-full body, considerable mouthfeel without being heavy or cloying. Moderately creamy in texture. Smooth. Moderate to low carbonation. Can have a slight alcohol warmth in stronger versions."
+                       cbf/ibu-min         18}))
 
 
 (def czech-lager

--- a/src/common_beer_data/styles/bjcp_2015/dark_british_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/dark_british_beer.cljc
@@ -1,32 +1,33 @@
 (ns common-beer-data.styles.bjcp-2015.dark-british-beer
   "2015 BJCP guidelines on Dark British Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def sweet-stout
   "A very dark, sweet, full-bodied, slightly roasty ale that can suggest coffee-and-cream, or sweetened espresso."
   (styles/build-style :sweet-stout
-                      {:category        "Dark British Beer"
-                       :carb-min        1.5
-                       :fg-max          1.024
-                       :og-min          1.044
-                       :name            "Sweet Stout"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.04
-                       :fg-min          1.012
-                       :category-number "16"
-                       :carb-max        3.0
-                       :ibu-max         40
-                       :ingredients     "The sweetness in most Sweet Stouts comes from a lower bitterness level than most other stouts and a high percentage of unfermentable dextrins. Lactose, an unfermentable sugar, is frequently added to provide additional residual sweetness. Base of pale malt, and may use roasted barley, black malt, chocolate malt, crystal malt, and adjuncts such as maize or brewing sugars."
-                       :examples        "Bristol Beer Factory Milk Stout, Left Hand Milk Stout, Lancaster Milk Stout, Mackeson's XXX Stout, Marston's Oyster Stout, Samuel Adams Cream Stout"
-                       :notes           "A very dark, sweet, full-bodied, slightly roasty ale that can suggest coffee-and-cream, or sweetened espresso."
-                       :og-max          1.06
-                       :color-min       30.0
-                       :abv-max         0.06
-                       :color-max       40.0
-                       :profile         "Aroma: Mild roasted grain aroma, sometimes with coffee and/or chocolate notes. An impression of cream-like sweetness often exists. Fruitiness can be low to moderately high. Diacetyl low to none. Hop aroma low to none, with floral or earthy notes. Appearance: Very dark brown to black in color. Can be opaque (if not, it should be clear). Creamy tan to brown head. Flavor: Dark roasted grain/malt impression with coffee and/or chocolate flavors dominate the palate. Hop bitterness is moderate. Medium to high sweetness provides a counterpoint to the roasted character and hop bitterness, and lasts into the finish. Low to moderate fruity esters. Diacetyl low to none. The balance between dark grains/malts and sweetness can vary, from quite sweet to moderately dry and somewhat roasty. Mouthfeel: Medium-full to full-bodied and creamy. Low to moderate carbonation. High residual sweetness from unfermented sugars enhances the full-tasting mouthfeel."
-                       :ibu-min         20}))
+                      {cbf/category        "Dark British Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.024
+                       cbf/og-min          1.044
+                       cbf/name            "Sweet Stout"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.04
+                       cbf/fg-min          1.012
+                       cbf/category-number "16"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         40
+                       cbf/ingredients     "The sweetness in most Sweet Stouts comes from a lower bitterness level than most other stouts and a high percentage of unfermentable dextrins. Lactose, an unfermentable sugar, is frequently added to provide additional residual sweetness. Base of pale malt, and may use roasted barley, black malt, chocolate malt, crystal malt, and adjuncts such as maize or brewing sugars."
+                       cbf/examples        "Bristol Beer Factory Milk Stout, Left Hand Milk Stout, Lancaster Milk Stout, Mackeson's XXX Stout, Marston's Oyster Stout, Samuel Adams Cream Stout"
+                       cbf/notes           "A very dark, sweet, full-bodied, slightly roasty ale that can suggest coffee-and-cream, or sweetened espresso."
+                       cbf/og-max          1.06
+                       cbf/color-min       30.0
+                       cbf/abv-max         0.06
+                       cbf/color-max       40.0
+                       cbf/profile         "Aroma: Mild roasted grain aroma, sometimes with coffee and/or chocolate notes. An impression of cream-like sweetness often exists. Fruitiness can be low to moderately high. Diacetyl low to none. Hop aroma low to none, with floral or earthy notes. Appearance: Very dark brown to black in color. Can be opaque (if not, it should be clear). Creamy tan to brown head. Flavor: Dark roasted grain/malt impression with coffee and/or chocolate flavors dominate the palate. Hop bitterness is moderate. Medium to high sweetness provides a counterpoint to the roasted character and hop bitterness, and lasts into the finish. Low to moderate fruity esters. Diacetyl low to none. The balance between dark grains/malts and sweetness can vary, from quite sweet to moderately dry and somewhat roasty. Mouthfeel: Medium-full to full-bodied and creamy. Low to moderate carbonation. High residual sweetness from unfermented sugars enhances the full-tasting mouthfeel."
+                       cbf/ibu-min         20}))
 
 
 (def oatmeal-stout
@@ -34,79 +35,79 @@
    
    The sweetness, balance, and oatmeal impression can vary considerably."
   (styles/build-style :oatmeal-stout
-                      {:category        "Dark British Beer"
-                       :carb-min        1.5
-                       :fg-max          1.018
-                       :og-min          1.045
-                       :name            "Oatmeal Stout"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.042
-                       :fg-min          1.01
-                       :category-number "16"
-                       :carb-max        3.0
-                       :ibu-max         40
-                       :ingredients     "Pale, caramel and dark roasted malts (often chocolate) and grains. Oatmeal or malted oats (5-20% or more) used to enhance fullness of body and complexity of flavor. Hops primarily for bittering. Can use brewing sugars or syrups. English ale yeast."
-                       :examples        "Anderson Valley Barney Flats Oatmeal Stout, Broughton Scottish Oatmeal Stout, Figueroa Mountain Stagecoach Stout, St-Ambroise Oatmeal Stout, Samuel Smith Oatmeal Stout, Young's Oatmeal Stout"
-                       :notes           "A very dark, full-bodied, roasty, malty ale with a complementary oatmeal flavor. The sweetness, balance, and oatmeal impression can vary considerably."
-                       :og-max          1.065
-                       :color-min       22.0
-                       :abv-max         0.059
-                       :color-max       40.0
-                       :profile         "Aroma: Mild roasted grain aromas, generally with a coffee-like character. A light malty sweetness can suggest a coffee-and-cream impression. Fruitiness should be low to medium-high. Diacetyl medium-low to none. Hop aroma medium-low to none, earthy or floral. A light grainy-nutty oatmeal aroma is optional. Appearance: Medium brown to black in color. Thick, creamy, persistent tan- to brown-colored head. Can be opaque (if not, it should be clear). Flavor: Similar to the aroma, with a mild roasted coffee to coffee-and-cream flavor, and low to moderately-high fruitiness. Oats and dark roasted grains provide some flavor complexity; the oats can add a nutty, grainy or earthy flavor. Dark grains can combine with malt sweetness to give the impression of milk chocolate or coffee with cream. Medium hop bitterness with the balance toward malt. Medium-sweet to medium-dry finish. Diacetyl medium-low to none. Hop flavor medium-low to none, typically earthy or floral. Mouthfeel: Medium-full to full body, with a smooth, silky, velvety, sometimes an almost oily slickness from the oatmeal. Creamy. Medium to medium-high carbonation."
-                       :ibu-min         25}))
+                      {cbf/category        "Dark British Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.018
+                       cbf/og-min          1.045
+                       cbf/name            "Oatmeal Stout"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.042
+                       cbf/fg-min          1.01
+                       cbf/category-number "16"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         40
+                       cbf/ingredients     "Pale, caramel and dark roasted malts (often chocolate) and grains. Oatmeal or malted oats (5-20% or more) used to enhance fullness of body and complexity of flavor. Hops primarily for bittering. Can use brewing sugars or syrups. English ale yeast."
+                       cbf/examples        "Anderson Valley Barney Flats Oatmeal Stout, Broughton Scottish Oatmeal Stout, Figueroa Mountain Stagecoach Stout, St-Ambroise Oatmeal Stout, Samuel Smith Oatmeal Stout, Young's Oatmeal Stout"
+                       cbf/notes           "A very dark, full-bodied, roasty, malty ale with a complementary oatmeal flavor. The sweetness, balance, and oatmeal impression can vary considerably."
+                       cbf/og-max          1.065
+                       cbf/color-min       22.0
+                       cbf/abv-max         0.059
+                       cbf/color-max       40.0
+                       cbf/profile         "Aroma: Mild roasted grain aromas, generally with a coffee-like character. A light malty sweetness can suggest a coffee-and-cream impression. Fruitiness should be low to medium-high. Diacetyl medium-low to none. Hop aroma medium-low to none, earthy or floral. A light grainy-nutty oatmeal aroma is optional. Appearance: Medium brown to black in color. Thick, creamy, persistent tan- to brown-colored head. Can be opaque (if not, it should be clear). Flavor: Similar to the aroma, with a mild roasted coffee to coffee-and-cream flavor, and low to moderately-high fruitiness. Oats and dark roasted grains provide some flavor complexity; the oats can add a nutty, grainy or earthy flavor. Dark grains can combine with malt sweetness to give the impression of milk chocolate or coffee with cream. Medium hop bitterness with the balance toward malt. Medium-sweet to medium-dry finish. Diacetyl medium-low to none. Hop flavor medium-low to none, typically earthy or floral. Mouthfeel: Medium-full to full body, with a smooth, silky, velvety, sometimes an almost oily slickness from the oatmeal. Creamy. Medium to medium-high carbonation."
+                       cbf/ibu-min         25}))
 
 
 (def tropical-stout
   "A very dark, sweet, fruity, moderately strong ale with smooth roasty flavors without a burnt harshness."
   (styles/build-style :tropical-stout
-                      {:category        "Dark British Beer"
-                       :carb-min        1.5
-                       :fg-max          1.018
-                       :og-min          1.056
-                       :name            "Tropical Stout"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.055
-                       :fg-min          1.01
-                       :category-number "16"
-                       :carb-max        3.0
-                       :ibu-max         50
-                       :ingredients     "Similar to a sweet stout, but with more gravity. Pale and dark roasted malts and grains. Hops mostly for bitterness. May use adjuncts and sugar to boost gravity. Typically made with warm-fermented lager yeast."
-                       :examples        "ABC Extra Stout, Dragon Stout, Jamaica Stout, Lion Stout, Royal Extra Stout"
-                       :notes           "A very dark, sweet, fruity, moderately strong ale with smooth roasty flavors without a burnt harshness."
-                       :og-max          1.075
-                       :color-min       30.0
-                       :abv-max         0.08
-                       :color-max       40.0
-                       :profile         "Aroma: Sweetness evident, moderate to high intensity. Roasted grain aromas moderate to high, and can have coffee or chocolate notes. Fruitiness medium to high. May have a molasses, licorice, dried fruit, and/or vinous aromatics. Stronger versions can have a subtle clean aroma of alcohol. Hop aroma low to none. Diacetyl low to none. Appearance: Very deep brown to black in color. Clarity usually obscured by deep color (if not opaque, should be clear). Large tan to brown head with good retention. Flavor: Quite sweet with a smooth dark grain flavors, and restrained bitterness. Roasted grain and malt character can be moderate to high with a smooth coffee or chocolate flavor, although the roast character is moderated in the balance by the sweet finish. Moderate to high fruity esters. Can have a sweet, dark rum-like quality. Little to no hop flavor. Medium-low to no diacetyl. Mouthfeel: Medium-full to full body, often with a smooth, creamy character. May give a warming (but never hot) impression from alcohol presence. Moderate to moderately-high carbonation."
-                       :ibu-min         30}))
+                      {cbf/category        "Dark British Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.018
+                       cbf/og-min          1.056
+                       cbf/name            "Tropical Stout"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.055
+                       cbf/fg-min          1.01
+                       cbf/category-number "16"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         50
+                       cbf/ingredients     "Similar to a sweet stout, but with more gravity. Pale and dark roasted malts and grains. Hops mostly for bitterness. May use adjuncts and sugar to boost gravity. Typically made with warm-fermented lager yeast."
+                       cbf/examples        "ABC Extra Stout, Dragon Stout, Jamaica Stout, Lion Stout, Royal Extra Stout"
+                       cbf/notes           "A very dark, sweet, fruity, moderately strong ale with smooth roasty flavors without a burnt harshness."
+                       cbf/og-max          1.075
+                       cbf/color-min       30.0
+                       cbf/abv-max         0.08
+                       cbf/color-max       40.0
+                       cbf/profile         "Aroma: Sweetness evident, moderate to high intensity. Roasted grain aromas moderate to high, and can have coffee or chocolate notes. Fruitiness medium to high. May have a molasses, licorice, dried fruit, and/or vinous aromatics. Stronger versions can have a subtle clean aroma of alcohol. Hop aroma low to none. Diacetyl low to none. Appearance: Very deep brown to black in color. Clarity usually obscured by deep color (if not opaque, should be clear). Large tan to brown head with good retention. Flavor: Quite sweet with a smooth dark grain flavors, and restrained bitterness. Roasted grain and malt character can be moderate to high with a smooth coffee or chocolate flavor, although the roast character is moderated in the balance by the sweet finish. Moderate to high fruity esters. Can have a sweet, dark rum-like quality. Little to no hop flavor. Medium-low to no diacetyl. Mouthfeel: Medium-full to full body, often with a smooth, creamy character. May give a warming (but never hot) impression from alcohol presence. Moderate to moderately-high carbonation."
+                       cbf/ibu-min         30}))
 
 
 (def foreign-extra-stout
   "A very dark, moderately strong, fairly dry, stout with prominent roast flavors."
   (styles/build-style :foreign-extra-stout
-                      {:category        "Dark British Beer"
-                       :carb-min        1.5
-                       :fg-max          1.018
-                       :og-min          1.056
-                       :name            "Foreign Extra Stout"
-                       :type            "Ale"
-                       :style-letter    "D"
-                       :abv-min         0.063
-                       :fg-min          1.01
-                       :category-number "16"
-                       :carb-max        3.0
-                       :ibu-max         70
-                       :ingredients     "Pale and dark roasted malts and grains, historically also could have used brown and amber malts. Hops mostly for bitterness, typically English varieties. May use adjuncts and sugar to boost gravity."
-                       :examples        "Coopers Best Extra Stout, Guinness Foreign Extra Stout, The Kernel Export Stout, Ridgeway Foreign Export Stout, Southwark Old Stout"
-                       :notes           "A very dark, moderately strong, fairly dry, stout with prominent roast flavors."
-                       :og-max          1.075
-                       :color-min       30.0
-                       :abv-max         0.08
-                       :color-max       40.0
-                       :profile         "Aroma: Moderate to high roasted grain aromas, often with coffee, chocolate and/or lightly burnt notes. Low to medium fruitiness. May have a sweet aroma, or molasses, licorice, dried fruit, and/or vinous aromatics. Stronger versions can have a subtle, clean aroma of alcohol. Hop aroma moderately low to none, can be earthy, herbal or floral. Diacetyl low to none. Appearance: Very deep brown to black in color. Clarity usually obscured by deep color (if not opaque, should be clear). Large tan to brown head with good retention. Flavor: Moderate to high roasted grain and malt flavor with a coffee, chocolate, or lightly burnt grain character, although without a sharp bite. Moderately dry. Low to medium esters. Medium to high bitterness. Moderate to no hop flavor, can be earthy, herbal, or floral. Diacetyl medium-low to none. Mouthfeel: Medium-full to full body, often with a smooth, sometimes creamy character. May give a warming (but never hot) impression from alcohol presence. Moderate to moderately-high carbonation."
-                       :ibu-min         50}))
+                      {cbf/category        "Dark British Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.018
+                       cbf/og-min          1.056
+                       cbf/name            "Foreign Extra Stout"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "D"
+                       cbf/abv-min         0.063
+                       cbf/fg-min          1.01
+                       cbf/category-number "16"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         70
+                       cbf/ingredients     "Pale and dark roasted malts and grains, historically also could have used brown and amber malts. Hops mostly for bitterness, typically English varieties. May use adjuncts and sugar to boost gravity."
+                       cbf/examples        "Coopers Best Extra Stout, Guinness Foreign Extra Stout, The Kernel Export Stout, Ridgeway Foreign Export Stout, Southwark Old Stout"
+                       cbf/notes           "A very dark, moderately strong, fairly dry, stout with prominent roast flavors."
+                       cbf/og-max          1.075
+                       cbf/color-min       30.0
+                       cbf/abv-max         0.08
+                       cbf/color-max       40.0
+                       cbf/profile         "Aroma: Moderate to high roasted grain aromas, often with coffee, chocolate and/or lightly burnt notes. Low to medium fruitiness. May have a sweet aroma, or molasses, licorice, dried fruit, and/or vinous aromatics. Stronger versions can have a subtle, clean aroma of alcohol. Hop aroma moderately low to none, can be earthy, herbal or floral. Diacetyl low to none. Appearance: Very deep brown to black in color. Clarity usually obscured by deep color (if not opaque, should be clear). Large tan to brown head with good retention. Flavor: Moderate to high roasted grain and malt flavor with a coffee, chocolate, or lightly burnt grain character, although without a sharp bite. Moderately dry. Low to medium esters. Medium to high bitterness. Moderate to no hop flavor, can be earthy, herbal, or floral. Diacetyl medium-low to none. Mouthfeel: Medium-full to full body, often with a smooth, sometimes creamy character. May give a warming (but never hot) impression from alcohol presence. Moderate to moderately-high carbonation."
+                       cbf/ibu-min         50}))
 
 
 (def dark-british-beer

--- a/src/common_beer_data/styles/bjcp_2015/dark_european_lager.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/dark_european_lager.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.dark-european-lager
   "2015 BJCP guidelines on Dark European Lagers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def munich-dunkel
@@ -8,27 +9,27 @@
    
    Deeply bready-toasty, often with chocolate-like flavors in the freshest examples, but never harsh, roasty, or astringent; a decidedly malt-balanced beer, yet still easily drinkable."
   (styles/build-style :munich-dunkel
-                      {:category        "Dark European Lager"
-                       :carb-min        1.5
-                       :fg-max          1.016
-                       :og-min          1.048
-                       :name            "Munich Dunkel"
-                       :type            "Lager"
-                       :style-letter    "A"
-                       :abv-min         0.045
-                       :fg-min          1.01
-                       :category-number "8"
-                       :carb-max        3.0
-                       :ibu-max         28
-                       :ingredients     "Grist is traditionally made up of German Munich malt (up to 100% in some cases) with the remainder German Pilsner malt. Small amounts of crystal malt can add dextrins and color but should not introduce excessive residual sweetness. Slight additions of roasted malts (such as Carafa or chocolate) may be used to improve color but should not add strong flavors. Traditional German hop varieties and German lager yeast strains should be used. Often decoction mashed (up to a triple decoction) to enhance the malt flavors and create the depth of color."
-                       :examples        "Ayinger Altbairisch Dunkel, Chuckanut Dunkel Lager, Ettaler Kloster Dunkel, Hacker-Pschorr Alt Munich Dark, Weltenburger Kloster Barock-Dunkel"
-                       :notes           "Characterized by depth, richness and complexity typical of darker Munich malts with the accompanying Maillard products. Deeply bready-toasty, often with chocolate-like flavors in the freshest examples, but never harsh, roasty, or astringent; a decidedly malt-balanced beer, yet still easily drinkable."
-                       :og-max          1.056
-                       :color-min       14.0
-                       :abv-max         0.056
-                       :color-max       28.0
-                       :profile         "Aroma: Rich, elegant, deep malt sweetness, typically like bread crusts (often toasted bread crusts). Hints of chocolate, nuts, caramel, and/or toffee are also acceptable, with fresh traditional versions often showing higher levels of chocolate. Clean fermentation profile. A slight spicy, floral, or herbal hop aroma is acceptable. Appearance: Deep copper to dark brown, often with a red or garnet tint. Creamy, light to medium tan head. Usually clear, although murky unfiltered versions exist. Flavor: Dominated by the soft, rich, and complex flavor of darker Munich malts, usually with overtones reminiscent of toasted bread crusts, but without a burnt-harsh-grainy toastiness. The palate can be moderately malty, although it should not be overwhelming or cloyingly sweet. Mild caramel, toast or nuttiness may be present. Very fresh examples often have a pleasant malty-chocolate character that isn't roasty or sweet. Burnt or bitter flavors from roasted malts are inappropriate, as are pronounced caramel flavors from crystal malt. Hop bitterness is moderately low but perceptible, with the balance tipped firmly towards maltiness. Hop flavor is low to none; if noted, should reflect floral, spicy, or herbal German-type varieties. Aftertaste remains malty, although the hop bitterness may become more apparent in the medium-dry finish. Clean fermentation profile and lager character. Mouthfeel: Medium to medium-full body, providing a soft and dextrinous mouthfeel without being heavy or cloying. Moderate carbonation. The use of continental Munich-type malts should provide a richness, not a harsh or biting astringency."
-                       :ibu-min         18}))
+                      {cbf/category        "Dark European Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.016
+                       cbf/og-min          1.048
+                       cbf/name            "Munich Dunkel"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.045
+                       cbf/fg-min          1.01
+                       cbf/category-number "8"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         28
+                       cbf/ingredients     "Grist is traditionally made up of German Munich malt (up to 100% in some cases) with the remainder German Pilsner malt. Small amounts of crystal malt can add dextrins and color but should not introduce excessive residual sweetness. Slight additions of roasted malts (such as Carafa or chocolate) may be used to improve color but should not add strong flavors. Traditional German hop varieties and German lager yeast strains should be used. Often decoction mashed (up to a triple decoction) to enhance the malt flavors and create the depth of color."
+                       cbf/examples        "Ayinger Altbairisch Dunkel, Chuckanut Dunkel Lager, Ettaler Kloster Dunkel, Hacker-Pschorr Alt Munich Dark, Weltenburger Kloster Barock-Dunkel"
+                       cbf/notes           "Characterized by depth, richness and complexity typical of darker Munich malts with the accompanying Maillard products. Deeply bready-toasty, often with chocolate-like flavors in the freshest examples, but never harsh, roasty, or astringent; a decidedly malt-balanced beer, yet still easily drinkable."
+                       cbf/og-max          1.056
+                       cbf/color-min       14.0
+                       cbf/abv-max         0.056
+                       cbf/color-max       28.0
+                       cbf/profile         "Aroma: Rich, elegant, deep malt sweetness, typically like bread crusts (often toasted bread crusts). Hints of chocolate, nuts, caramel, and/or toffee are also acceptable, with fresh traditional versions often showing higher levels of chocolate. Clean fermentation profile. A slight spicy, floral, or herbal hop aroma is acceptable. Appearance: Deep copper to dark brown, often with a red or garnet tint. Creamy, light to medium tan head. Usually clear, although murky unfiltered versions exist. Flavor: Dominated by the soft, rich, and complex flavor of darker Munich malts, usually with overtones reminiscent of toasted bread crusts, but without a burnt-harsh-grainy toastiness. The palate can be moderately malty, although it should not be overwhelming or cloyingly sweet. Mild caramel, toast or nuttiness may be present. Very fresh examples often have a pleasant malty-chocolate character that isn't roasty or sweet. Burnt or bitter flavors from roasted malts are inappropriate, as are pronounced caramel flavors from crystal malt. Hop bitterness is moderately low but perceptible, with the balance tipped firmly towards maltiness. Hop flavor is low to none; if noted, should reflect floral, spicy, or herbal German-type varieties. Aftertaste remains malty, although the hop bitterness may become more apparent in the medium-dry finish. Clean fermentation profile and lager character. Mouthfeel: Medium to medium-full body, providing a soft and dextrinous mouthfeel without being heavy or cloying. Moderate carbonation. The use of continental Munich-type malts should provide a richness, not a harsh or biting astringency."
+                       cbf/ibu-min         18}))
 
 
 (def schwarzbier
@@ -36,27 +37,27 @@
    
    The lighter body, dryness, and lack of a harsh, burnt, or heavy aftertaste helps make this beer quite drinkable."
   (styles/build-style :schwarzbier
-                      {:category        "Dark European Lager"
-                       :carb-min        1.5
-                       :fg-max          1.016
-                       :og-min          1.046
-                       :name            "Schwarzbier"
-                       :type            "Lager"
-                       :style-letter    "B"
-                       :abv-min         0.044
-                       :fg-min          1.01
-                       :category-number "8"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "German Munich malt and/or Pilsner malts for the base, supplemented by a judicious use of roasted malts (such as Carafa types) for the dark color and subtle roast flavors. Huskless dark roasted malts can add roast flavors without burnt flavors. German hop varieties and clean German lager yeasts are traditional."
-                       :examples        "Devils Backbone Schwartz Bier, Einbecker Schwarzbier, Eisenbahn Dunkel, Köstritzer Schwarzbier, Mönchshof Schwarzbier, Nuezeller Original Badebier"
-                       :notes           "A dark German lager that balances roasted yet smooth malt flavors with moderate hop bitterness. The lighter body, dryness, and lack of a harsh, burnt, or heavy aftertaste helps make this beer quite drinkable."
-                       :og-max          1.052
-                       :color-min       17.0
-                       :abv-max         0.054
-                       :color-max       30.0
-                       :profile         "Aroma: Low to moderate malt, with low aromatic malty sweetness and/or hints of roast malt often apparent. The malt can be clean and neutral or moderately rich and bready, and may have a hint of dark caramel. The roast character can be somewhat dark chocolate- or coffee-like but should never be burnt. A low spicy, floral, or herbal hop aroma is optional. Clean lager yeast character, although a light sulfur is possible. Appearance: Medium to very dark brown in color, often with deep ruby to garnet highlights, yet almost never truly black. Very clear. Large, persistent, tan-colored head. Flavor: Light to moderate malt flavor, which can have a clean, neutral character to a moderately rich, bread-malty quality. Light to moderate roasted malt flavors can give a bitter-chocolate palate that lasts into the finish, but which are never burnt. Medium-low to medium bitterness, which can last into the finish. Light to moderate spicy, floral, or herbal hop flavor. Clean lager character. Aftertaste tends to dry out slowly and linger, featuring hop bitterness with a complementary but subtle roastiness in the background. Some residual sweetness is acceptable but not required. Mouthfeel: Medium-light to medium body. Moderate to moderately-high carbonation. Smooth. No harshness or astringency, despite the use of dark, roasted malts."
-                       :ibu-min         20}))
+                      {cbf/category        "Dark European Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.016
+                       cbf/og-min          1.046
+                       cbf/name            "Schwarzbier"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.044
+                       cbf/fg-min          1.01
+                       cbf/category-number "8"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "German Munich malt and/or Pilsner malts for the base, supplemented by a judicious use of roasted malts (such as Carafa types) for the dark color and subtle roast flavors. Huskless dark roasted malts can add roast flavors without burnt flavors. German hop varieties and clean German lager yeasts are traditional."
+                       cbf/examples        "Devils Backbone Schwartz Bier, Einbecker Schwarzbier, Eisenbahn Dunkel, Köstritzer Schwarzbier, Mönchshof Schwarzbier, Nuezeller Original Badebier"
+                       cbf/notes           "A dark German lager that balances roasted yet smooth malt flavors with moderate hop bitterness. The lighter body, dryness, and lack of a harsh, burnt, or heavy aftertaste helps make this beer quite drinkable."
+                       cbf/og-max          1.052
+                       cbf/color-min       17.0
+                       cbf/abv-max         0.054
+                       cbf/color-max       30.0
+                       cbf/profile         "Aroma: Low to moderate malt, with low aromatic malty sweetness and/or hints of roast malt often apparent. The malt can be clean and neutral or moderately rich and bready, and may have a hint of dark caramel. The roast character can be somewhat dark chocolate- or coffee-like but should never be burnt. A low spicy, floral, or herbal hop aroma is optional. Clean lager yeast character, although a light sulfur is possible. Appearance: Medium to very dark brown in color, often with deep ruby to garnet highlights, yet almost never truly black. Very clear. Large, persistent, tan-colored head. Flavor: Light to moderate malt flavor, which can have a clean, neutral character to a moderately rich, bread-malty quality. Light to moderate roasted malt flavors can give a bitter-chocolate palate that lasts into the finish, but which are never burnt. Medium-low to medium bitterness, which can last into the finish. Light to moderate spicy, floral, or herbal hop flavor. Clean lager character. Aftertaste tends to dry out slowly and linger, featuring hop bitterness with a complementary but subtle roastiness in the background. Some residual sweetness is acceptable but not required. Mouthfeel: Medium-light to medium body. Moderate to moderately-high carbonation. Smooth. No harshness or astringency, despite the use of dark, roasted malts."
+                       cbf/ibu-min         20}))
 
 
 (def dark-european-lager

--- a/src/common_beer_data/styles/bjcp_2015/european_sour_ale.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/european_sour_ale.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.european-sour-ale
   "2015 BJCP guidelines on European Sour Ales."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def berliner-weisse
@@ -9,27 +10,27 @@
    A light bread dough malt flavor supports the sourness, which shouldn't seem artificial. 
    Any Brettanomyces funk is restrained."
   (styles/build-style :berliner-weisse
-                      {:category        "European Sour Ale"
-                       :carb-min        1.5
-                       :fg-max          1.006
-                       :og-min          1.028
-                       :name            "Berliner Weisse"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.028
-                       :fg-min          1.003
-                       :category-number "23"
-                       :carb-max        3.0
-                       :ibu-max         8
-                       :ingredients     "Wheat malt content is typically 50% of the grist (as is tradition with all German wheat beers) with the remainder typically being Pilsner malt. A symbiotic fermentation with top-fermenting yeast and Lactobacillus (various strains) provides the sharp sourness, which may be enhanced by blending of beers of different ages during fermentation and by extended cool aging. Hop bitterness is non-existent. Decoction mashing with mash hopping is traditional. German brewing scientists believe that Brettanomyces is essential to get the correct flavor profile, but this character is never strong."
-                       :examples        "Bayerischer Bahnhof Berliner Style Weisse, Berliner Kindl Weisse, Nodding Head Berliner Weisse, The Bruery Hottenroth"
-                       :notes           "A very pale, refreshing, low-alcohol German wheat beer with a clean lactic sourness and a very high carbonation level. A light bread dough malt flavor supports the sourness, which shouldn't seem artificial. Any Brettanomyces funk is restrained."
-                       :og-max          1.032
-                       :color-min       2.0
-                       :abv-max         0.038
-                       :color-max       3.0
-                       :profile         "Aroma: A sharply sour character is dominant (moderate to moderately-high). Can have up to a moderately fruity character (often lemony or tart apple). The fruitiness may increase with age and a light flowery character may develop. No hop aroma. The wheat may present as uncooked bread dough in fresher versions; combined with the acidity, may suggest sourdough bread. May optionally have a restrained funky Brettanomyces character. Appearance: Very pale straw in color. Clarity ranges from clear to somewhat hazy. Large, dense, white head with poor retention. Always effervescent. Flavor: Clean lactic sourness dominates and can be quite strong. Some complementary doughy, bready or grainy wheat flavor is generally noticeable. Hop bitterness is undetectable; sourness provides the balance rather than hops. Never vinegary. A restrained citrusy-lemony or tart apple fruitiness may be detected. Very dry finish. Balance dominated by sourness, but some malt flavor should be present. No hop flavor. May optionally have a restrained funky Brettanomyces character. Mouthfeel: Light body. Very high carbonation. No sensation of alcohol. Crisp, juicy acidity."
-                       :ibu-min         3}))
+                      {cbf/category        "European Sour Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.006
+                       cbf/og-min          1.028
+                       cbf/name            "Berliner Weisse"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.028
+                       cbf/fg-min          1.003
+                       cbf/category-number "23"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         8
+                       cbf/ingredients     "Wheat malt content is typically 50% of the grist (as is tradition with all German wheat beers) with the remainder typically being Pilsner malt. A symbiotic fermentation with top-fermenting yeast and Lactobacillus (various strains) provides the sharp sourness, which may be enhanced by blending of beers of different ages during fermentation and by extended cool aging. Hop bitterness is non-existent. Decoction mashing with mash hopping is traditional. German brewing scientists believe that Brettanomyces is essential to get the correct flavor profile, but this character is never strong."
+                       cbf/examples        "Bayerischer Bahnhof Berliner Style Weisse, Berliner Kindl Weisse, Nodding Head Berliner Weisse, The Bruery Hottenroth"
+                       cbf/notes           "A very pale, refreshing, low-alcohol German wheat beer with a clean lactic sourness and a very high carbonation level. A light bread dough malt flavor supports the sourness, which shouldn't seem artificial. Any Brettanomyces funk is restrained."
+                       cbf/og-max          1.032
+                       cbf/color-min       2.0
+                       cbf/abv-max         0.038
+                       cbf/color-max       3.0
+                       cbf/profile         "Aroma: A sharply sour character is dominant (moderate to moderately-high). Can have up to a moderately fruity character (often lemony or tart apple). The fruitiness may increase with age and a light flowery character may develop. No hop aroma. The wheat may present as uncooked bread dough in fresher versions; combined with the acidity, may suggest sourdough bread. May optionally have a restrained funky Brettanomyces character. Appearance: Very pale straw in color. Clarity ranges from clear to somewhat hazy. Large, dense, white head with poor retention. Always effervescent. Flavor: Clean lactic sourness dominates and can be quite strong. Some complementary doughy, bready or grainy wheat flavor is generally noticeable. Hop bitterness is undetectable; sourness provides the balance rather than hops. Never vinegary. A restrained citrusy-lemony or tart apple fruitiness may be detected. Very dry finish. Balance dominated by sourness, but some malt flavor should be present. No hop flavor. May optionally have a restrained funky Brettanomyces character. Mouthfeel: Light body. Very high carbonation. No sensation of alcohol. Crisp, juicy acidity."
+                       cbf/ibu-min         3}))
 
 
 (def flanders-red-ale
@@ -37,53 +38,53 @@
    
    The dry finish and tannin completes the mental image of a fine red wine."
   (styles/build-style :flanders-red-ale
-                      {:category        "European Sour Ale"
-                       :carb-min        1.5
-                       :fg-max          1.012
-                       :og-min          1.048
-                       :name            "Flanders Red Ale"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.046
-                       :fg-min          1.002
-                       :category-number "23"
-                       :carb-max        3.0
-                       :ibu-max         25
-                       :ingredients     "A base of Vienna and/or Munich malts, light to medium cara-malts, and a small amount of Special B are used with up to 20% maize. Low alpha acid continental hops are commonly used (avoid high alpha or distinctive American hops). Saccharomyces, Lactobacillus and Brettanomyces (and acetobacter) contribute to the fermentation and eventual flavor."
-                       :examples        "Cuvée des Jacobins Rouge, Duchesse de Bourgogne, Rodenbach Grand Cru, Rodenbach Klassiek, Vichtenaar Flemish Ale"
-                       :notes           "A sour, fruity, red wine-like Belgian-style ale with interesting supportive malt flavors and fruit complexity. The dry finish and tannin completes the mental image of a fine red wine."
-                       :og-max          1.057
-                       :color-min       10.0
-                       :abv-max         0.065
-                       :color-max       16.0
-                       :profile         "Aroma: Complex fruity-sour profile with supporting malt that often gives a wine-like impression. Fruitiness is high, and reminiscent of black cherries, oranges, plums or red currants. There are often low to medium-low vanilla and/or chocolate notes. Spicy phenols can be present in low amounts for complexity. The sour aroma ranges from balanced to intense. Prominent vinegary acetic character is inappropriate. No hop aroma. Diacetyl is perceived only in very minor quantities, if at all, as a complementary aroma. Appearance: Deep red, burgundy to reddish-brown in color. Good clarity. White to very pale tan head. Average to good head retention. Flavor: Intense fruitiness commonly includes plum, orange, black cherry or red currant flavors. A mild vanilla and/or chocolate character is often present. Spicy phenols can be present in low amounts for complexity. Sour flavor ranges from complementary to intense, and can have an acidic bite. Malty flavors range from complementary to prominent, and often have a soft toasty-rich quality. Generally as the sour character increases, the malt character blends to more of a background flavor (and vice versa). No hop flavor. Restrained hop bitterness. An acidic, tannic bitterness is often present in low to moderate amounts, and adds an aged red wine-like character and finish. Prominent vinegary acetic character is inappropriate. Diacetyl is perceived only in very minor quantities, if at all, as a complementary flavor. Balanced to the malt side, but dominated by the fruity, sour, wine-like impression. Mouthfeel: Medium bodied. Low to medium carbonation. Low to medium astringency, like a well-aged red wine, often with a prickly acidity. Deceivingly light and crisp on the palate although a somewhat sweet finish is not uncommon."
-                       :ibu-min         10}))
+                      {cbf/category        "European Sour Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.012
+                       cbf/og-min          1.048
+                       cbf/name            "Flanders Red Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.046
+                       cbf/fg-min          1.002
+                       cbf/category-number "23"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         25
+                       cbf/ingredients     "A base of Vienna and/or Munich malts, light to medium cara-malts, and a small amount of Special B are used with up to 20% maize. Low alpha acid continental hops are commonly used (avoid high alpha or distinctive American hops). Saccharomyces, Lactobacillus and Brettanomyces (and acetobacter) contribute to the fermentation and eventual flavor."
+                       cbf/examples        "Cuvée des Jacobins Rouge, Duchesse de Bourgogne, Rodenbach Grand Cru, Rodenbach Klassiek, Vichtenaar Flemish Ale"
+                       cbf/notes           "A sour, fruity, red wine-like Belgian-style ale with interesting supportive malt flavors and fruit complexity. The dry finish and tannin completes the mental image of a fine red wine."
+                       cbf/og-max          1.057
+                       cbf/color-min       10.0
+                       cbf/abv-max         0.065
+                       cbf/color-max       16.0
+                       cbf/profile         "Aroma: Complex fruity-sour profile with supporting malt that often gives a wine-like impression. Fruitiness is high, and reminiscent of black cherries, oranges, plums or red currants. There are often low to medium-low vanilla and/or chocolate notes. Spicy phenols can be present in low amounts for complexity. The sour aroma ranges from balanced to intense. Prominent vinegary acetic character is inappropriate. No hop aroma. Diacetyl is perceived only in very minor quantities, if at all, as a complementary aroma. Appearance: Deep red, burgundy to reddish-brown in color. Good clarity. White to very pale tan head. Average to good head retention. Flavor: Intense fruitiness commonly includes plum, orange, black cherry or red currant flavors. A mild vanilla and/or chocolate character is often present. Spicy phenols can be present in low amounts for complexity. Sour flavor ranges from complementary to intense, and can have an acidic bite. Malty flavors range from complementary to prominent, and often have a soft toasty-rich quality. Generally as the sour character increases, the malt character blends to more of a background flavor (and vice versa). No hop flavor. Restrained hop bitterness. An acidic, tannic bitterness is often present in low to moderate amounts, and adds an aged red wine-like character and finish. Prominent vinegary acetic character is inappropriate. Diacetyl is perceived only in very minor quantities, if at all, as a complementary flavor. Balanced to the malt side, but dominated by the fruity, sour, wine-like impression. Mouthfeel: Medium bodied. Low to medium carbonation. Low to medium astringency, like a well-aged red wine, often with a prickly acidity. Deceivingly light and crisp on the palate although a somewhat sweet finish is not uncommon."
+                       cbf/ibu-min         10}))
 
 
 (def oud-bruin
   "A malty, fruity, aged, somewhat sour Belgian-style brown ale."
   (styles/build-style :oud-bruin
-                      {:category        "European Sour Ale"
-                       :carb-min        1.5
-                       :fg-max          1.012
-                       :og-min          1.04
-                       :name            "Oud Bruin"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.04
-                       :fg-min          1.008
-                       :category-number "23"
-                       :carb-max        3.0
-                       :ibu-max         25
-                       :ingredients     "A base of Pils malt with judicious amounts of dark cara malts and a tiny bit of black or roast malt. Often includes maize. Low alpha acid continental hops are typical (avoid high alpha or distinctive American hops). Saccharomyces and Lactobacillus (and acetobacter) contribute to the fermentation and eventual flavor. Lactobacillus reacts poorly to elevated levels of alcohol. Water high in carbonates is typical of its home region and will buffer the acidity of darker malts and the lactic sourness. Magnesium in the water accentuates the sourness."
-                       :examples        "Ichtegem Oud Bruin, Liefmans Goudenband, Liefmans Liefmans Oud Bruin, Petrus Oud Bruin, Riva Vondel, Vanderghinste Bellegems Bruin"
-                       :notes           "A malty, fruity, aged, somewhat sour Belgian-style brown ale."
-                       :og-max          1.074
-                       :color-min       15.0
-                       :abv-max         0.08
-                       :color-max       22.0
-                       :profile         "Aroma: Complex combination of fruity esters and rich malt character. Medium to medium-high esters commonly reminiscent of raisins, plums, figs, dates, black cherries or prunes. Medium low to medium high malt character of caramel, toffee, orange, treacle or chocolate. Spicy phenols can be present in low amounts for complexity. A sherry-like character may be present and generally denotes an aged example. A low sour aroma may be present, and can modestly increase with age but should not grow to a noticeable acetic/vinegary character. Hop aroma absent. Diacetyl is perceived only in very minor quantities, if at all, as a complementary aroma. Appearance: Dark reddish-brown to brown in color. Good clarity. Average to good head retention. Ivory to light tan head color. Flavor: Malty with fruity complexity and typically some caramel character. Medium to medium-high fruitiness commonly includes dark or dried fruit such as raisins, plums, figs, dates, black cherries or prunes. Medium low to medium high malt character of caramel, toffee, orange, treacle or chocolate. Spicy phenols can be present in low amounts for complexity. A slight sourness often becomes more pronounced in well-aged examples, along with some sherry-like character, producing a \"sweet-and-sour\" profile. The sourness should not grow to a notable acetic/vinegary character. Hop flavor absent. Restrained hop bitterness. Low oxidation is appropriate as a point of complexity. Diacetyl is perceived only in very minor quantities, if at all, as a complementary flavor. Balance is malty, but with fruitiness and sourness present. Sweet and tart finish Mouthfeel: Medium to medium-full body. Low to moderate carbonation. No astringency."
-                       :ibu-min         20}))
+                      {cbf/category        "European Sour Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.012
+                       cbf/og-min          1.04
+                       cbf/name            "Oud Bruin"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.04
+                       cbf/fg-min          1.008
+                       cbf/category-number "23"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         25
+                       cbf/ingredients     "A base of Pils malt with judicious amounts of dark cara malts and a tiny bit of black or roast malt. Often includes maize. Low alpha acid continental hops are typical (avoid high alpha or distinctive American hops). Saccharomyces and Lactobacillus (and acetobacter) contribute to the fermentation and eventual flavor. Lactobacillus reacts poorly to elevated levels of alcohol. Water high in carbonates is typical of its home region and will buffer the acidity of darker malts and the lactic sourness. Magnesium in the water accentuates the sourness."
+                       cbf/examples        "Ichtegem Oud Bruin, Liefmans Goudenband, Liefmans Liefmans Oud Bruin, Petrus Oud Bruin, Riva Vondel, Vanderghinste Bellegems Bruin"
+                       cbf/notes           "A malty, fruity, aged, somewhat sour Belgian-style brown ale."
+                       cbf/og-max          1.074
+                       cbf/color-min       15.0
+                       cbf/abv-max         0.08
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Complex combination of fruity esters and rich malt character. Medium to medium-high esters commonly reminiscent of raisins, plums, figs, dates, black cherries or prunes. Medium low to medium high malt character of caramel, toffee, orange, treacle or chocolate. Spicy phenols can be present in low amounts for complexity. A sherry-like character may be present and generally denotes an aged example. A low sour aroma may be present, and can modestly increase with age but should not grow to a noticeable acetic/vinegary character. Hop aroma absent. Diacetyl is perceived only in very minor quantities, if at all, as a complementary aroma. Appearance: Dark reddish-brown to brown in color. Good clarity. Average to good head retention. Ivory to light tan head color. Flavor: Malty with fruity complexity and typically some caramel character. Medium to medium-high fruitiness commonly includes dark or dried fruit such as raisins, plums, figs, dates, black cherries or prunes. Medium low to medium high malt character of caramel, toffee, orange, treacle or chocolate. Spicy phenols can be present in low amounts for complexity. A slight sourness often becomes more pronounced in well-aged examples, along with some sherry-like character, producing a \"sweet-and-sour\" profile. The sourness should not grow to a notable acetic/vinegary character. Hop flavor absent. Restrained hop bitterness. Low oxidation is appropriate as a point of complexity. Diacetyl is perceived only in very minor quantities, if at all, as a complementary flavor. Balance is malty, but with fruitiness and sourness present. Sweet and tart finish Mouthfeel: Medium to medium-full body. Low to moderate carbonation. No astringency."
+                       cbf/ibu-min         20}))
 
 
 (def lambic
@@ -91,27 +92,27 @@
    
    Traditionally spontaneously fermented in the Brussels area and served uncarbonated, the refreshing acidity makes for a very pleasant café drink."
   (styles/build-style :lambic
-                      {:category        "European Sour Ale"
-                       :carb-min        1.5
-                       :fg-max          1.01
-                       :og-min          1.04
-                       :name            "Lambic"
-                       :type            "Ale"
-                       :style-letter    "D"
-                       :abv-min         0.05
-                       :fg-min          1.001
-                       :category-number "23"
-                       :carb-max        3.0
-                       :ibu-max         10
-                       :ingredients     "Unmalted wheat (30-40%), Pilsner malt and aged hops (3 years) are used. The aged hops are used more for preservative effects than bitterness, and makes actual bitterness levels difficult to estimate. Traditionally these beers are spontaneously fermented with naturally occurring yeast and bacteria in predominately oaken barrels. The barrels used are neutral with little oak character, so don't expect a fresh or forward oak character - more neutral is typical. Home-brewed and craft-brewed versions are more typically made with pure cultures of yeast commonly including Saccharomyces, Brettanomyces, Pediococcus and Lactobacillus in an attempt to recreate the effects of the dominant microbiota of Brussels and the surrounding countryside of the Senne River valley. Cultures taken from bottles are sometimes used but there is no simple way of knowing what organisms are still viable."
-                       :examples        "The only bottled version readily available is Cantillon Grand Cru Bruocsella of whatever single batch vintage the brewer deems worthy to bottle. De Cam sometimes bottles their very old (5 years) lambic. In and around Brussels there are specialty cafes that often have draught lambics from traditional brewers or blenders such as Boon, De Cam, Cantillon, Drie Fonteinen, Lindemans, Timmermans and Girardin."
-                       :notes           "A fairly sour, often moderately funky wild Belgian wheat beer with sourness taking the place of hop bitterness in the balance. Traditionally spontaneously fermented in the Brussels area and served uncarbonated, the refreshing acidity makes for a very pleasant café drink."
-                       :og-max          1.054
-                       :color-min       3.0
-                       :abv-max         0.065
-                       :color-max       7.0
-                       :profile         "Aroma: A decidedly sour aroma is often dominant in young examples, but may become more subdued with age as it blends with aromas described as barnyard, earthy, goaty, hay, horsey, and horse blanket. A mild citrus-fruity aroma is considered favorable. An enteric, smoky, cigar-like, or cheesy aroma is unfavorable. Older versions are commonly fruity with aromas of apples or even honey. No hop aroma. Appearance: Pale yellow to deep golden in color; age tends to darken the beer. Clarity is hazy to good. Younger versions are often cloudy, while older ones are generally clear. White colored head generally has poor retention. Flavor: Young examples are often noticeably lactic-sour, but aging can bring this character more in balance with the malt, wheat and barnyard characteristics. Fruity flavors are simpler in young lambics and more complex in the older examples, where they are reminiscent of apples or other light fruits, rhubarb, or honey. Some citrus flavor (often grapefruit) is occasionally noticeable, and is desirable. The malt and wheat character are typically low with some bready-grainy notes. An enteric, smoky or cigar-like character is undesirable. Hop bitterness is low to none, and generally undetectable; sourness provides the balance. Typically has a dry finish. No hop flavor. Mouthfeel: Light to medium-light body. In spite of the low finishing gravity, the many mouth-filling flavors prevent the beer from feeling like water. As a rule of thumb, lambic dries with age, which makes dryness a reasonable indicator of age. Has a medium to high tart, puckering quality without being sharply astringent. Traditional versions are virtually to completely uncarbonated, but bottled examples can pick up moderate carbonation with age."
-                       :ibu-min         0}))
+                      {cbf/category        "European Sour Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.01
+                       cbf/og-min          1.04
+                       cbf/name            "Lambic"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "D"
+                       cbf/abv-min         0.05
+                       cbf/fg-min          1.001
+                       cbf/category-number "23"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         10
+                       cbf/ingredients     "Unmalted wheat (30-40%), Pilsner malt and aged hops (3 years) are used. The aged hops are used more for preservative effects than bitterness, and makes actual bitterness levels difficult to estimate. Traditionally these beers are spontaneously fermented with naturally occurring yeast and bacteria in predominately oaken barrels. The barrels used are neutral with little oak character, so don't expect a fresh or forward oak character - more neutral is typical. Home-brewed and craft-brewed versions are more typically made with pure cultures of yeast commonly including Saccharomyces, Brettanomyces, Pediococcus and Lactobacillus in an attempt to recreate the effects of the dominant microbiota of Brussels and the surrounding countryside of the Senne River valley. Cultures taken from bottles are sometimes used but there is no simple way of knowing what organisms are still viable."
+                       cbf/examples        "The only bottled version readily available is Cantillon Grand Cru Bruocsella of whatever single batch vintage the brewer deems worthy to bottle. De Cam sometimes bottles their very old (5 years) lambic. In and around Brussels there are specialty cafes that often have draught lambics from traditional brewers or blenders such as Boon, De Cam, Cantillon, Drie Fonteinen, Lindemans, Timmermans and Girardin."
+                       cbf/notes           "A fairly sour, often moderately funky wild Belgian wheat beer with sourness taking the place of hop bitterness in the balance. Traditionally spontaneously fermented in the Brussels area and served uncarbonated, the refreshing acidity makes for a very pleasant café drink."
+                       cbf/og-max          1.054
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.065
+                       cbf/color-max       7.0
+                       cbf/profile         "Aroma: A decidedly sour aroma is often dominant in young examples, but may become more subdued with age as it blends with aromas described as barnyard, earthy, goaty, hay, horsey, and horse blanket. A mild citrus-fruity aroma is considered favorable. An enteric, smoky, cigar-like, or cheesy aroma is unfavorable. Older versions are commonly fruity with aromas of apples or even honey. No hop aroma. Appearance: Pale yellow to deep golden in color; age tends to darken the beer. Clarity is hazy to good. Younger versions are often cloudy, while older ones are generally clear. White colored head generally has poor retention. Flavor: Young examples are often noticeably lactic-sour, but aging can bring this character more in balance with the malt, wheat and barnyard characteristics. Fruity flavors are simpler in young lambics and more complex in the older examples, where they are reminiscent of apples or other light fruits, rhubarb, or honey. Some citrus flavor (often grapefruit) is occasionally noticeable, and is desirable. The malt and wheat character are typically low with some bready-grainy notes. An enteric, smoky or cigar-like character is undesirable. Hop bitterness is low to none, and generally undetectable; sourness provides the balance. Typically has a dry finish. No hop flavor. Mouthfeel: Light to medium-light body. In spite of the low finishing gravity, the many mouth-filling flavors prevent the beer from feeling like water. As a rule of thumb, lambic dries with age, which makes dryness a reasonable indicator of age. Has a medium to high tart, puckering quality without being sharply astringent. Traditional versions are virtually to completely uncarbonated, but bottled examples can pick up moderate carbonation with age."
+                       cbf/ibu-min         0}))
 
 
 (def gueuze
@@ -119,27 +120,27 @@
    
    The spontaneous fermentation character can provide a very interesting complexity, with a wide range of wild barnyard, horse blanket, or leather characteristics intermingling with citrusy-fruity flavors and acidity."
   (styles/build-style :gueuze
-                      {:category        "European Sour Ale"
-                       :carb-min        1.5
-                       :fg-max          1.006
-                       :og-min          1.04
-                       :name            "Gueuze"
-                       :type            "Ale"
-                       :style-letter    "E"
-                       :abv-min         0.05
-                       :fg-min          1.0
-                       :category-number "23"
-                       :carb-max        3.0
-                       :ibu-max         10
-                       :ingredients     "Unmalted wheat (30-40%), Pilsner malt and aged hops (3 years) are used. The aged hops are used more for preservative effects than bitterness, and makes actual bitterness levels difficult to estimate. Traditionally these beers are spontaneously fermented with naturally occurring yeast and bacteria in predominately oaken barrels. The barrels used are old and have little oak character, so don't expect a fresh or forward oak character - more neutral is typical. Home-brewed and craft-brewed versions are more typically made with pure cultures of yeast commonly including Saccharomyces, Brettanomyces, Pediococcus and Lactobacillus in an attempt to recreate the effects of the dominant microbiota of Brussels and the surrounding countryside of the Senne River valley. Cultures taken from bottles are sometimes used but there is no simple way of knowing what organisms are still viable."
-                       :examples        "Boon Oude Gueuze, Boon Oude Gueuze Marriage Parfait, Cantillon Gueuze, De Cam Gueuze, De Cam/Drei Fonteinen Millennium Gueuze, Drie Fonteinen Oud Gueuze, Girardin Gueuze (Black Label), Hanssens Oude Gueuze, Lindemans Gueuze Cuvée René, Mort Subite (Unfiltered) Gueuze, Oud Beersel Oude Gueuze"
-                       :notes           "A complex, pleasantly sour but balanced wild Belgian wheat beer that is highly carbonated and very refreshing. The spontaneous fermentation character can provide a very interesting complexity, with a wide range of wild barnyard, horse blanket, or leather characteristics intermingling with citrusy-fruity flavors and acidity."
-                       :og-max          1.06
-                       :color-min       3.0
-                       :abv-max         0.08
-                       :color-max       7.0
-                       :profile         "Aroma: A moderately sour aroma blends with aromas described as barnyard, leather, earthy, goaty, hay, horsey, and horse blanket. While some may be more dominantly sour, balance is the key and denotes a better gueuze. Commonly fruity with aromas of citrus fruits (often grapefruit), apples or other light fruits, rhubarb, or honey. A very mild oak aroma is considered favorable. An enteric, smoky, cigar-like, or cheesy aroma is unfavorable. No hop aroma. Appearance: Golden color, with excellent clarity and a thick, rocky, mousse-like, white head that seems to last forever. Always effervescent. Flavor: A moderately sour character is classically in balance with the malt, wheat and barnyard characteristics. A low, complementary sweetness may be present but higher levels are not traditional. While some may be more dominantly sour, balance is the key and denotes a better gueuze. A varied fruit flavor is common, and can have a honey-like character. A mild vanilla and/or oak flavor is occasionally noticeable. The malt is generally low and bready-grainy. An enteric, smoky or cigar-like character is undesirable. Hop bitterness is generally absent but a very low hop bitterness may occasionally be perceived; sourness provides most of the balance. Crisp, dry, and tart finish. No hop flavor. Mouthfeel: Light to medium-light body. In spite of the low finishing gravity, the many mouth-filling flavors prevent the beer from feeling like water. Has a low to high tart, puckering quality without being sharply astringent. Some versions have a light warming character. Highly carbonated."
-                       :ibu-min         0}))
+                      {cbf/category        "European Sour Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.006
+                       cbf/og-min          1.04
+                       cbf/name            "Gueuze"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "E"
+                       cbf/abv-min         0.05
+                       cbf/fg-min          1.0
+                       cbf/category-number "23"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         10
+                       cbf/ingredients     "Unmalted wheat (30-40%), Pilsner malt and aged hops (3 years) are used. The aged hops are used more for preservative effects than bitterness, and makes actual bitterness levels difficult to estimate. Traditionally these beers are spontaneously fermented with naturally occurring yeast and bacteria in predominately oaken barrels. The barrels used are old and have little oak character, so don't expect a fresh or forward oak character - more neutral is typical. Home-brewed and craft-brewed versions are more typically made with pure cultures of yeast commonly including Saccharomyces, Brettanomyces, Pediococcus and Lactobacillus in an attempt to recreate the effects of the dominant microbiota of Brussels and the surrounding countryside of the Senne River valley. Cultures taken from bottles are sometimes used but there is no simple way of knowing what organisms are still viable."
+                       cbf/examples        "Boon Oude Gueuze, Boon Oude Gueuze Marriage Parfait, Cantillon Gueuze, De Cam Gueuze, De Cam/Drei Fonteinen Millennium Gueuze, Drie Fonteinen Oud Gueuze, Girardin Gueuze (Black Label), Hanssens Oude Gueuze, Lindemans Gueuze Cuvée René, Mort Subite (Unfiltered) Gueuze, Oud Beersel Oude Gueuze"
+                       cbf/notes           "A complex, pleasantly sour but balanced wild Belgian wheat beer that is highly carbonated and very refreshing. The spontaneous fermentation character can provide a very interesting complexity, with a wide range of wild barnyard, horse blanket, or leather characteristics intermingling with citrusy-fruity flavors and acidity."
+                       cbf/og-max          1.06
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.08
+                       cbf/color-max       7.0
+                       cbf/profile         "Aroma: A moderately sour aroma blends with aromas described as barnyard, leather, earthy, goaty, hay, horsey, and horse blanket. While some may be more dominantly sour, balance is the key and denotes a better gueuze. Commonly fruity with aromas of citrus fruits (often grapefruit), apples or other light fruits, rhubarb, or honey. A very mild oak aroma is considered favorable. An enteric, smoky, cigar-like, or cheesy aroma is unfavorable. No hop aroma. Appearance: Golden color, with excellent clarity and a thick, rocky, mousse-like, white head that seems to last forever. Always effervescent. Flavor: A moderately sour character is classically in balance with the malt, wheat and barnyard characteristics. A low, complementary sweetness may be present but higher levels are not traditional. While some may be more dominantly sour, balance is the key and denotes a better gueuze. A varied fruit flavor is common, and can have a honey-like character. A mild vanilla and/or oak flavor is occasionally noticeable. The malt is generally low and bready-grainy. An enteric, smoky or cigar-like character is undesirable. Hop bitterness is generally absent but a very low hop bitterness may occasionally be perceived; sourness provides most of the balance. Crisp, dry, and tart finish. No hop flavor. Mouthfeel: Light to medium-light body. In spite of the low finishing gravity, the many mouth-filling flavors prevent the beer from feeling like water. Has a low to high tart, puckering quality without being sharply astringent. Some versions have a light warming character. Highly carbonated."
+                       cbf/ibu-min         0}))
 
 
 (def fruit-lambic
@@ -147,27 +148,27 @@
    
    The type of fruit can sometimes be hard to identify as fermented and aged fruit characteristics can seem different from the more recognizable fresh fruit aromas and flavors."
   (styles/build-style :fruit-lambic
-                      {:category        "European Sour Ale"
-                       :carb-min        1.5
-                       :fg-max          1.01
-                       :og-min          1.04
-                       :name            "Fruit Lambic"
-                       :type            "Ale"
-                       :style-letter    "F"
-                       :abv-min         0.05
-                       :fg-min          1.0
-                       :category-number "23"
-                       :carb-max        3.0
-                       :ibu-max         10
-                       :ingredients     "Unmalted wheat (30-40%), Pilsner malt and aged hops (3 years) are used. The aged hops are used more for preservative effects than bitterness, and makes actual bitterness levels difficult to estimate. Traditional products use 10-30% fruit (25%, if cherry). Fruits traditionally used include tart cherries (with pits), raspberries or Muscat grapes. More recent examples include peaches, apricots or merlot grapes. Tart or acidic fruit is traditionally used as its purpose is not to sweeten the beer but to add a new dimension. Traditionally these beers are spontaneously fermented with naturally occurring yeast and bacteria in predominately oaken barrels. The barrels used are old and have little oak character, so don't expect a fresh or forward oak character - more neutral is typical. Home-brewed and craft-brewed versions are more typically made with pure cultures of yeast commonly including Saccharomyces, Brettanomyces, Pediococcus and Lactobacillus in an attempt to recreate the effects of the dominant microbiota of Brussels and the surrounding countryside of the Senne River valley. Cultures taken from bottles are sometimes used but there is no simple way of knowing what organisms are still viable."
-                       :examples        "Boon Framboise Marriage Parfait, Boon Kriek Marriage Parfait, Boon Oude Kriek, Cantillon Fou' Foune, Cantillon Kriek, Cantillon Lou Pepe Kriek, Cantillon Lou Pepe Framboise, Cantillon Rose de Gambrinus, Cantillon St. Lamvinus, Cantillon Vigneronne, De Cam Oude Kriek, Drie Fonteinen Kriek, Girardin Kriek, Hanssens Oude Kriek, Oud Beersel Kriek, Mort Subite Kriek"
-                       :notes           "A complex, fruity, pleasantly sour, wild wheat ale fermented by a variety of Belgian microbiota, and showcasing the fruit contributions blended with the wild character. The type of fruit can sometimes be hard to identify as fermented and aged fruit characteristics can seem different from the more recognizable fresh fruit aromas and flavors."
-                       :og-max          1.06
-                       :color-min       3.0
-                       :abv-max         0.07
-                       :color-max       7.0
-                       :profile         "Aroma: The specified fruit should be the dominant aroma. A low to moderately sour character blends with aromas described as barnyard, earthy, goaty, hay, horsey, and horse blanket (and thus should be recognizable as a lambic). The fruit aroma commonly blends well with the other aromas. An enteric, smoky, cigar-like, or cheesy aroma is unfavorable. No hop aroma. Appearance: The variety of fruit generally determines the color, although lighter-colored fruit may have little effect on the color. The color intensity may fade with age. Clarity is often good, although some fruit will not drop bright. A thick rocky, mousse-like head, sometimes a shade of fruit, is generally long-lasting (carbonation-dependent). Carbonation is typically high, but must be specified. Flavor: The specified fruit should be evident. Low to moderately sour flavor, often with an acidic bite in the finish. The classic barnyard characteristics may be low to high. When young, the beer will present its full fruity taste. As it ages, the lambic taste will become dominant at the expense of the fruit character—thus fruit lambics are not intended for long aging. The finish is commonly dry and tart, but a low, complementary sweetness may be present; higher sweetness levels are not traditional but can be included for personal preference (sweetness level must be specified). A mild vanilla and/or oak flavor is occasionally noticeable. An enteric, smoky or cigar-like character is undesirable. Hop bitterness is generally absent; acidity provides the balance. No hop flavor. Mouthfeel: Light to medium-light body. In spite of the low finishing gravity, the many mouth-filling flavors prevent the beer from tasting like water. Has a low to high tart, puckering quality without being sharply astringent. Some versions have a light warming character. Carbonation can vary from sparkling to nearly still (must be specified)."
-                       :ibu-min         0}))
+                      {cbf/category        "European Sour Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.01
+                       cbf/og-min          1.04
+                       cbf/name            "Fruit Lambic"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "F"
+                       cbf/abv-min         0.05
+                       cbf/fg-min          1.0
+                       cbf/category-number "23"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         10
+                       cbf/ingredients     "Unmalted wheat (30-40%), Pilsner malt and aged hops (3 years) are used. The aged hops are used more for preservative effects than bitterness, and makes actual bitterness levels difficult to estimate. Traditional products use 10-30% fruit (25%, if cherry). Fruits traditionally used include tart cherries (with pits), raspberries or Muscat grapes. More recent examples include peaches, apricots or merlot grapes. Tart or acidic fruit is traditionally used as its purpose is not to sweeten the beer but to add a new dimension. Traditionally these beers are spontaneously fermented with naturally occurring yeast and bacteria in predominately oaken barrels. The barrels used are old and have little oak character, so don't expect a fresh or forward oak character - more neutral is typical. Home-brewed and craft-brewed versions are more typically made with pure cultures of yeast commonly including Saccharomyces, Brettanomyces, Pediococcus and Lactobacillus in an attempt to recreate the effects of the dominant microbiota of Brussels and the surrounding countryside of the Senne River valley. Cultures taken from bottles are sometimes used but there is no simple way of knowing what organisms are still viable."
+                       cbf/examples        "Boon Framboise Marriage Parfait, Boon Kriek Marriage Parfait, Boon Oude Kriek, Cantillon Fou' Foune, Cantillon Kriek, Cantillon Lou Pepe Kriek, Cantillon Lou Pepe Framboise, Cantillon Rose de Gambrinus, Cantillon St. Lamvinus, Cantillon Vigneronne, De Cam Oude Kriek, Drie Fonteinen Kriek, Girardin Kriek, Hanssens Oude Kriek, Oud Beersel Kriek, Mort Subite Kriek"
+                       cbf/notes           "A complex, fruity, pleasantly sour, wild wheat ale fermented by a variety of Belgian microbiota, and showcasing the fruit contributions blended with the wild character. The type of fruit can sometimes be hard to identify as fermented and aged fruit characteristics can seem different from the more recognizable fresh fruit aromas and flavors."
+                       cbf/og-max          1.06
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.07
+                       cbf/color-max       7.0
+                       cbf/profile         "Aroma: The specified fruit should be the dominant aroma. A low to moderately sour character blends with aromas described as barnyard, earthy, goaty, hay, horsey, and horse blanket (and thus should be recognizable as a lambic). The fruit aroma commonly blends well with the other aromas. An enteric, smoky, cigar-like, or cheesy aroma is unfavorable. No hop aroma. Appearance: The variety of fruit generally determines the color, although lighter-colored fruit may have little effect on the color. The color intensity may fade with age. Clarity is often good, although some fruit will not drop bright. A thick rocky, mousse-like head, sometimes a shade of fruit, is generally long-lasting (carbonation-dependent). Carbonation is typically high, but must be specified. Flavor: The specified fruit should be evident. Low to moderately sour flavor, often with an acidic bite in the finish. The classic barnyard characteristics may be low to high. When young, the beer will present its full fruity taste. As it ages, the lambic taste will become dominant at the expense of the fruit character—thus fruit lambics are not intended for long aging. The finish is commonly dry and tart, but a low, complementary sweetness may be present; higher sweetness levels are not traditional but can be included for personal preference (sweetness level must be specified). A mild vanilla and/or oak flavor is occasionally noticeable. An enteric, smoky or cigar-like character is undesirable. Hop bitterness is generally absent; acidity provides the balance. No hop flavor. Mouthfeel: Light to medium-light body. In spite of the low finishing gravity, the many mouth-filling flavors prevent the beer from tasting like water. Has a low to high tart, puckering quality without being sharply astringent. Some versions have a light warming character. Carbonation can vary from sparkling to nearly still (must be specified)."
+                       cbf/ibu-min         0}))
 
 
 (def european-sour-ale

--- a/src/common_beer_data/styles/bjcp_2015/fruit_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/fruit_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.fruit-beer
   "2015 BJCP guidelines on Fruit Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def fruit-beer
@@ -8,27 +9,27 @@
    
    The fruit character should be evident but in balance with the beer, not so forward as to suggest an artificial product."
   (styles/build-style :fruit-beer
-                      {:category        "Fruit Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Fruit Beer"
-                       :type            "Mixed"
-                       :style-letter    "A"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "29"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Virtually any style of beer. Any combination of Saccharomyces, Brettanomyces, Lactobacillus, Pediococcus, or other similar fermenters. Can also be a blend of styles. While cherries, raspberries, and peaches are most common, other fruits can be used as well. Vegetables with fruit-like characteristics (chile, rhubarb, pumpkin, etc.) may also be used. Wood or barrel aging is very common, but not required."
-                       :examples        "Bell's Cherry Stout, Dogfish Head Aprihop, Ebulum Elderberry Black Ale, Founders Rübæus"
-                       :notes           "A harmonious marriage of fruit and beer, but still recognizable as a beer. The fruit character should be evident but in balance with the beer, not so forward as to suggest an artificial product."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: The distinctive aromatics associated with the declared fruit should be noticeable in the aroma; however, note that some fruit (e.g., raspberries, cherries) have stronger aromas and are more distinctive than others (e.g., blueberries, strawberries) - allow for a range of fruit character and intensity from subtle to aggressive. The additional aromatics should blend well with whatever aromatics are appropriate for the declared base beer style. Appearance: Appearance should be appropriate for the declared base beer and declared fruit. For lighter-colored beers with fruits that exhibit distinctive colors, the color should be noticeable. Note that the color of fruit in beer is often lighter than the flesh of the fruit itself and may take on slightly different shades. Fruit beers may have some haze or be clear, although haze is a generally undesirable. The head may take on some of the color of the fruit. Flavor: As with aroma, the distinctive flavor character associated with the declared fruit should be noticeable, and may range in intensity from subtle to aggressive. The balance of fruit with the underlying beer is vital, and the fruit character should not be so artificial and/or inappropriately overpowering as to suggest a 'fruit juice drink.' Hop bitterness, flavor, malt flavors, alcohol content, and fermentation by-products, such as esters, should be appropriate to the base beer and be harmonious and balanced with the distinctive fruit flavors present. Remember that fruit generally add flavor not sweetness to fruit beers. The sugar found in fruit is usually fully fermented and contributes to lighter flavors and a drier finish than might be expected for the declared base style. However, residual sweetness is not necessarily a negative characteristic unless it has a raw, unfermented quality. Mouthfeel: Mouthfeel may vary depending on the base beer selected and as appropriate to that base beer. Body and carbonation levels should be appropriate to the declared base beer style. Fruit generally adds fermentables that tend to thin out the beer; the resulting beer may seem lighter than expected for the declared base style. Smaller and darker fruit have a tendency to add a tannic depth that should overwhelm the base beer."
-                       :ibu-min         7}))
+                      {cbf/category        "Fruit Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Fruit Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "29"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Virtually any style of beer. Any combination of Saccharomyces, Brettanomyces, Lactobacillus, Pediococcus, or other similar fermenters. Can also be a blend of styles. While cherries, raspberries, and peaches are most common, other fruits can be used as well. Vegetables with fruit-like characteristics (chile, rhubarb, pumpkin, etc.) may also be used. Wood or barrel aging is very common, but not required."
+                       cbf/examples        "Bell's Cherry Stout, Dogfish Head Aprihop, Ebulum Elderberry Black Ale, Founders Rübæus"
+                       cbf/notes           "A harmonious marriage of fruit and beer, but still recognizable as a beer. The fruit character should be evident but in balance with the beer, not so forward as to suggest an artificial product."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: The distinctive aromatics associated with the declared fruit should be noticeable in the aroma; however, note that some fruit (e.g., raspberries, cherries) have stronger aromas and are more distinctive than others (e.g., blueberries, strawberries) - allow for a range of fruit character and intensity from subtle to aggressive. The additional aromatics should blend well with whatever aromatics are appropriate for the declared base beer style. Appearance: Appearance should be appropriate for the declared base beer and declared fruit. For lighter-colored beers with fruits that exhibit distinctive colors, the color should be noticeable. Note that the color of fruit in beer is often lighter than the flesh of the fruit itself and may take on slightly different shades. Fruit beers may have some haze or be clear, although haze is a generally undesirable. The head may take on some of the color of the fruit. Flavor: As with aroma, the distinctive flavor character associated with the declared fruit should be noticeable, and may range in intensity from subtle to aggressive. The balance of fruit with the underlying beer is vital, and the fruit character should not be so artificial and/or inappropriately overpowering as to suggest a 'fruit juice drink.' Hop bitterness, flavor, malt flavors, alcohol content, and fermentation by-products, such as esters, should be appropriate to the base beer and be harmonious and balanced with the distinctive fruit flavors present. Remember that fruit generally add flavor not sweetness to fruit beers. The sugar found in fruit is usually fully fermented and contributes to lighter flavors and a drier finish than might be expected for the declared base style. However, residual sweetness is not necessarily a negative characteristic unless it has a raw, unfermented quality. Mouthfeel: Mouthfeel may vary depending on the base beer selected and as appropriate to that base beer. Body and carbonation levels should be appropriate to the declared base beer style. Fruit generally adds fermentables that tend to thin out the beer; the resulting beer may seem lighter than expected for the declared base style. Smaller and darker fruit have a tendency to add a tannic depth that should overwhelm the base beer."
+                       cbf/ibu-min         7}))
 
 
 (def fruit-and-spice-beer
@@ -36,27 +37,27 @@
    
    The fruit and spice character should each be evident but in balance with the beer, not so forward as to suggest an artificial product."
   (styles/build-style :fruit-and-spice-beer
-                      {:category        "Fruit Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Fruit and Spice Beer"
-                       :type            "Mixed"
-                       :style-letter    "B"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "29"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Virtually any style of beer. Any combination of Saccharomyces, Brettanomyces, Lactobacillus, Pediococcus, or other similar fermenters. Can also be a blend of styles. While cherries, raspberries, and peaches are most common, other fruits can be used as well. Vegetables with fruit-like characteristics (chile, rhubarb, pumpkin, etc.) may also be used. Wood or barrel aging is very common, but not required."
-                       :examples        "Bell's Cherry Stout, Dogfish Head Aprihop, Ebulum Elderberry Black Ale, Founders Rübæus"
-                       :notes           "A harmonious marriage of fruit, spice, and beer, but still recognizable as a beer. The fruit and spice character should each be evident but in balance with the beer, not so forward as to suggest an artificial product."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: The distinctive aromatics associated with the declared fruit and spices should be noticeable in the aroma; however, note that some fruit (e.g., raspberries, cherries) and some spices (e.g., cinnamon, ginger) have stronger aromas and are more distinctive than others (e.g., blueberries, strawberries) - allow for a range of fruit and spice character and intensity from subtle to aggressive. The additional aromatics should blend well with whatever aromatics are appropriate for the declared base beer style. The hop aroma may be absent or balanced, depending on the declared base style. Appearance: Appearance should be appropriate for the declared base beer and declared fruit and spices. For lighter-colored beers with fruits or spices that exhibit distinctive colors, the color should be noticeable. Note that the color of fruit in beer is often lighter than the flesh of the fruit itself and may take on slightly different shades. May have some haze or be clear, although haze is a generally undesirable. The head may take on some of the color of the fruit or spice. Flavor: As with aroma, the distinctive flavor character associated with the declared fruits and spices should be noticeable, and may range in intensity from subtle to aggressive. The balance of fruit and spices with the underlying beer is vital, and the fruit character should not be so artificial and/or inappropriately overpowering as to suggest a spiced fruit juice drink. Hop bitterness, flavor, malt flavors, alcohol content, and fermentation by-products, such as esters, should be appropriate to the base beer and be harmonious and balanced with the distinctive fruit and spice flavors present. Remember that fruit generally add flavor not sweetness. The sugar found in fruit is usually fully fermented and contributes to lighter flavors and a drier finish than might be expected for the declared base style. However, residual sweetness is not necessarily a negative characteristic unless it has a raw, unfermented quality. Some SHV(s) are inherently bitter and may result in a beer more bitter than the declared base style. Mouthfeel: Mouthfeel may vary depending on the base beer selected and as appropriate to that base beer. Body and carbonation levels should be appropriate to the declared base beer style. Fruit generally adds fermentables that tend to thin out the beer; the resulting beer may seem lighter than expected for the declared base style. Some SHV(s) may add additional body, although fermentable additions may thin out the beer. Some SHV(s) may add a bit of astringency, although a \"raw\" spice character is undesirable."
-                       :ibu-min         7}))
+                      {cbf/category        "Fruit Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Fruit and Spice Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "29"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Virtually any style of beer. Any combination of Saccharomyces, Brettanomyces, Lactobacillus, Pediococcus, or other similar fermenters. Can also be a blend of styles. While cherries, raspberries, and peaches are most common, other fruits can be used as well. Vegetables with fruit-like characteristics (chile, rhubarb, pumpkin, etc.) may also be used. Wood or barrel aging is very common, but not required."
+                       cbf/examples        "Bell's Cherry Stout, Dogfish Head Aprihop, Ebulum Elderberry Black Ale, Founders Rübæus"
+                       cbf/notes           "A harmonious marriage of fruit, spice, and beer, but still recognizable as a beer. The fruit and spice character should each be evident but in balance with the beer, not so forward as to suggest an artificial product."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: The distinctive aromatics associated with the declared fruit and spices should be noticeable in the aroma; however, note that some fruit (e.g., raspberries, cherries) and some spices (e.g., cinnamon, ginger) have stronger aromas and are more distinctive than others (e.g., blueberries, strawberries) - allow for a range of fruit and spice character and intensity from subtle to aggressive. The additional aromatics should blend well with whatever aromatics are appropriate for the declared base beer style. The hop aroma may be absent or balanced, depending on the declared base style. Appearance: Appearance should be appropriate for the declared base beer and declared fruit and spices. For lighter-colored beers with fruits or spices that exhibit distinctive colors, the color should be noticeable. Note that the color of fruit in beer is often lighter than the flesh of the fruit itself and may take on slightly different shades. May have some haze or be clear, although haze is a generally undesirable. The head may take on some of the color of the fruit or spice. Flavor: As with aroma, the distinctive flavor character associated with the declared fruits and spices should be noticeable, and may range in intensity from subtle to aggressive. The balance of fruit and spices with the underlying beer is vital, and the fruit character should not be so artificial and/or inappropriately overpowering as to suggest a spiced fruit juice drink. Hop bitterness, flavor, malt flavors, alcohol content, and fermentation by-products, such as esters, should be appropriate to the base beer and be harmonious and balanced with the distinctive fruit and spice flavors present. Remember that fruit generally add flavor not sweetness. The sugar found in fruit is usually fully fermented and contributes to lighter flavors and a drier finish than might be expected for the declared base style. However, residual sweetness is not necessarily a negative characteristic unless it has a raw, unfermented quality. Some SHV(s) are inherently bitter and may result in a beer more bitter than the declared base style. Mouthfeel: Mouthfeel may vary depending on the base beer selected and as appropriate to that base beer. Body and carbonation levels should be appropriate to the declared base beer style. Fruit generally adds fermentables that tend to thin out the beer; the resulting beer may seem lighter than expected for the declared base style. Some SHV(s) may add additional body, although fermentable additions may thin out the beer. Some SHV(s) may add a bit of astringency, although a \"raw\" spice character is undesirable."
+                       cbf/ibu-min         7}))
 
 
 (def specialty-fruit-beer
@@ -64,27 +65,27 @@
    
    The fruit and sugar character should both be evident but in balance with the beer, not so forward as to suggest an artificial product."
   (styles/build-style :specialty-fruit-beer
-                      {:category        "Fruit Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Specialty Fruit Beer"
-                       :type            "Mixed"
-                       :style-letter    "C"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "29"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Virtually any style of beer. Any combination of Saccharomyces, Brettanomyces, Lactobacillus, Pediococcus, or other similar fermenters. Can also be a blend of styles. While cherries, raspberries, and peaches are most common, other fruits can be used as well. Vegetables with fruit-like characteristics (chile, rhubarb, pumpkin, etc.) may also be used. Wood or barrel aging is very common, but not required."
-                       :examples        "New Planet Raspberry Ale"
-                       :notes           "A harmonious marriage of fruit, sugar, and beer, but still recognizable as a beer. The fruit and sugar character should both be evident but in balance with the beer, not so forward as to suggest an artificial product."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: Same as fruit beer, except that some additional fermentables (honey, molasses, etc.) may add an aroma component. Whatever additional aroma component is present should be in balance with the fruit and the beer components, and be a pleasant combination. Appearance: Same as fruit beer. Flavor: Same as fruit beer, except that some additional fermentables (honey, molasses, etc.) may add a flavor component. Whatever additional flavor component is present should be in balance with the fruit and the beer components, and be a pleasant combination. Added sugars should not have a raw, unfermented flavor. Some added sugars will have unfermentable elements that may provide a fuller finish; fully fermentable sugars may thin out the finish. Mouthfeel: Same as fruit beer, although depending on the type of sugar added, could increase or decrease the body."
-                       :ibu-min         7}))
+                      {cbf/category        "Fruit Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Specialty Fruit Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "29"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Virtually any style of beer. Any combination of Saccharomyces, Brettanomyces, Lactobacillus, Pediococcus, or other similar fermenters. Can also be a blend of styles. While cherries, raspberries, and peaches are most common, other fruits can be used as well. Vegetables with fruit-like characteristics (chile, rhubarb, pumpkin, etc.) may also be used. Wood or barrel aging is very common, but not required."
+                       cbf/examples        "New Planet Raspberry Ale"
+                       cbf/notes           "A harmonious marriage of fruit, sugar, and beer, but still recognizable as a beer. The fruit and sugar character should both be evident but in balance with the beer, not so forward as to suggest an artificial product."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Same as fruit beer, except that some additional fermentables (honey, molasses, etc.) may add an aroma component. Whatever additional aroma component is present should be in balance with the fruit and the beer components, and be a pleasant combination. Appearance: Same as fruit beer. Flavor: Same as fruit beer, except that some additional fermentables (honey, molasses, etc.) may add a flavor component. Whatever additional flavor component is present should be in balance with the fruit and the beer components, and be a pleasant combination. Added sugars should not have a raw, unfermented flavor. Some added sugars will have unfermentable elements that may provide a fuller finish; fully fermentable sugars may thin out the finish. Mouthfeel: Same as fruit beer, although depending on the type of sugar added, could increase or decrease the body."
+                       cbf/ibu-min         7}))
 
 
 (def fruit-beers

--- a/src/common_beer_data/styles/bjcp_2015/german_wheat_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/german_wheat_beer.cljc
@@ -1,32 +1,33 @@
 (ns common-beer-data.styles.bjcp-2015.german-wheat-beer
   "2015 BJCP guidelines on German Wheat Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def weissbier
   "A pale, refreshing German wheat beer with high carbonation, dry finish, a fluffy mouthfeel, and a distinctive banana-and-clove yeast character."
   (styles/build-style :weissbier
-                      {:category        "German Wheat Beer"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.044
-                       :name            "Weissbier"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.043
-                       :fg-min          1.01
-                       :category-number "10"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "By German brewing tradition, at least 50% of the grist must be malted wheat, although some versions use up to 70%; the remainder is typically Pilsner malt. A decoction mash is traditional, although modern brewers typically don't follow this practice. Weizen ale yeast produces the typical spicy and fruity character, although high fermentation temperatures can affect the balance and produce off-flavors."
-                       :examples        "Ayinger Bräu Weisse, Hacker-Pschorr Weisse, Paulaner Hefe-Weizen Naturtrüb, Schneider Weisse Unser Original, Weihenstephaner Hefeweissbier"
-                       :notes           "A pale, refreshing German wheat beer with high carbonation, dry finish, a fluffy mouthfeel, and a distinctive banana-and-clove yeast character."
-                       :og-max          1.052
-                       :color-min       2.0
-                       :abv-max         0.056
-                       :color-max       6.0
-                       :profile         "Aroma: Moderate to strong phenols (usually clove) and fruity esters (typically banana). The balance and intensity of the phenol and ester components can vary but the best examples are reasonably balanced and fairly prominent. The hop character ranges from low to none. A light to moderate wheat aroma (which might be perceived as bready or grainy) may be present but other malt characteristics should not. Optional, but acceptable, aromatics can include a light to moderate vanilla character, and/or a faint bubblegum aroma. None of these optional characteristics should be high or dominant, but often can add to the complexity and balance. Appearance: Pale straw to gold in color. A very thick, moussy, long-lasting white head is characteristic. The high protein content of wheat impairs clarity in an unfiltered beer, although the level of haze is somewhat variable. Flavor: Low to moderately strong banana and clove flavor. The balance and intensity of the phenol and ester components can vary but the best examples are reasonably balanced and fairly prominent. Optionally, a very light to moderate vanilla character and/or faint bubblegum notes can accentuate the banana flavor, sweetness and roundness; neither should be dominant if present. The soft, somewhat bready or grainy flavor of wheat is complementary, as is a slightly grainy-sweet malt character. Hop flavor is very low to none, and hop bitterness is very low to moderately low. Well-rounded, flavorful palate with a relatively dry finish. The perception of sweetness is more due to the absence of hop bitterness than actual residual sweetness; a sweet or heavy finish would significantly impair drinkability. Mouthfeel: Medium-light to medium body; never heavy. Suspended yeast may increase the perception of body. The texture of wheat imparts the sensation of a fluffy, creamy fullness that may progress to a light, spritzy finish aided by high to very high carbonation. Always effervescent."
-                       :ibu-min         8}))
+                      {cbf/category        "German Wheat Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.044
+                       cbf/name            "Weissbier"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.043
+                       cbf/fg-min          1.01
+                       cbf/category-number "10"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "By German brewing tradition, at least 50% of the grist must be malted wheat, although some versions use up to 70%; the remainder is typically Pilsner malt. A decoction mash is traditional, although modern brewers typically don't follow this practice. Weizen ale yeast produces the typical spicy and fruity character, although high fermentation temperatures can affect the balance and produce off-flavors."
+                       cbf/examples        "Ayinger Bräu Weisse, Hacker-Pschorr Weisse, Paulaner Hefe-Weizen Naturtrüb, Schneider Weisse Unser Original, Weihenstephaner Hefeweissbier"
+                       cbf/notes           "A pale, refreshing German wheat beer with high carbonation, dry finish, a fluffy mouthfeel, and a distinctive banana-and-clove yeast character."
+                       cbf/og-max          1.052
+                       cbf/color-min       2.0
+                       cbf/abv-max         0.056
+                       cbf/color-max       6.0
+                       cbf/profile         "Aroma: Moderate to strong phenols (usually clove) and fruity esters (typically banana). The balance and intensity of the phenol and ester components can vary but the best examples are reasonably balanced and fairly prominent. The hop character ranges from low to none. A light to moderate wheat aroma (which might be perceived as bready or grainy) may be present but other malt characteristics should not. Optional, but acceptable, aromatics can include a light to moderate vanilla character, and/or a faint bubblegum aroma. None of these optional characteristics should be high or dominant, but often can add to the complexity and balance. Appearance: Pale straw to gold in color. A very thick, moussy, long-lasting white head is characteristic. The high protein content of wheat impairs clarity in an unfiltered beer, although the level of haze is somewhat variable. Flavor: Low to moderately strong banana and clove flavor. The balance and intensity of the phenol and ester components can vary but the best examples are reasonably balanced and fairly prominent. Optionally, a very light to moderate vanilla character and/or faint bubblegum notes can accentuate the banana flavor, sweetness and roundness; neither should be dominant if present. The soft, somewhat bready or grainy flavor of wheat is complementary, as is a slightly grainy-sweet malt character. Hop flavor is very low to none, and hop bitterness is very low to moderately low. Well-rounded, flavorful palate with a relatively dry finish. The perception of sweetness is more due to the absence of hop bitterness than actual residual sweetness; a sweet or heavy finish would significantly impair drinkability. Mouthfeel: Medium-light to medium body; never heavy. Suspended yeast may increase the perception of body. The texture of wheat imparts the sensation of a fluffy, creamy fullness that may progress to a light, spritzy finish aided by high to very high carbonation. Always effervescent."
+                       cbf/ibu-min         8}))
 
 
 (def dunkles-weissbier
@@ -34,53 +35,53 @@
     
     Highly carbonated and refreshing, with a creamy, fluffy texture and light finish that encourages drinking."
   (styles/build-style :dunkles-weissbier
-                      {:category        "German Wheat Beer"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.044
-                       :name            "Dunkles Weissbier"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.043
-                       :fg-min          1.01
-                       :category-number "10"
-                       :carb-max        3.0
-                       :ibu-max         18
-                       :ingredients     "By German brewing tradition, at least 50% of the grist must be malted wheat, although some versions use up to 70%; the remainder is usually Munich, Vienna, or dark or caramel wheat malts, or Pilsner malt with color malt. A decoction mash is traditional, but infrequently used today. Weizen ale yeasts produce the typical spicy and fruity character, although extreme fermentation temperatures can affect the balance and produce off-flavors."
-                       :examples        "Ayinger Ur-Weisse, Ettaler Weissbier Dunkel, Franziskaner Hefe-Weisse Dunkel, Hacker-Pschorr Weisse Dark, Tucher Dunkles Hefe Weizen, Weihenstephaner Hefeweissbier Dunkel"
-                       :notes           "A moderately dark German wheat beer with a distinctive banana-and-clove yeast character, supported by a toasted bread or caramel malt flavor. Highly carbonated and refreshing, with a creamy, fluffy texture and light finish that encourages drinking."
-                       :og-max          1.056
-                       :color-min       14.0
-                       :abv-max         0.056
-                       :color-max       23.0
-                       :profile         "Aroma: Moderate phenols (usually clove) and fruity esters (usually banana). The balance and intensity of the phenol and ester components can vary but the best examples are reasonably balanced. Optionally, a low to moderate vanilla character and/or faint bubblegum notes may be present, but should not dominate. Hop aroma ranges from low to none, and may be lightly floral, spicy, or herbal. A light to moderate wheat aroma (which might be perceived as bready, doughy or grainy) may be present and is often accompanied by a caramel, bread crust, or richer malt aroma. The malt aroma may moderate the phenols and esters somewhat. Appearance: Light copper to mahogany brown in color. A very thick, moussy, long-lasting off-white head is characteristic. The high protein content of wheat impairs clarity in this traditionally unfiltered style, although the level of haze is somewhat variable. Suspended yeast sediment can contribute to cloudiness. Flavor: Low to moderately strong banana and clove flavor. The balance and intensity of the phenol and ester components can vary but the best examples are reasonably balanced and fairly prominent. Optionally, a very light to moderate vanilla character and/or faint bubblegum notes can accentuate the banana flavor, sweetness and roundness; neither should be dominant if present. The soft, somewhat bready, doughy, or grainy flavor of wheat is complementary, as is a richer caramel, toast, or bread crust flavor. The malty richness can be low to medium-high, and supports the yeast character. A roasted malt character is inappropriate. A spicy, herbal, or floral hop flavor is very low to none, and hop bitterness is very low to low. Well-rounded, flavorful, often somewhat malty palate with a relatively dry finish. Mouthfeel: Medium-light to medium-full body. The texture of wheat as well as yeast in suspension imparts the sensation of a fluffy, creamy fullness that may progress to a lighter finish, aided by moderate to high carbonation. Effervescent."
-                       :ibu-min         10}))
+                      {cbf/category        "German Wheat Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.044
+                       cbf/name            "Dunkles Weissbier"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.043
+                       cbf/fg-min          1.01
+                       cbf/category-number "10"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         18
+                       cbf/ingredients     "By German brewing tradition, at least 50% of the grist must be malted wheat, although some versions use up to 70%; the remainder is usually Munich, Vienna, or dark or caramel wheat malts, or Pilsner malt with color malt. A decoction mash is traditional, but infrequently used today. Weizen ale yeasts produce the typical spicy and fruity character, although extreme fermentation temperatures can affect the balance and produce off-flavors."
+                       cbf/examples        "Ayinger Ur-Weisse, Ettaler Weissbier Dunkel, Franziskaner Hefe-Weisse Dunkel, Hacker-Pschorr Weisse Dark, Tucher Dunkles Hefe Weizen, Weihenstephaner Hefeweissbier Dunkel"
+                       cbf/notes           "A moderately dark German wheat beer with a distinctive banana-and-clove yeast character, supported by a toasted bread or caramel malt flavor. Highly carbonated and refreshing, with a creamy, fluffy texture and light finish that encourages drinking."
+                       cbf/og-max          1.056
+                       cbf/color-min       14.0
+                       cbf/abv-max         0.056
+                       cbf/color-max       23.0
+                       cbf/profile         "Aroma: Moderate phenols (usually clove) and fruity esters (usually banana). The balance and intensity of the phenol and ester components can vary but the best examples are reasonably balanced. Optionally, a low to moderate vanilla character and/or faint bubblegum notes may be present, but should not dominate. Hop aroma ranges from low to none, and may be lightly floral, spicy, or herbal. A light to moderate wheat aroma (which might be perceived as bready, doughy or grainy) may be present and is often accompanied by a caramel, bread crust, or richer malt aroma. The malt aroma may moderate the phenols and esters somewhat. Appearance: Light copper to mahogany brown in color. A very thick, moussy, long-lasting off-white head is characteristic. The high protein content of wheat impairs clarity in this traditionally unfiltered style, although the level of haze is somewhat variable. Suspended yeast sediment can contribute to cloudiness. Flavor: Low to moderately strong banana and clove flavor. The balance and intensity of the phenol and ester components can vary but the best examples are reasonably balanced and fairly prominent. Optionally, a very light to moderate vanilla character and/or faint bubblegum notes can accentuate the banana flavor, sweetness and roundness; neither should be dominant if present. The soft, somewhat bready, doughy, or grainy flavor of wheat is complementary, as is a richer caramel, toast, or bread crust flavor. The malty richness can be low to medium-high, and supports the yeast character. A roasted malt character is inappropriate. A spicy, herbal, or floral hop flavor is very low to none, and hop bitterness is very low to low. Well-rounded, flavorful, often somewhat malty palate with a relatively dry finish. Mouthfeel: Medium-light to medium-full body. The texture of wheat as well as yeast in suspension imparts the sensation of a fluffy, creamy fullness that may progress to a lighter finish, aided by moderate to high carbonation. Effervescent."
+                       cbf/ibu-min         10}))
 
 
 (def weizenbock
   "A strong, malty, fruity, wheat-based ale combining the best malt and yeast flavors of a weissbier (pale or dark) with the malty-rich flavor, strength, and body of a Dunkles Bock or Doppelbock."
   (styles/build-style :weizenbock
-                      {:category        "German Wheat Beer"
-                       :carb-min        1.5
-                       :fg-max          1.022
-                       :og-min          1.064
-                       :name            "Weizenbock"
-                       :type            "Lager"
-                       :style-letter    "C"
-                       :abv-min         0.065
-                       :fg-min          1.015
-                       :category-number "10"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "A high percentage of malted wheat is used (by German brewing tradition must be at least 50%, although it may contain up to 70%), with the remainder being Munich- and/or Vienna-type barley malts in darker versions, and more Pils malt in paler versions. Some color malts may be used sparingly. A traditional decoction mash can give the appropriate body without cloying sweetness. Weizen ale yeasts produce the typical spicy and fruity character. Too warm or too cold fermentation will cause the phenols and esters to be out of balance and may create off-flavors. Hop choice is essentially irrelevant, but German varieties are most traditional."
-                       :examples        "Dark-Eisenbahn Weizenbock, Plank Bavarian Dunkler Weizenbock, Penn Weizenbock, Schneider Unser Aventinus; Pale -Plank Bavarian Heller Weizenbock, Weihenstephaner Vitus"
-                       :notes           "A strong, malty, fruity, wheat-based ale combining the best malt and yeast flavors of a weissbier (pale or dark) with the malty-rich flavor, strength, and body of a Dunkles Bock or Doppelbock."
-                       :og-max          1.09
-                       :color-min       6.0
-                       :abv-max         0.09
-                       :color-max       25.0
-                       :profile         "Aroma: Medium-high to high malty-rich character with a significant bready-grainy wheat component. Paler versions will have a bready-toasty malty richness, while darker versions will have a deeper, richer malt presence with significant Maillard products. The malt component is similar to a helles bock for pale versions (grainy-sweet-rich, lightly toasted) or a dunkles bock for dark versions (bready-malty-rich, highly toasted, optional caramel). The yeast contributes a typical weizen character of banana and spice (clove, vanilla), which can be medium-low to medium-high. Darker versions can have some dark fruit aroma (plums, prunes, grapes, raisins), particularly as they age. A low to moderate alcohol aroma is acceptable, but shouldn't be hot or solventy. No hop aroma. The malt, yeast, and alcohol intertwine to produce a complex, inviting, prominent bouquet. Appearance: Pale and dark versions exist, with pale versions being light gold to light amber, and dark versions being dark amber to dark ruby-brown in color. A very thick, moussy, long-lasting white to off-white (pale versions) or light tan (dark versions) head is characteristic. The high protein content of wheat impairs clarity in this traditionally unfiltered style, although the level of haze is somewhat variable. Suspended yeast sediment can contribute to the cloudiness. Flavor: Similar to the aroma, a medium-high to high malty-rich flavor together with a significant bready-grainy wheat flavor. Paler versions will have a bready, toasty, grainy-sweet malt richness, while darker versions will have deeper, bready-rich or toasted malt flavors with significant Maillard products, optional caramel. Low to moderate banana and spice (clove, vanilla) yeast character. Darker versions can have some dark fruit flavor (plums, prunes, grapes, raisins), particularly as they age. A light chocolate character (but not roast) is optional in darker versions. No hop flavor. A low hop bitterness can give a slightly sweet palate impression, but the beer typically finishes dry (sometimes enhanced by a light alcohol character). The interplay between the malt, yeast, and alcohol adds complexity and interest, which is often enhanced with age. Mouthfeel: Medium-full to full body. A fluffy or creamy texture is typical, as is the mild warming sensation of substantial alcohol content. Moderate to high carbonation."
-                       :ibu-min         15}))
+                      {cbf/category        "German Wheat Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.022
+                       cbf/og-min          1.064
+                       cbf/name            "Weizenbock"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.065
+                       cbf/fg-min          1.015
+                       cbf/category-number "10"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "A high percentage of malted wheat is used (by German brewing tradition must be at least 50%, although it may contain up to 70%), with the remainder being Munich- and/or Vienna-type barley malts in darker versions, and more Pils malt in paler versions. Some color malts may be used sparingly. A traditional decoction mash can give the appropriate body without cloying sweetness. Weizen ale yeasts produce the typical spicy and fruity character. Too warm or too cold fermentation will cause the phenols and esters to be out of balance and may create off-flavors. Hop choice is essentially irrelevant, but German varieties are most traditional."
+                       cbf/examples        "Dark-Eisenbahn Weizenbock, Plank Bavarian Dunkler Weizenbock, Penn Weizenbock, Schneider Unser Aventinus; Pale -Plank Bavarian Heller Weizenbock, Weihenstephaner Vitus"
+                       cbf/notes           "A strong, malty, fruity, wheat-based ale combining the best malt and yeast flavors of a weissbier (pale or dark) with the malty-rich flavor, strength, and body of a Dunkles Bock or Doppelbock."
+                       cbf/og-max          1.09
+                       cbf/color-min       6.0
+                       cbf/abv-max         0.09
+                       cbf/color-max       25.0
+                       cbf/profile         "Aroma: Medium-high to high malty-rich character with a significant bready-grainy wheat component. Paler versions will have a bready-toasty malty richness, while darker versions will have a deeper, richer malt presence with significant Maillard products. The malt component is similar to a helles bock for pale versions (grainy-sweet-rich, lightly toasted) or a dunkles bock for dark versions (bready-malty-rich, highly toasted, optional caramel). The yeast contributes a typical weizen character of banana and spice (clove, vanilla), which can be medium-low to medium-high. Darker versions can have some dark fruit aroma (plums, prunes, grapes, raisins), particularly as they age. A low to moderate alcohol aroma is acceptable, but shouldn't be hot or solventy. No hop aroma. The malt, yeast, and alcohol intertwine to produce a complex, inviting, prominent bouquet. Appearance: Pale and dark versions exist, with pale versions being light gold to light amber, and dark versions being dark amber to dark ruby-brown in color. A very thick, moussy, long-lasting white to off-white (pale versions) or light tan (dark versions) head is characteristic. The high protein content of wheat impairs clarity in this traditionally unfiltered style, although the level of haze is somewhat variable. Suspended yeast sediment can contribute to the cloudiness. Flavor: Similar to the aroma, a medium-high to high malty-rich flavor together with a significant bready-grainy wheat flavor. Paler versions will have a bready, toasty, grainy-sweet malt richness, while darker versions will have deeper, bready-rich or toasted malt flavors with significant Maillard products, optional caramel. Low to moderate banana and spice (clove, vanilla) yeast character. Darker versions can have some dark fruit flavor (plums, prunes, grapes, raisins), particularly as they age. A light chocolate character (but not roast) is optional in darker versions. No hop flavor. A low hop bitterness can give a slightly sweet palate impression, but the beer typically finishes dry (sometimes enhanced by a light alcohol character). The interplay between the malt, yeast, and alcohol adds complexity and interest, which is often enhanced with age. Mouthfeel: Medium-full to full body. A fluffy or creamy texture is typical, as is the mild warming sensation of substantial alcohol content. Moderate to high carbonation."
+                       cbf/ibu-min         15}))
 
 
 (def german-wheat-beer

--- a/src/common_beer_data/styles/bjcp_2015/historic_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/historic_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.historic-beer
   "2015 BJCP guidelines on Historic Beer."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def gose
@@ -8,27 +9,27 @@
    
    Very refreshing, with bright flavors and high attenuation."
   (styles/build-style :gose
-                      {:category        "Historical Beer"
-                       :carb-min        1.5
-                       :fg-max          1.01
-                       :og-min          1.036
-                       :name            "Gose"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.042
-                       :fg-min          1.006
-                       :category-number "27"
-                       :carb-max        3.0
-                       :ibu-max         12
-                       :ingredients     "Pilsner and wheat malt, restrained use of salt and coriander seed, lactobacillus. The coriander should have a fresh, citrusy (lemon or bitter orange), bright note, and not be vegetal, celery-like, or ham-like. The salt should have a sea salt or fresh salt character, not a metallic, iodine note."
-                       :examples        "Anderson Valley Gose, Bayerisch Bahnhof Leipziger Gose, Döllnitzer Ritterguts Gose"
-                       :notes           "A highly-carbonated, tart and fruity wheat ale with a restrained coriander and salt character and low bitterness. Very refreshing, with bright flavors and high attenuation."
-                       :og-max          1.056
-                       :color-min       3.0
-                       :abv-max         0.048
-                       :color-max       4.0
-                       :profile         "Aroma: Light to moderately fruity aroma of pome fruit. Light sourness, slightly sharp. Noticeable coriander, which can have an aromatic lemony quality, and an intensity up to moderate. Light bready, doughy, yeasty character like uncooked sourdough bread. The acidity and coriander can give a bright, lively impression. The salt may be perceived as a very light, clean sea breeze character or just a general freshness, if noticeable at all. Appearance: Unfiltered, with a moderate to full haze. Moderate to tall sized white head with tight bubbles and good retention. Effervescent. Medium yellow color. Flavor: Moderate to restrained but noticeable sourness, like a squeeze of lemon in iced tea. Moderate bready/doughy malt flavor. Light to moderate fruity character of pome fruit, stone fruit, or lemons. Light to moderate salt character, up to the threshold of taste; the salt should be noticeable (particularly in the initial taste) but not taste overtly salty. Low bitterness, no hop flavor. Dry, fully-attenuated finish, with acidity not hops balancing the malt. Acidity can be more noticeable in the finish, and enhance the refreshing quality of the beer. The acidity should be balanced, not forward (although historical versions could be very sour). Mouthfeel: High to very high carbonation, effervescent. Medium-light to medium-full body. Salt may give a slightly tingly, mouthwatering quality, if perceived at all. The yeast and wheat can give it a little body, but it shouldn't have a heavy feel."
-                       :ibu-min         5}))
+                      {cbf/category        "Historical Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.01
+                       cbf/og-min          1.036
+                       cbf/name            "Gose"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.042
+                       cbf/fg-min          1.006
+                       cbf/category-number "27"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         12
+                       cbf/ingredients     "Pilsner and wheat malt, restrained use of salt and coriander seed, lactobacillus. The coriander should have a fresh, citrusy (lemon or bitter orange), bright note, and not be vegetal, celery-like, or ham-like. The salt should have a sea salt or fresh salt character, not a metallic, iodine note."
+                       cbf/examples        "Anderson Valley Gose, Bayerisch Bahnhof Leipziger Gose, Döllnitzer Ritterguts Gose"
+                       cbf/notes           "A highly-carbonated, tart and fruity wheat ale with a restrained coriander and salt character and low bitterness. Very refreshing, with bright flavors and high attenuation."
+                       cbf/og-max          1.056
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.048
+                       cbf/color-max       4.0
+                       cbf/profile         "Aroma: Light to moderately fruity aroma of pome fruit. Light sourness, slightly sharp. Noticeable coriander, which can have an aromatic lemony quality, and an intensity up to moderate. Light bready, doughy, yeasty character like uncooked sourdough bread. The acidity and coriander can give a bright, lively impression. The salt may be perceived as a very light, clean sea breeze character or just a general freshness, if noticeable at all. Appearance: Unfiltered, with a moderate to full haze. Moderate to tall sized white head with tight bubbles and good retention. Effervescent. Medium yellow color. Flavor: Moderate to restrained but noticeable sourness, like a squeeze of lemon in iced tea. Moderate bready/doughy malt flavor. Light to moderate fruity character of pome fruit, stone fruit, or lemons. Light to moderate salt character, up to the threshold of taste; the salt should be noticeable (particularly in the initial taste) but not taste overtly salty. Low bitterness, no hop flavor. Dry, fully-attenuated finish, with acidity not hops balancing the malt. Acidity can be more noticeable in the finish, and enhance the refreshing quality of the beer. The acidity should be balanced, not forward (although historical versions could be very sour). Mouthfeel: High to very high carbonation, effervescent. Medium-light to medium-full body. Salt may give a slightly tingly, mouthwatering quality, if perceived at all. The yeast and wheat can give it a little body, but it shouldn't have a heavy feel."
+                       cbf/ibu-min         5}))
 
 
 (def kentucky-common
@@ -36,27 +37,27 @@
    
    Refreshing due to its high carbonation and mild flavors, and highly sessionable due to being served very fresh and with restrained alcohol levels."
   (styles/build-style :kentucky-common
-                      {:category        "Historical Beer"
-                       :carb-min        1.5
-                       :fg-max          1.018
-                       :og-min          1.044
-                       :name            "Kentucky Common"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.04
-                       :fg-min          1.01
-                       :category-number "27"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "Six-row barley malt was used with 35% corn grits to dilute the excessive protein levels along with 1 to 2% each caramel and black malt. Native American hops, usually about .2 pounds per barrel of Western hops for bittering and a similar amount of New York hops (such as Clusters) for flavor (15 minutes prior to knock out). Imported continental Saazer-type hops (.1 pounds per barrel) were added at knock out for aroma. Water in the Louisville area was typically moderate to high in carbonates. Mash water was often pre-boiled to precipitate the carbonate and Gypsum was commonly added. Considering the time from mash in to kegging for delivery was typically 6 to 8 days, clearly aggressive top-fermenting yeasts was used."
-                       :examples        "Apocalypse Brew Works Ortel's 1912"
-                       :notes           "A darker-colored, light-flavored, malt-accented beer with a dry finish and interesting character malt flavors. Refreshing due to its high carbonation and mild flavors, and highly sessionable due to being served very fresh and with restrained alcohol levels."
-                       :og-max          1.055
-                       :color-min       11.0
-                       :abv-max         0.055
-                       :color-max       20.0
-                       :profile         "Aroma: Low to medium grainy, corn-like or sweet maltiness with a low toast, biscuity-grainy, bready, or caramel malt accent. Medium to moderately-low hop aroma, usually floral or spicy in character. Clean fermentation character, with possible faint berry ester. Low levels of DMS are acceptable. No sourness. Malt-forward in the balance. Appearance: Amber-orange to light brown in color. Typically clear, but may have some light haze due to limited conditioning. Foam stand may not be long lasting, and is usually white to beige in color. Flavor: Moderate grainy-sweet maltiness with low to medium-low caramel, toffee, bready, and/or biscuity notes. Generally light palate flavors typical of adjunct beers; a low grainy, corn-like sweetness is common. Medium to low floral or spicy hop flavor. Medium to low hop bitterness, which should neither be coarse nor have a harsh aftertaste. May exhibit light fruitiness. Balance in the finish is towards the malt. May have a lightly flinty or minerally-sulfate flavor in the finish. The finish is fairly dry, including the contributions of roasted grains and minerals. No sourness. Mouthfeel: Medium to medium-light body with a relatively soft mouthfeel. Highly carbonated. Can have a creamy texture."
-                       :ibu-min         15}))
+                      {cbf/category        "Historical Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.018
+                       cbf/og-min          1.044
+                       cbf/name            "Kentucky Common"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.04
+                       cbf/fg-min          1.01
+                       cbf/category-number "27"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "Six-row barley malt was used with 35% corn grits to dilute the excessive protein levels along with 1 to 2% each caramel and black malt. Native American hops, usually about .2 pounds per barrel of Western hops for bittering and a similar amount of New York hops (such as Clusters) for flavor (15 minutes prior to knock out). Imported continental Saazer-type hops (.1 pounds per barrel) were added at knock out for aroma. Water in the Louisville area was typically moderate to high in carbonates. Mash water was often pre-boiled to precipitate the carbonate and Gypsum was commonly added. Considering the time from mash in to kegging for delivery was typically 6 to 8 days, clearly aggressive top-fermenting yeasts was used."
+                       cbf/examples        "Apocalypse Brew Works Ortel's 1912"
+                       cbf/notes           "A darker-colored, light-flavored, malt-accented beer with a dry finish and interesting character malt flavors. Refreshing due to its high carbonation and mild flavors, and highly sessionable due to being served very fresh and with restrained alcohol levels."
+                       cbf/og-max          1.055
+                       cbf/color-min       11.0
+                       cbf/abv-max         0.055
+                       cbf/color-max       20.0
+                       cbf/profile         "Aroma: Low to medium grainy, corn-like or sweet maltiness with a low toast, biscuity-grainy, bready, or caramel malt accent. Medium to moderately-low hop aroma, usually floral or spicy in character. Clean fermentation character, with possible faint berry ester. Low levels of DMS are acceptable. No sourness. Malt-forward in the balance. Appearance: Amber-orange to light brown in color. Typically clear, but may have some light haze due to limited conditioning. Foam stand may not be long lasting, and is usually white to beige in color. Flavor: Moderate grainy-sweet maltiness with low to medium-low caramel, toffee, bready, and/or biscuity notes. Generally light palate flavors typical of adjunct beers; a low grainy, corn-like sweetness is common. Medium to low floral or spicy hop flavor. Medium to low hop bitterness, which should neither be coarse nor have a harsh aftertaste. May exhibit light fruitiness. Balance in the finish is towards the malt. May have a lightly flinty or minerally-sulfate flavor in the finish. The finish is fairly dry, including the contributions of roasted grains and minerals. No sourness. Mouthfeel: Medium to medium-light body with a relatively soft mouthfeel. Highly carbonated. Can have a creamy texture."
+                       cbf/ibu-min         15}))
 
 
 (def lichtenhainer
@@ -64,53 +65,53 @@
    
    Complex yet refreshing character due to high attenuation and carbonation, along with low bitterness and moderate sourness."
   (styles/build-style :lichtenhainer
-                      {:category        "Historical Beer"
-                       :carb-min        1.5
-                       :fg-max          1.008
-                       :og-min          1.032
-                       :name            "Lichtenhainer"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.035
-                       :fg-min          1.004
-                       :category-number "27"
-                       :carb-max        3.0
-                       :ibu-max         12
-                       :ingredients     "Smoked barley malt, wheat malt, lactobacillus, top-fermenting yeast. Grists vary, but the wheat would typically be 30-50%."
-                       :examples        "Apocalypse Brew Works Ortel's 1912"
-                       :notes           "A sour, smoked, lower-gravity historical German wheat beer. Complex yet refreshing character due to high attenuation and carbonation, along with low bitterness and moderate sourness."
-                       :og-max          1.04
-                       :color-min       3.0
-                       :abv-max         0.047
-                       :color-max       6.0
-                       :profile         "Aroma: Moderately strong fresh smoky aroma, light hints of sourness, medium-low fruity esters, possibly apples or lemons, moderate bready-grainy malt. The smoke character is stronger than the bready notes, and the smoke has a 'dry' character, like the remnants of an old fire, not a 'greasy' smoke. Appearance: Tall off-white head, rocky and persistent. Deep yellow to light gold color. Fair clarity, may be somewhat hazy. Flavor: Moderately strong fruity flavor, possibly lemons or apples. Moderate intensity, clean lactic tartness (no funk). Similar smoky character as aroma (dry wood fire), medium strength. Dry finish, with acidity and smoke in the aftertaste. Low bitterness; the acidity is providing the balance, not hops. Fresh, clean palate and slightly puckery aftertaste. The wheat character is on the low side; the smoke and acidity are more prominent in the balance. The lemony-tart/green apple flavor is strongest in the finish, with smoke a close second. Complex. Mouthfeel: Tingly acidity. High carbonation. Medium to medium-light body."
-                       :ibu-min         5}))
+                      {cbf/category        "Historical Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.008
+                       cbf/og-min          1.032
+                       cbf/name            "Lichtenhainer"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.035
+                       cbf/fg-min          1.004
+                       cbf/category-number "27"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         12
+                       cbf/ingredients     "Smoked barley malt, wheat malt, lactobacillus, top-fermenting yeast. Grists vary, but the wheat would typically be 30-50%."
+                       cbf/examples        "Apocalypse Brew Works Ortel's 1912"
+                       cbf/notes           "A sour, smoked, lower-gravity historical German wheat beer. Complex yet refreshing character due to high attenuation and carbonation, along with low bitterness and moderate sourness."
+                       cbf/og-max          1.04
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.047
+                       cbf/color-max       6.0
+                       cbf/profile         "Aroma: Moderately strong fresh smoky aroma, light hints of sourness, medium-low fruity esters, possibly apples or lemons, moderate bready-grainy malt. The smoke character is stronger than the bready notes, and the smoke has a 'dry' character, like the remnants of an old fire, not a 'greasy' smoke. Appearance: Tall off-white head, rocky and persistent. Deep yellow to light gold color. Fair clarity, may be somewhat hazy. Flavor: Moderately strong fruity flavor, possibly lemons or apples. Moderate intensity, clean lactic tartness (no funk). Similar smoky character as aroma (dry wood fire), medium strength. Dry finish, with acidity and smoke in the aftertaste. Low bitterness; the acidity is providing the balance, not hops. Fresh, clean palate and slightly puckery aftertaste. The wheat character is on the low side; the smoke and acidity are more prominent in the balance. The lemony-tart/green apple flavor is strongest in the finish, with smoke a close second. Complex. Mouthfeel: Tingly acidity. High carbonation. Medium to medium-light body."
+                       cbf/ibu-min         5}))
 
 
 (def london-brown-ale
   "A luscious, sweet, malt-oriented dark brown ale, with caramel and toffee malt complexity and a sweet finish."
   (styles/build-style :london-brown-ale
-                      {:category        "Historical Beer"
-                       :carb-min        1.5
-                       :fg-max          1.015
-                       :og-min          1.033
-                       :name            "London Brown Ale"
-                       :type            "Ale"
-                       :style-letter    "D"
-                       :abv-min         0.028
-                       :fg-min          1.012
-                       :category-number "27"
-                       :carb-max        3.0
-                       :ibu-max         20
-                       :ingredients     "English pale ale malt as a base with a healthy proportion of darker caramel malts and often some roasted (black) malt and wheat malt (this is Mann's traditional grist - others can rely on dark sugars for color and flavor). Moderate to high carbonate water. English hop varieties are most authentic, though with low flavor and bitterness almost any type could be used. Post-fermentation sweetening with lactose or artificial sweeteners, or sucrose (if pasteurized)."
-                       :examples        "Harveys Bloomsbury Brown Ale, Mann's Brown Ale"
-                       :notes           "A luscious, sweet, malt-oriented dark brown ale, with caramel and toffee malt complexity and a sweet finish."
-                       :og-max          1.038
-                       :color-min       22.0
-                       :abv-max         0.036
-                       :color-max       35.0
-                       :profile         "Aroma: Moderate malty-sweet aroma, often with a rich, caramel or toffee-like character. Low to medium fruity esters, often dark fruit like plums. Very low to no hop aroma, earthy or floral qualities. Appearance: Medium to very dark brown color, but can be nearly black. Nearly opaque, although should be relatively clear if visible. Low to moderate off-white to tan head. Flavor: Deep, caramel or toffee-like malty and sweet flavor on the palate and lasting into the finish. Hints of biscuit and coffee are common. Some fruity esters can be present (typically dark fruit); relatively clean fermentation profile for an English ale. Low hop bitterness. Hop flavor is low to non-existent, possibly earthy or floral in character. Moderately-low to no perceivable roasty or bitter black malt flavor. Moderately sweet finish with a smooth, malty aftertaste. May have a sugary-sweet flavor. Mouthfeel: Medium body, but the residual sweetness may give a heavier impression. Medium-low to medium carbonation. Quite creamy and smooth in texture, particularly for its gravity."
-                       :ibu-min         15}))
+                      {cbf/category        "Historical Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.015
+                       cbf/og-min          1.033
+                       cbf/name            "London Brown Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "D"
+                       cbf/abv-min         0.028
+                       cbf/fg-min          1.012
+                       cbf/category-number "27"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         20
+                       cbf/ingredients     "English pale ale malt as a base with a healthy proportion of darker caramel malts and often some roasted (black) malt and wheat malt (this is Mann's traditional grist - others can rely on dark sugars for color and flavor). Moderate to high carbonate water. English hop varieties are most authentic, though with low flavor and bitterness almost any type could be used. Post-fermentation sweetening with lactose or artificial sweeteners, or sucrose (if pasteurized)."
+                       cbf/examples        "Harveys Bloomsbury Brown Ale, Mann's Brown Ale"
+                       cbf/notes           "A luscious, sweet, malt-oriented dark brown ale, with caramel and toffee malt complexity and a sweet finish."
+                       cbf/og-max          1.038
+                       cbf/color-min       22.0
+                       cbf/abv-max         0.036
+                       cbf/color-max       35.0
+                       cbf/profile         "Aroma: Moderate malty-sweet aroma, often with a rich, caramel or toffee-like character. Low to medium fruity esters, often dark fruit like plums. Very low to no hop aroma, earthy or floral qualities. Appearance: Medium to very dark brown color, but can be nearly black. Nearly opaque, although should be relatively clear if visible. Low to moderate off-white to tan head. Flavor: Deep, caramel or toffee-like malty and sweet flavor on the palate and lasting into the finish. Hints of biscuit and coffee are common. Some fruity esters can be present (typically dark fruit); relatively clean fermentation profile for an English ale. Low hop bitterness. Hop flavor is low to non-existent, possibly earthy or floral in character. Moderately-low to no perceivable roasty or bitter black malt flavor. Moderately sweet finish with a smooth, malty aftertaste. May have a sugary-sweet flavor. Mouthfeel: Medium body, but the residual sweetness may give a heavier impression. Medium-low to medium carbonation. Quite creamy and smooth in texture, particularly for its gravity."
+                       cbf/ibu-min         15}))
 
 
 (def piwo-grodziskie
@@ -118,27 +119,27 @@
    
    Highly sessionable."
   (styles/build-style :piwo-grodziskie
-                      {:category        "Historical Beer"
-                       :carb-min        1.5
-                       :fg-max          1.012
-                       :og-min          1.028
-                       :name            "Piwo Grodziskie"
-                       :type            "Ale"
-                       :style-letter    "E"
-                       :abv-min         0.025
-                       :fg-min          1.006
-                       :category-number "27"
-                       :carb-max        3.0
-                       :ibu-max         35
-                       :ingredients     "Grain bill usually consists entirely of oak-smoked wheat malt. Oak-smoked wheat malt has a different (and less intense) smoke character than German beechwood-smoked barley malt; it has a drier, crisper, leaner quality - a bacon/ham smoke flavor is inappropriate. Saazer-type hops (Polish, Czech or German), moderate hardness sulfate water, and a relatively clean and attenuative continental ale yeast fermented at moderate ale temperatures are traditional. German hefeweizen yeast or other strains with a phenol or strong ester character are inappropriate."
-                       :examples        "Harveys Bloomsbury Brown Ale, Mann's Brown Ale"
-                       :notes           "A low-gravity, highly-carbonated, light-bodied ale combining an oak-smoked flavor with a clean hop bitterness. Highly sessionable."
-                       :og-max          1.032
-                       :color-min       3.0
-                       :abv-max         0.033
-                       :color-max       6.0
-                       :profile         "Aroma: Low to moderate oak wood smoke is the most prominent aroma component, but can be subtle and hard to detect. A low spicy, herbal, or floral hop aroma is typically present, and should be lower than or equal to the smoke in intensity. Hints of grainy wheat are also detected in the best examples. The aroma is otherwise clean, although light pome fruit esters (especially ripe red apple or pear) are welcome. No acidity. Slight water-derived sulfury notes may be present. Appearance: Pale yellow to medium gold in color with excellent clarity. A tall, billowy, white, tightly-knit head with excellent retention is distinctive. Murkiness is a fault. Flavor: Moderately-low to medium oak smoke flavor up front which carries into the finish; the smoke can be stronger in flavor than in aroma. The smoke character is gentle, should not be acrid, and can lend an impression of sweetness. A moderate to strong bitterness is readily evident which lingers through the finish. The overall balance is toward bitterness. Low but perceptible spicy, herbal, or floral hop flavor. Low grainy wheat character in the background. Light pome fruit esters (red apple or pear) may be present. Dry, crisp finish. No sourness. Mouthfeel: Light in body, with a crisp and dry finish. Carbonation is quite high and can add a slight carbonic bite or prickly sensation. No noticeable alcohol warmth."
-                       :ibu-min         20}))
+                      {cbf/category        "Historical Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.012
+                       cbf/og-min          1.028
+                       cbf/name            "Piwo Grodziskie"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "E"
+                       cbf/abv-min         0.025
+                       cbf/fg-min          1.006
+                       cbf/category-number "27"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         35
+                       cbf/ingredients     "Grain bill usually consists entirely of oak-smoked wheat malt. Oak-smoked wheat malt has a different (and less intense) smoke character than German beechwood-smoked barley malt; it has a drier, crisper, leaner quality - a bacon/ham smoke flavor is inappropriate. Saazer-type hops (Polish, Czech or German), moderate hardness sulfate water, and a relatively clean and attenuative continental ale yeast fermented at moderate ale temperatures are traditional. German hefeweizen yeast or other strains with a phenol or strong ester character are inappropriate."
+                       cbf/examples        "Harveys Bloomsbury Brown Ale, Mann's Brown Ale"
+                       cbf/notes           "A low-gravity, highly-carbonated, light-bodied ale combining an oak-smoked flavor with a clean hop bitterness. Highly sessionable."
+                       cbf/og-max          1.032
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.033
+                       cbf/color-max       6.0
+                       cbf/profile         "Aroma: Low to moderate oak wood smoke is the most prominent aroma component, but can be subtle and hard to detect. A low spicy, herbal, or floral hop aroma is typically present, and should be lower than or equal to the smoke in intensity. Hints of grainy wheat are also detected in the best examples. The aroma is otherwise clean, although light pome fruit esters (especially ripe red apple or pear) are welcome. No acidity. Slight water-derived sulfury notes may be present. Appearance: Pale yellow to medium gold in color with excellent clarity. A tall, billowy, white, tightly-knit head with excellent retention is distinctive. Murkiness is a fault. Flavor: Moderately-low to medium oak smoke flavor up front which carries into the finish; the smoke can be stronger in flavor than in aroma. The smoke character is gentle, should not be acrid, and can lend an impression of sweetness. A moderate to strong bitterness is readily evident which lingers through the finish. The overall balance is toward bitterness. Low but perceptible spicy, herbal, or floral hop flavor. Low grainy wheat character in the background. Light pome fruit esters (red apple or pear) may be present. Dry, crisp finish. No sourness. Mouthfeel: Light in body, with a crisp and dry finish. Carbonation is quite high and can add a slight carbonic bite or prickly sensation. No noticeable alcohol warmth."
+                       cbf/ibu-min         20}))
 
 
 (def pre-prohibition-lager
@@ -147,105 +148,105 @@
    All malt or rice-based versions have a crisper, more neutral character. 
    The higher bitterness level is the largest differentiator between this style and most modern mass-market pale lagers, but the more robust flavor profile also sets it apart."
   (styles/build-style :pre-prohibition-lager
-                      {:category        "Historical Beer"
-                       :carb-min        1.5
-                       :fg-max          1.015
-                       :og-min          1.044
-                       :name            "Pre-Prohibition Lager"
-                       :type            "Lager"
-                       :style-letter    "F"
-                       :abv-min         0.045
-                       :fg-min          1.01
-                       :category-number "27"
-                       :carb-max        3.0
-                       :ibu-max         40
-                       :ingredients     "Six-row barley with 20% to 30% flaked maize (corn) or rice to dilute the excessive protein levels; modern versions may be all malt. Native American hops such as Clusters, traditional continental hops, or modern noble-type crosses are also appropriate. Modern American hops such as Cascade are inappropriate. Water with a high mineral content can lead to an unpleasant coarseness in flavor and harshness in aftertaste. A wide range of lager yeast character can be exhibited, although modern versions tend to be fairly clean."
-                       :examples        "Anchor California Lager, Coors Batch 19, Little Harpeth Chicken Scratch"
-                       :notes           "A clean, refreshing, but bitter pale lager, often showcasing a grainy-sweet corn flavor. All malt or rice-based versions have a crisper, more neutral character. The higher bitterness level is the largest differentiator between this style and most modern mass-market pale lagers, but the more robust flavor profile also sets it apart."
-                       :og-max          1.06
-                       :color-min       3.0
-                       :abv-max         0.06
-                       :color-max       6.0
-                       :profile         "Aroma: Low to medium grainy, corn-like or sweet maltiness may be evident (although rice-based beers are more neutral). Medium to moderately high hop aroma, with a range of character from rustic to floral to herbal/spicy; a fruity or citrusy modern hop character is inappropriate. Clean lager character. Low DMS is acceptable. May show some yeast character, as with modern American lagers; allow for a range of subtle supporting yeast notes. Appearance: Yellow to deep gold color. Substantial, long lasting white head. Bright clarity. Flavor: Medium to medium-high maltiness with a grainy flavor, and optionally a corn-like roundness and impression of sweetness. Substantial hop bitterness stands up to the malt and lingers through the dry finish. All malt and rice-based versions are often crisper, drier, and generally lack corn-like flavors. Medium to high hop flavor, with a rustic, floral, or herbal/spicy character. Medium to high hop bitterness, which should neither be overly coarse nor have a harsh aftertaste. Allow for a range of lager yeast character, as with modern American lagers, but generally fairly neutral. Mouthfeel: Medium body with a moderately rich, creamy mouthfeel. Smooth and well-lagered. Medium to high carbonation levels."
-                       :ibu-min         25}))
+                      {cbf/category        "Historical Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.015
+                       cbf/og-min          1.044
+                       cbf/name            "Pre-Prohibition Lager"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "F"
+                       cbf/abv-min         0.045
+                       cbf/fg-min          1.01
+                       cbf/category-number "27"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         40
+                       cbf/ingredients     "Six-row barley with 20% to 30% flaked maize (corn) or rice to dilute the excessive protein levels; modern versions may be all malt. Native American hops such as Clusters, traditional continental hops, or modern noble-type crosses are also appropriate. Modern American hops such as Cascade are inappropriate. Water with a high mineral content can lead to an unpleasant coarseness in flavor and harshness in aftertaste. A wide range of lager yeast character can be exhibited, although modern versions tend to be fairly clean."
+                       cbf/examples        "Anchor California Lager, Coors Batch 19, Little Harpeth Chicken Scratch"
+                       cbf/notes           "A clean, refreshing, but bitter pale lager, often showcasing a grainy-sweet corn flavor. All malt or rice-based versions have a crisper, more neutral character. The higher bitterness level is the largest differentiator between this style and most modern mass-market pale lagers, but the more robust flavor profile also sets it apart."
+                       cbf/og-max          1.06
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.06
+                       cbf/color-max       6.0
+                       cbf/profile         "Aroma: Low to medium grainy, corn-like or sweet maltiness may be evident (although rice-based beers are more neutral). Medium to moderately high hop aroma, with a range of character from rustic to floral to herbal/spicy; a fruity or citrusy modern hop character is inappropriate. Clean lager character. Low DMS is acceptable. May show some yeast character, as with modern American lagers; allow for a range of subtle supporting yeast notes. Appearance: Yellow to deep gold color. Substantial, long lasting white head. Bright clarity. Flavor: Medium to medium-high maltiness with a grainy flavor, and optionally a corn-like roundness and impression of sweetness. Substantial hop bitterness stands up to the malt and lingers through the dry finish. All malt and rice-based versions are often crisper, drier, and generally lack corn-like flavors. Medium to high hop flavor, with a rustic, floral, or herbal/spicy character. Medium to high hop bitterness, which should neither be overly coarse nor have a harsh aftertaste. Allow for a range of lager yeast character, as with modern American lagers, but generally fairly neutral. Mouthfeel: Medium body with a moderately rich, creamy mouthfeel. Smooth and well-lagered. Medium to high carbonation levels."
+                       cbf/ibu-min         25}))
 
 
 (def pre-prohibition-porter
   "An American adaptation of English Porter using American ingredients, including adjuncts."
   (styles/build-style :pre-prohibition-porter
-                      {:category        "Historical Beer"
-                       :carb-min        1.5
-                       :fg-max          1.016
-                       :og-min          1.046
-                       :name            "Pre-Prohibition Porter"
-                       :type            "Ale"
-                       :style-letter    "G"
-                       :abv-min         0.045
-                       :fg-min          1.01
-                       :category-number "27"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "Two and six row malt (or a combination of both) are used, along with low percentages of dark malts including black, chocolate, and brown malt (roasted barley is not typically used). Adjuncts are acceptable, including corn, brewers licorice, molasses, and porterine. More historical versions will have up to twenty percent adjuncts. Lager or ale yeast. Emphasis on historical or traditional American bittering hops (Cluster, Willamette, Cascade), though finishing and flavor hops may vary."
-                       :examples        "Stegmaier Porter, Yuengling Porter"
-                       :notes           "An American adaptation of English Porter using American ingredients, including adjuncts."
-                       :og-max          1.06
-                       :color-min       18.0
-                       :abv-max         0.06
-                       :color-max       30.0
-                       :profile         "Aroma: Base grainy malt aroma with low levels of dark malt (slight burnt or chocolate notes). Low hop aroma. Low to moderate low levels of DMS acceptable. May show low levels of caramel and biscuit aroma. No to very low esters. Light adjunct (licorice, molasses) aroma acceptable. Diacetyl low to none. Clean lager profile acceptable. Appearance: Medium to dark brown, though some examples can be nearly black in color, with ruby or mahogany highlights. Relatively clear. Light to medium tan head which will persist in the glass. Flavor: Grainy base malt flavor, with low levels of chocolate or burnt black malt notes, along with low levels of caramel, biscuit, licorice, and toast notes. Corn/DMS flavor acceptable at low to moderate levels. American hop bitterness low to moderate and American hop flavor low to none. Balance is typically even between malt and hops, with a moderate dry finish. Mouthfeel: Medium light to medium body, moderate carbonation, low to moderate creaminess. May have a slight astringency from the dark malts."
-                       :ibu-min         20}))
+                      {cbf/category        "Historical Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.016
+                       cbf/og-min          1.046
+                       cbf/name            "Pre-Prohibition Porter"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "G"
+                       cbf/abv-min         0.045
+                       cbf/fg-min          1.01
+                       cbf/category-number "27"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "Two and six row malt (or a combination of both) are used, along with low percentages of dark malts including black, chocolate, and brown malt (roasted barley is not typically used). Adjuncts are acceptable, including corn, brewers licorice, molasses, and porterine. More historical versions will have up to twenty percent adjuncts. Lager or ale yeast. Emphasis on historical or traditional American bittering hops (Cluster, Willamette, Cascade), though finishing and flavor hops may vary."
+                       cbf/examples        "Stegmaier Porter, Yuengling Porter"
+                       cbf/notes           "An American adaptation of English Porter using American ingredients, including adjuncts."
+                       cbf/og-max          1.06
+                       cbf/color-min       18.0
+                       cbf/abv-max         0.06
+                       cbf/color-max       30.0
+                       cbf/profile         "Aroma: Base grainy malt aroma with low levels of dark malt (slight burnt or chocolate notes). Low hop aroma. Low to moderate low levels of DMS acceptable. May show low levels of caramel and biscuit aroma. No to very low esters. Light adjunct (licorice, molasses) aroma acceptable. Diacetyl low to none. Clean lager profile acceptable. Appearance: Medium to dark brown, though some examples can be nearly black in color, with ruby or mahogany highlights. Relatively clear. Light to medium tan head which will persist in the glass. Flavor: Grainy base malt flavor, with low levels of chocolate or burnt black malt notes, along with low levels of caramel, biscuit, licorice, and toast notes. Corn/DMS flavor acceptable at low to moderate levels. American hop bitterness low to moderate and American hop flavor low to none. Balance is typically even between malt and hops, with a moderate dry finish. Mouthfeel: Medium light to medium body, moderate carbonation, low to moderate creaminess. May have a slight astringency from the dark malts."
+                       cbf/ibu-min         20}))
 
 
 (def roggenbier
   "A dunkelweizen made with rye rather than wheat, but with a greater body and light finishing hops."
   (styles/build-style :roggenbier
-                      {:category        "Historical Beer"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.046
-                       :name            "Roggenbier"
-                       :type            "Ale"
-                       :style-letter    "H"
-                       :abv-min         0.045
-                       :fg-min          1.01
-                       :category-number "27"
-                       :carb-max        3.0
-                       :ibu-max         20
-                       :ingredients     "Malted rye typically constitutes 50% or greater of the grist (some versions have 60-65% rye). Remainder of grist can include pale malt, Munich malt, wheat malt, crystal malt and/or small amounts of debittered dark malts for color adjustment. Weizen yeast provides distinctive banana esters and clove phenols. Light usage of Saazer-type hops in bitterness, flavor and aroma. Lower fermentation temperatures accentuate the clove character by suppressing ester formation. Decoction mash traditionally used (as with weissbiers)."
-                       :examples        "Thurn und Taxis Roggen"
-                       :notes           "A dunkelweizen made with rye rather than wheat, but with a greater body and light finishing hops."
-                       :og-max          1.056
-                       :color-min       14.0
-                       :abv-max         0.06
-                       :color-max       19.0
-                       :profile         "Aroma: Light to moderate spicy rye aroma intermingled with light to moderate weizen yeast aromatics (spicy clove and fruity esters, either banana or citrus). Light spicy, floral, or herbal hops are acceptable. Appearance: Light coppery-orange to very dark reddish or coppery-brown color. Large creamy off-white to tan head, quite dense and persistent (often thick and rocky). Cloudy, hazy appearance. Flavor: Grainy, moderately-low to moderately-strong spicy rye flavor, often having a hearty flavor reminiscent of rye or pumpernickel bread. Medium to medium-low bitterness allows an initial malt sweetness (sometimes with a bit of caramel) to be tasted before yeast and rye character takes over. Low to moderate weizen yeast character (banana, clove), although the balance can vary. Medium-dry, grainy finish with a lightly bitter (from rye) aftertaste. Low to moderate spicy, herbal, or floral hop flavor acceptable, and can persist into aftertaste. Mouthfeel: Medium to medium-full body. High carbonation. Moderately creamy."
-                       :ibu-min         10}))
+                      {cbf/category        "Historical Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.046
+                       cbf/name            "Roggenbier"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "H"
+                       cbf/abv-min         0.045
+                       cbf/fg-min          1.01
+                       cbf/category-number "27"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         20
+                       cbf/ingredients     "Malted rye typically constitutes 50% or greater of the grist (some versions have 60-65% rye). Remainder of grist can include pale malt, Munich malt, wheat malt, crystal malt and/or small amounts of debittered dark malts for color adjustment. Weizen yeast provides distinctive banana esters and clove phenols. Light usage of Saazer-type hops in bitterness, flavor and aroma. Lower fermentation temperatures accentuate the clove character by suppressing ester formation. Decoction mash traditionally used (as with weissbiers)."
+                       cbf/examples        "Thurn und Taxis Roggen"
+                       cbf/notes           "A dunkelweizen made with rye rather than wheat, but with a greater body and light finishing hops."
+                       cbf/og-max          1.056
+                       cbf/color-min       14.0
+                       cbf/abv-max         0.06
+                       cbf/color-max       19.0
+                       cbf/profile         "Aroma: Light to moderate spicy rye aroma intermingled with light to moderate weizen yeast aromatics (spicy clove and fruity esters, either banana or citrus). Light spicy, floral, or herbal hops are acceptable. Appearance: Light coppery-orange to very dark reddish or coppery-brown color. Large creamy off-white to tan head, quite dense and persistent (often thick and rocky). Cloudy, hazy appearance. Flavor: Grainy, moderately-low to moderately-strong spicy rye flavor, often having a hearty flavor reminiscent of rye or pumpernickel bread. Medium to medium-low bitterness allows an initial malt sweetness (sometimes with a bit of caramel) to be tasted before yeast and rye character takes over. Low to moderate weizen yeast character (banana, clove), although the balance can vary. Medium-dry, grainy finish with a lightly bitter (from rye) aftertaste. Low to moderate spicy, herbal, or floral hop flavor acceptable, and can persist into aftertaste. Mouthfeel: Medium to medium-full body. High carbonation. Moderately creamy."
+                       cbf/ibu-min         10}))
 
 
 (def sahti
   "A sweet, heavy, strong traditional Finnish beer with a rye, juniper, and juniper berry flavor and a strong banana-clove yeast character."
   (styles/build-style :sahti
-                      {:category        "Historical Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Sahti"
-                       :type            "Ale"
-                       :style-letter    "I"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "27"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Malted barley along with malted and unmalted grains, often rye. Low hops. Juniper boughs used for lautering (traditionally in a hollowed-out log), but often producing a juniper/berry character. Often uses top-fermenting baker's yeast in a fast, warm fermentation (German Weizen yeast is a good substitute). Not boiled; a long mash steep is used, with a separately added hop tea."
-                       :examples        "Thurn und Taxis Roggen"
-                       :notes           "A sweet, heavy, strong traditional Finnish beer with a rye, juniper, and juniper berry flavor and a strong banana-clove yeast character."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: High banana esters with moderate to moderately-high clove-like phenolics. Not sour. May have a low to moderate juniper character. Grainy malt, caramel, and rye in background. Light alcohol aroma. Sweet malt impression. Appearance: Pale yellow to dark brown color; most are medium to dark amber. Generally quite cloudy (unfiltered). Little head, due to low carbonation. Flavor: Strong banana and moderate to moderately-high clove yeast character. Moderate grainy rye flavor. Low bitterness. Fairly sweet finish. Juniper can add a pine-like flavor; juniper berries can add a gin-like flavor; both should be complementary, not dominant. No noticeable hop flavor. Moderate caramel flavor but no roast. Multi-layered and complex, with kind of a wortiness that is unusual in other beer styles. Not sour. Mouthfeel: Thick, viscous, and heavy with protein (no boil means no hot break). Nearly still to medium-low carbonation. Strongly warming from the alcohol level and young age, but often masked by sweetness."
-                       :ibu-min         7}))
+                      {cbf/category        "Historical Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Sahti"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "I"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "27"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Malted barley along with malted and unmalted grains, often rye. Low hops. Juniper boughs used for lautering (traditionally in a hollowed-out log), but often producing a juniper/berry character. Often uses top-fermenting baker's yeast in a fast, warm fermentation (German Weizen yeast is a good substitute). Not boiled; a long mash steep is used, with a separately added hop tea."
+                       cbf/examples        "Thurn und Taxis Roggen"
+                       cbf/notes           "A sweet, heavy, strong traditional Finnish beer with a rye, juniper, and juniper berry flavor and a strong banana-clove yeast character."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: High banana esters with moderate to moderately-high clove-like phenolics. Not sour. May have a low to moderate juniper character. Grainy malt, caramel, and rye in background. Light alcohol aroma. Sweet malt impression. Appearance: Pale yellow to dark brown color; most are medium to dark amber. Generally quite cloudy (unfiltered). Little head, due to low carbonation. Flavor: Strong banana and moderate to moderately-high clove yeast character. Moderate grainy rye flavor. Low bitterness. Fairly sweet finish. Juniper can add a pine-like flavor; juniper berries can add a gin-like flavor; both should be complementary, not dominant. No noticeable hop flavor. Moderate caramel flavor but no roast. Multi-layered and complex, with kind of a wortiness that is unusual in other beer styles. Not sour. Mouthfeel: Thick, viscous, and heavy with protein (no boil means no hot break). Nearly still to medium-low carbonation. Strongly warming from the alcohol level and young age, but often masked by sweetness."
+                       cbf/ibu-min         7}))
 
 
 (def historic-beer

--- a/src/common_beer_data/styles/bjcp_2015/international_lager.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/international_lager.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.international-lager
   "2015 BJCP guidelines on International Lagers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def international-pale-lager
@@ -8,27 +9,27 @@
    
    Served cold, it is refreshing and thirst-quenching."
   (styles/build-style :international-pale-lager
-                      {:category        "International Lager"
-                       :carb-min        1.5
-                       :fg-max          1.012
-                       :og-min          1.042
-                       :name            "International Pale Lager"
-                       :type            "Lager"
-                       :style-letter    "A"
-                       :abv-min         0.046
-                       :fg-min          1.008
-                       :category-number "2"
-                       :carb-max        3.0
-                       :ibu-max         25
-                       :ingredients     "Two- or six-row barley. May use rice, corn, or sugar as adjuncts, or may be all malt."
-                       :examples        "Asahi Super Dry, Birra Moretti, Corona Extra, Devils Backbone Gold Leaf Lager, Full Sail Session Premium Lager, Heineken, Red Stripe, Singha"
-                       :notes           "A highly-attenuated pale lager without strong flavors, typically well-balanced and highly carbonated. Served cold, it is refreshing and thirst-quenching."
-                       :og-max          1.05
-                       :color-min       2.0
-                       :abv-max         0.06
-                       :color-max       6.0
-                       :profile         "Aroma: Low to medium-low malt aroma, which can be grainy-malty or slightly corny-sweet. Hop aroma may range from very low to a medium, spicy or floral hop presence. While a clean fermentation profile is generally most desirable, low levels of yeast character (such as a light apple fruitiness) are not a fault. A light amount of DMS or corn aroma is not a fault. Appearance: Pale straw to gold color. White, frothy head may not be long lasting. Very clear. Flavor: Low to moderate levels of grainy-malt flavor, with a crisp, dry, well-attenuated finish. The grain character can be somewhat neutral, or show a light bready-crackery quality or up to moderate corny or malty sweetness. Hop flavor ranges from none to medium levels, and often showing a floral, spicy, or herbal character if detected. Hop bitterness at medium-low to medium level. Balance may vary from slightly malty to slightly bitter, but is relatively close to even. Neutral aftertaste with light malt and sometimes hop flavors. A light amount of DMS is not a fault. Mouthfeel: Light to medium body. Moderately high to highly carbonated. Can have a slight carbonic bite on the tongue."
-                       :ibu-min         18}))
+                      {cbf/category        "International Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.012
+                       cbf/og-min          1.042
+                       cbf/name            "International Pale Lager"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.046
+                       cbf/fg-min          1.008
+                       cbf/category-number "2"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         25
+                       cbf/ingredients     "Two- or six-row barley. May use rice, corn, or sugar as adjuncts, or may be all malt."
+                       cbf/examples        "Asahi Super Dry, Birra Moretti, Corona Extra, Devils Backbone Gold Leaf Lager, Full Sail Session Premium Lager, Heineken, Red Stripe, Singha"
+                       cbf/notes           "A highly-attenuated pale lager without strong flavors, typically well-balanced and highly carbonated. Served cold, it is refreshing and thirst-quenching."
+                       cbf/og-max          1.05
+                       cbf/color-min       2.0
+                       cbf/abv-max         0.06
+                       cbf/color-max       6.0
+                       cbf/profile         "Aroma: Low to medium-low malt aroma, which can be grainy-malty or slightly corny-sweet. Hop aroma may range from very low to a medium, spicy or floral hop presence. While a clean fermentation profile is generally most desirable, low levels of yeast character (such as a light apple fruitiness) are not a fault. A light amount of DMS or corn aroma is not a fault. Appearance: Pale straw to gold color. White, frothy head may not be long lasting. Very clear. Flavor: Low to moderate levels of grainy-malt flavor, with a crisp, dry, well-attenuated finish. The grain character can be somewhat neutral, or show a light bready-crackery quality or up to moderate corny or malty sweetness. Hop flavor ranges from none to medium levels, and often showing a floral, spicy, or herbal character if detected. Hop bitterness at medium-low to medium level. Balance may vary from slightly malty to slightly bitter, but is relatively close to even. Neutral aftertaste with light malt and sometimes hop flavors. A light amount of DMS is not a fault. Mouthfeel: Light to medium body. Moderately high to highly carbonated. Can have a slight carbonic bite on the tongue."
+                       cbf/ibu-min         18}))
 
 
 (def international-amber-lager
@@ -37,27 +38,27 @@
    Usually fairly well-attenuated, often with an adjunct quality. 
    Smooth, easily-drinkable lager character."
   (styles/build-style :international-amber-lager
-                      {:category        "International Lager"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.042
-                       :name            "International Amber Lager"
-                       :type            "Lager"
-                       :style-letter    "B"
-                       :abv-min         0.046
-                       :fg-min          1.008
-                       :category-number "2"
-                       :carb-max        3.0
-                       :ibu-max         25
-                       :ingredients     "Two-row or six-row base malt. Color malts such as victory, amber, etc. Caramel malt adjuncts. European or American hops or a combination of both."
-                       :examples        "Brooklyn Lager, Capital Winter Skål, Dos Equis Amber, Schell's Oktoberfest, Yuengling Lager"
-                       :notes           "A well-attenuated malty amber lager with an interesting caramel or toast quality and restrained bitterness. Usually fairly well-attenuated, often with an adjunct quality. Smooth, easily-drinkable lager character."
-                       :og-max          1.055
-                       :color-min       7.0
-                       :abv-max         0.06
-                       :color-max       14.0
-                       :profile         "Aroma: Low to moderate malt aroma which can be grainy, with a very low to moderate caramel-sweet to toasty-malty aroma. Hop aroma can range from low to none with a mildly floral or spicy character. Clean lager profile. A slight DMS or corny aroma is acceptable. Appearance: Golden-amber to reddish-copper color. Bright clarity. White to off-white foam stand which may not last. Flavor: Low to moderate malt profile which can vary from dry to grainy-sweet. Low to moderate levels of caramel and toasty-bready notes can be evident. Low to medium-low corny sweetness is optional, but not a fault. Hop bitterness is low to moderate, and hop flavor is low to moderate with a spicy, herbal, or floral character. The balance can be fairly malty to nearly even, with the bitterness becoming more noticeable but not objectionable. The bitterness level can increase if the malt character increases to match. Clean fermentation profile. Finish is moderately dry with a moderately malty aftertaste. Mouthfeel: Light to medium body. Medium to high carbonation. Smooth; some examples can be creamy."
-                       :ibu-min         8}))
+                      {cbf/category        "International Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.042
+                       cbf/name            "International Amber Lager"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.046
+                       cbf/fg-min          1.008
+                       cbf/category-number "2"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         25
+                       cbf/ingredients     "Two-row or six-row base malt. Color malts such as victory, amber, etc. Caramel malt adjuncts. European or American hops or a combination of both."
+                       cbf/examples        "Brooklyn Lager, Capital Winter Skål, Dos Equis Amber, Schell's Oktoberfest, Yuengling Lager"
+                       cbf/notes           "A well-attenuated malty amber lager with an interesting caramel or toast quality and restrained bitterness. Usually fairly well-attenuated, often with an adjunct quality. Smooth, easily-drinkable lager character."
+                       cbf/og-max          1.055
+                       cbf/color-min       7.0
+                       cbf/abv-max         0.06
+                       cbf/color-max       14.0
+                       cbf/profile         "Aroma: Low to moderate malt aroma which can be grainy, with a very low to moderate caramel-sweet to toasty-malty aroma. Hop aroma can range from low to none with a mildly floral or spicy character. Clean lager profile. A slight DMS or corny aroma is acceptable. Appearance: Golden-amber to reddish-copper color. Bright clarity. White to off-white foam stand which may not last. Flavor: Low to moderate malt profile which can vary from dry to grainy-sweet. Low to moderate levels of caramel and toasty-bready notes can be evident. Low to medium-low corny sweetness is optional, but not a fault. Hop bitterness is low to moderate, and hop flavor is low to moderate with a spicy, herbal, or floral character. The balance can be fairly malty to nearly even, with the bitterness becoming more noticeable but not objectionable. The bitterness level can increase if the malt character increases to match. Clean fermentation profile. Finish is moderately dry with a moderately malty aftertaste. Mouthfeel: Light to medium body. Medium to high carbonation. Smooth; some examples can be creamy."
+                       cbf/ibu-min         8}))
 
 
 (def international-dark-lager
@@ -65,27 +66,27 @@
    
    The low bitterness leaves the malt as the primary flavor element, and the low hop levels provide very little in the way of balance."
   (styles/build-style :international-dark-lager
-                      {:category        "International Lager"
-                       :carb-min        1.5
-                       :fg-max          1.012
-                       :og-min          1.044
-                       :name            "International Dark Lager"
-                       :type            "Lager"
-                       :style-letter    "C"
-                       :abv-min         0.042
-                       :fg-min          1.008
-                       :category-number "2"
-                       :carb-max        3.0
-                       :ibu-max         20
-                       :ingredients     "Two- or six-row barley, corn, rice, or sugars as adjuncts. Light use of caramel and darker malts. Commercial versions may use coloring agents."
-                       :examples        "Baltika #4 Original, Devils Backbone Old Virginia Dark, Dixie Blackened Voodoo, Saint Pauli Girl Dark, San Miguel Dark, Session Black Dark Lager, Shiner Bock"
-                       :notes           "A darker and somewhat sweeter version of international pale lager with a little more body and flavor, but equally restrained in bitterness. The low bitterness leaves the malt as the primary flavor element, and the low hop levels provide very little in the way of balance."
-                       :og-max          1.056
-                       :color-min       14.0
-                       :abv-max         0.06
-                       :color-max       22.0
-                       :profile         "Aroma: Little to no malt aroma; may have a light corn character. Medium-low to no roast and caramel malt aroma. Hop aroma may range from none to light spicy or floral hop presence. While a clean fermentation profile is generally most desirable, low levels of yeast character (such as a light apple fruitiness) are not a fault. A light amount of DMS or corn aroma is not a fault. Appearance: Deep amber to dark brown with bright clarity and ruby highlights. Foam stand may not be long lasting, and is beige to light tan in color. Flavor: Low to medium malty sweetness with medium-low to no caramel and/or roasted malt flavors (and may include hints of coffee, molasses or cocoa). Hop flavor ranges from none to low levels, and is typically floral, spicy, or herbal. Low to medium hop bitterness. May have a very light fruitiness. Moderately crisp finish. The balance is typically somewhat malty. Burnt or moderately strong roasted malt flavors are a defect. Mouthfeel: Light to medium-light body. Smooth with a light creaminess. Medium to high carbonation."
-                       :ibu-min         8}))
+                      {cbf/category        "International Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.012
+                       cbf/og-min          1.044
+                       cbf/name            "International Dark Lager"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.042
+                       cbf/fg-min          1.008
+                       cbf/category-number "2"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         20
+                       cbf/ingredients     "Two- or six-row barley, corn, rice, or sugars as adjuncts. Light use of caramel and darker malts. Commercial versions may use coloring agents."
+                       cbf/examples        "Baltika #4 Original, Devils Backbone Old Virginia Dark, Dixie Blackened Voodoo, Saint Pauli Girl Dark, San Miguel Dark, Session Black Dark Lager, Shiner Bock"
+                       cbf/notes           "A darker and somewhat sweeter version of international pale lager with a little more body and flavor, but equally restrained in bitterness. The low bitterness leaves the malt as the primary flavor element, and the low hop levels provide very little in the way of balance."
+                       cbf/og-max          1.056
+                       cbf/color-min       14.0
+                       cbf/abv-max         0.06
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Little to no malt aroma; may have a light corn character. Medium-low to no roast and caramel malt aroma. Hop aroma may range from none to light spicy or floral hop presence. While a clean fermentation profile is generally most desirable, low levels of yeast character (such as a light apple fruitiness) are not a fault. A light amount of DMS or corn aroma is not a fault. Appearance: Deep amber to dark brown with bright clarity and ruby highlights. Foam stand may not be long lasting, and is beige to light tan in color. Flavor: Low to medium malty sweetness with medium-low to no caramel and/or roasted malt flavors (and may include hints of coffee, molasses or cocoa). Hop flavor ranges from none to low levels, and is typically floral, spicy, or herbal. Low to medium hop bitterness. May have a very light fruitiness. Moderately crisp finish. The balance is typically somewhat malty. Burnt or moderately strong roasted malt flavors are a defect. Mouthfeel: Light to medium-light body. Smooth with a light creaminess. Medium to high carbonation."
+                       cbf/ibu-min         8}))
 
 
 (def international-lager

--- a/src/common_beer_data/styles/bjcp_2015/ipa.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/ipa.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.ipa
   "2015 BJCP guidelines on IPAs (India Pale Ales)."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def american-ipa
@@ -8,27 +9,27 @@
    
    The balance is hop-forward, with a clean fermentation profile, dryish finish, and clean, supporting malt allowing a creative range of hop character to shine through."
   (styles/build-style :american-ipa
-                      {:category        "IPA"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.056
-                       :name            "American IPA"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.055
-                       :fg-min          1.008
-                       :category-number "21"
-                       :carb-max        3.0
-                       :ibu-max         70
-                       :ingredients     "Pale ale or 2-row brewers malt as the base, American or New World hops, American or English yeast with a clean or slightly fruity profile. Generally all-malt, but mashed at lower temperatures for high attenuation. Sugar additions to aid attenuation are acceptable. Restrained use of crystal malts, if any, as high amounts can lead to a sweet finish and clash with the hop character."
-                       :examples        "Alpine Duet, Bell's Two-Hearted Ale, Fat Heads Head Hunter IPA, Firestone Walker Union Jack, Lagunitas IPA, Russian River Blind Pig IPA, Stone IPA"
-                       :notes           "A decidedly hoppy and bitter, moderately strong American pale ale, showcasing modern American or New World hop varieties. The balance is hop-forward, with a clean fermentation profile, dryish finish, and clean, supporting malt allowing a creative range of hop character to shine through."
-                       :og-max          1.07
-                       :color-min       6.0
-                       :abv-max         0.075
-                       :color-max       14.0
-                       :profile         "Aroma: A prominent to intense hop aroma featuring one or more characteristics of American or New World hops, such as citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, melon, etc. Many versions are dry hopped and can have an additional fresh hop aroma; this is desirable but not required. Grassiness should be minimal, if present. A low to medium-low clean, grainy-malty aroma may be found in the background. Fruitiness from yeast may also be detected in some versions, although a neutral fermentation character is also acceptable. A restrained alcohol note may be present, but this character should be minimal at best. Any American or New World hop character is acceptable; new hop varieties continue to be released and should not constrain this style. Appearance: Color ranges from medium gold to light reddish-amber. Should be clear, although unfiltered dry-hopped versions may be a bit hazy. Medium-sized, white to off-white head with good persistence. Flavor: Hop flavor is medium to very high, and should reflect an American or New World hop character, such as citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, melon, etc. Medium-high to very high hop bitterness. Malt flavor should be low to medium-low, and is generally clean and grainy-malty although some light caramel or toasty flavors are acceptable. Low yeast-derived fruitiness is acceptable but not required. Dry to medium-dry finish; residual sweetness should be low to none. The bitterness and hop flavor may linger into the aftertaste but should not be harsh. A very light, clean alcohol flavor may be noted in stronger versions. May be slightly sulfury, but most examples do not exhibit this character. Mouthfeel: Medium-light to medium body, with a smooth texture. Medium to medium-high carbonation. No harsh hop-derived astringency. Very light, smooth alcohol warming not a fault if it does not intrude into overall balance."
-                       :ibu-min         40}))
+                      {cbf/category        "IPA"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.056
+                       cbf/name            "American IPA"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.055
+                       cbf/fg-min          1.008
+                       cbf/category-number "21"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         70
+                       cbf/ingredients     "Pale ale or 2-row brewers malt as the base, American or New World hops, American or English yeast with a clean or slightly fruity profile. Generally all-malt, but mashed at lower temperatures for high attenuation. Sugar additions to aid attenuation are acceptable. Restrained use of crystal malts, if any, as high amounts can lead to a sweet finish and clash with the hop character."
+                       cbf/examples        "Alpine Duet, Bell's Two-Hearted Ale, Fat Heads Head Hunter IPA, Firestone Walker Union Jack, Lagunitas IPA, Russian River Blind Pig IPA, Stone IPA"
+                       cbf/notes           "A decidedly hoppy and bitter, moderately strong American pale ale, showcasing modern American or New World hop varieties. The balance is hop-forward, with a clean fermentation profile, dryish finish, and clean, supporting malt allowing a creative range of hop character to shine through."
+                       cbf/og-max          1.07
+                       cbf/color-min       6.0
+                       cbf/abv-max         0.075
+                       cbf/color-max       14.0
+                       cbf/profile         "Aroma: A prominent to intense hop aroma featuring one or more characteristics of American or New World hops, such as citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, melon, etc. Many versions are dry hopped and can have an additional fresh hop aroma; this is desirable but not required. Grassiness should be minimal, if present. A low to medium-low clean, grainy-malty aroma may be found in the background. Fruitiness from yeast may also be detected in some versions, although a neutral fermentation character is also acceptable. A restrained alcohol note may be present, but this character should be minimal at best. Any American or New World hop character is acceptable; new hop varieties continue to be released and should not constrain this style. Appearance: Color ranges from medium gold to light reddish-amber. Should be clear, although unfiltered dry-hopped versions may be a bit hazy. Medium-sized, white to off-white head with good persistence. Flavor: Hop flavor is medium to very high, and should reflect an American or New World hop character, such as citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, melon, etc. Medium-high to very high hop bitterness. Malt flavor should be low to medium-low, and is generally clean and grainy-malty although some light caramel or toasty flavors are acceptable. Low yeast-derived fruitiness is acceptable but not required. Dry to medium-dry finish; residual sweetness should be low to none. The bitterness and hop flavor may linger into the aftertaste but should not be harsh. A very light, clean alcohol flavor may be noted in stronger versions. May be slightly sulfury, but most examples do not exhibit this character. Mouthfeel: Medium-light to medium body, with a smooth texture. Medium to medium-high carbonation. No harsh hop-derived astringency. Very light, smooth alcohol warming not a fault if it does not intrude into overall balance."
+                       cbf/ibu-min         40}))
 
 
 (def specialty-ipa
@@ -37,27 +38,27 @@
    Should have good drinkability, regardless of the form. 
    Excessive harshness and heaviness are typically faults, as are strong flavor clashes between the hops and the other specialty ingredients."
   (styles/build-style :specialty-ipa
-                      {:category        "IPA"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.056
-                       :name            "Specialty IPA"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.055
-                       :fg-min          1.008
-                       :category-number "21"
-                       :carb-max        3.0
-                       :ibu-max         70
-                       :ingredients     "Pale ale or 2-row brewers malt as the base, American or New World hops, American or English yeast with a clean or slightly fruity profile. Generally all-malt, but mashed at lower temperatures for high attenuation. Sugar additions to aid attenuation are acceptable. Restrained use of crystal malts, if any, as high amounts can lead to a sweet finish and clash with the hop character."
-                       :examples        "Alpine Duet, Bell's Two-Hearted Ale, Fat Heads Head Hunter IPA, Firestone Walker Union Jack, Lagunitas IPA, Russian River Blind Pig IPA, Stone IPA"
-                       :notes           "Recognizable as an IPA by balance - a hop-forward, bitter, dryish beer - with something else present to distinguish it from the standard categories. Should have good drinkability, regardless of the form. Excessive harshness and heaviness are typically faults, as are strong flavor clashes between the hops and the other specialty ingredients."
-                       :og-max          1.07
-                       :color-min       6.0
-                       :abv-max         0.075
-                       :color-max       14.0
-                       :profile         "Aroma: Detectable hop aroma is required; characterization of hops is dependent on the specific type of Specialty IPA. Other aromatics may be present; hop aroma is typically the strongest element. Appearance: Color depends on specific type of Specialty IPA. Most should be clear, although certain styles with high amounts of starchy adjuncts, or unfiltered dry-hopped versions may be slightly hazy. Darker types can be opaque making clarity irrelevant. Good, persistent head stand with color dependent on the specific type of Specialty IPA. Flavor: Hop flavor is typically medium-low to high, with qualities dependent on typical varieties used in the specific Specialty IPA. Hop bitterness is typically medium-high to very high, with qualities dependent on typical varieties used in the specific Specialty IPA. Malt flavor generally low to medium, with qualities dependent on typical varieties used in the specific Specialty IPA. Commonly will have a medium-dry to dry finish. Some clean alcohol flavor can be noted in stronger versions. Various types of Specialty IPAs can show additional malt and yeast characteristics, depending on the type. Mouthfeel: Smooth, medium-light to medium-bodied mouthfeel. Medium carbonation. Some smooth alcohol warming can be sensed in stronger versions."
-                       :ibu-min         40}))
+                      {cbf/category        "IPA"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.056
+                       cbf/name            "Specialty IPA"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.055
+                       cbf/fg-min          1.008
+                       cbf/category-number "21"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         70
+                       cbf/ingredients     "Pale ale or 2-row brewers malt as the base, American or New World hops, American or English yeast with a clean or slightly fruity profile. Generally all-malt, but mashed at lower temperatures for high attenuation. Sugar additions to aid attenuation are acceptable. Restrained use of crystal malts, if any, as high amounts can lead to a sweet finish and clash with the hop character."
+                       cbf/examples        "Alpine Duet, Bell's Two-Hearted Ale, Fat Heads Head Hunter IPA, Firestone Walker Union Jack, Lagunitas IPA, Russian River Blind Pig IPA, Stone IPA"
+                       cbf/notes           "Recognizable as an IPA by balance - a hop-forward, bitter, dryish beer - with something else present to distinguish it from the standard categories. Should have good drinkability, regardless of the form. Excessive harshness and heaviness are typically faults, as are strong flavor clashes between the hops and the other specialty ingredients."
+                       cbf/og-max          1.07
+                       cbf/color-min       6.0
+                       cbf/abv-max         0.075
+                       cbf/color-max       14.0
+                       cbf/profile         "Aroma: Detectable hop aroma is required; characterization of hops is dependent on the specific type of Specialty IPA. Other aromatics may be present; hop aroma is typically the strongest element. Appearance: Color depends on specific type of Specialty IPA. Most should be clear, although certain styles with high amounts of starchy adjuncts, or unfiltered dry-hopped versions may be slightly hazy. Darker types can be opaque making clarity irrelevant. Good, persistent head stand with color dependent on the specific type of Specialty IPA. Flavor: Hop flavor is typically medium-low to high, with qualities dependent on typical varieties used in the specific Specialty IPA. Hop bitterness is typically medium-high to very high, with qualities dependent on typical varieties used in the specific Specialty IPA. Malt flavor generally low to medium, with qualities dependent on typical varieties used in the specific Specialty IPA. Commonly will have a medium-dry to dry finish. Some clean alcohol flavor can be noted in stronger versions. Various types of Specialty IPAs can show additional malt and yeast characteristics, depending on the type. Mouthfeel: Smooth, medium-light to medium-bodied mouthfeel. Medium carbonation. Some smooth alcohol warming can be sensed in stronger versions."
+                       cbf/ibu-min         40}))
 
 
 (def ipa

--- a/src/common_beer_data/styles/bjcp_2015/irish_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/irish_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.irish-beer
   "2015 BJCP guidelines on Irish Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def irish-red-ale
@@ -9,27 +10,27 @@
    Slightly malty in the balance sometimes with an initial soft toffee/caramel sweetness, a slightly grainy-biscuity palate, and a touch of roasted dryness in the finish. 
    Some versions can emphasize the caramel and sweetness more, while others will favor the grainy palate and roasted dryness."
   (styles/build-style :irish-red-ale
-                      {:category        "Irish Beer"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.036
-                       :name            "Irish Red Ale"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.038
-                       :fg-min          1.01
-                       :category-number "15"
-                       :carb-max        3.0
-                       :ibu-max         28
-                       :ingredients     "Generally has a bit of roasted barley or black malt to provide reddish color and dry roasted finish. Pale base malt. Caramel malts were historically imported and more expensive, so not all brewers would use them."
-                       :examples        "Caffrey's Irish Ale, Franciscan Well Rebel Red, Kilkenny Irish Beer, O'Hara's Irish Red Ale, Porterhouse Red Ale, Samuel Adams Irish Red, Smithwick's Irish Ale"
-                       :notes           "An easy-drinking pint, often with subtle flavors. Slightly malty in the balance sometimes with an initial soft toffee/caramel sweetness, a slightly grainy-biscuity palate, and a touch of roasted dryness in the finish. Some versions can emphasize the caramel and sweetness more, while others will favor the grainy palate and roasted dryness."
-                       :og-max          1.046
-                       :color-min       9.0
-                       :abv-max         0.05
-                       :color-max       14.0
-                       :profile         "Aroma: Low to moderate malt aroma, either neutral-grainy or with a lightly caramelly-toasty-toffee character. May have a very light buttery character (although this is not required). Hop aroma is low earthy or floral to none (usually not present). Quite clean. Appearance: Medium amber to medium reddish-copper color. Clear. Low off-white to tan colored head, average persistence. Flavor: Moderate to very little caramel malt flavor and sweetness, rarely with a light buttered toast or toffee-like quality. The palate often is fairly neutral and grainy, or can take on a lightly toasty or biscuity note as it finishes with a light taste of roasted grain, which lends a characteristic dryness to the finish. A light earthy or floral hop flavor is optional. Medium to medium-low hop bitterness. Medium-dry to dry finish. Clean and smooth. Little to no esters. The balance tends to be slightly towards the malt, although light use of roasted grains may increase the perception of bitterness slightly. Mouthfeel: Medium-light to medium body, although examples containing low levels of diacetyl may have a slightly slick mouthfeel (not required). Moderate carbonation. Smooth. Moderately attenuated."
-                       :ibu-min         18}))
+                      {cbf/category        "Irish Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.036
+                       cbf/name            "Irish Red Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.038
+                       cbf/fg-min          1.01
+                       cbf/category-number "15"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         28
+                       cbf/ingredients     "Generally has a bit of roasted barley or black malt to provide reddish color and dry roasted finish. Pale base malt. Caramel malts were historically imported and more expensive, so not all brewers would use them."
+                       cbf/examples        "Caffrey's Irish Ale, Franciscan Well Rebel Red, Kilkenny Irish Beer, O'Hara's Irish Red Ale, Porterhouse Red Ale, Samuel Adams Irish Red, Smithwick's Irish Ale"
+                       cbf/notes           "An easy-drinking pint, often with subtle flavors. Slightly malty in the balance sometimes with an initial soft toffee/caramel sweetness, a slightly grainy-biscuity palate, and a touch of roasted dryness in the finish. Some versions can emphasize the caramel and sweetness more, while others will favor the grainy palate and roasted dryness."
+                       cbf/og-max          1.046
+                       cbf/color-min       9.0
+                       cbf/abv-max         0.05
+                       cbf/color-max       14.0
+                       cbf/profile         "Aroma: Low to moderate malt aroma, either neutral-grainy or with a lightly caramelly-toasty-toffee character. May have a very light buttery character (although this is not required). Hop aroma is low earthy or floral to none (usually not present). Quite clean. Appearance: Medium amber to medium reddish-copper color. Clear. Low off-white to tan colored head, average persistence. Flavor: Moderate to very little caramel malt flavor and sweetness, rarely with a light buttered toast or toffee-like quality. The palate often is fairly neutral and grainy, or can take on a lightly toasty or biscuity note as it finishes with a light taste of roasted grain, which lends a characteristic dryness to the finish. A light earthy or floral hop flavor is optional. Medium to medium-low hop bitterness. Medium-dry to dry finish. Clean and smooth. Little to no esters. The balance tends to be slightly towards the malt, although light use of roasted grains may increase the perception of bitterness slightly. Mouthfeel: Medium-light to medium body, although examples containing low levels of diacetyl may have a slightly slick mouthfeel (not required). Moderate carbonation. Smooth. Moderately attenuated."
+                       cbf/ibu-min         18}))
 
 
 (def irish-stout
@@ -39,27 +40,27 @@
    Draught versions typically are creamy from a nitro pour, but bottled versions will not have this dispense-derived character. 
    The roasted flavor can be dry and coffee-like to somewhat chocolaty."
   (styles/build-style :irish-stout
-                      {:category        "Irish Beer"
-                       :carb-min        1.5
-                       :fg-max          1.011
-                       :og-min          1.036
-                       :name            "Irish Stout"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.04
-                       :fg-min          1.007
-                       :category-number "15"
-                       :carb-max        3.0
-                       :ibu-max         45
-                       :ingredients     "Guinness is made using roasted barley, flaked barley, and pale malt, but other breweries don't necessarily use roasted barley; they can use chocolate or other dark and specialty malts. Whatever combination of malts or grains is used, the resulting product should be black. Cork-type stouts are perhaps closer to historical London-type stouts in composition with a varied grist not dominated by roasted barley."
-                       :examples        "Beamish Irish Stout, Guinness Draught, Harpoon Boston Irish Stout, Murphy's Irish Stout, O'Hara's Irish Stout, Porterhouse Wrasslers 4X"
-                       :notes           "A black beer with a pronounced roasted flavor, often similar to coffee. The balance can range from fairly even to quite bitter, with the more balanced versions having a little malty sweetness and the bitter versions being quite dry. Draught versions typically are creamy from a nitro pour, but bottled versions will not have this dispense-derived character. The roasted flavor can be dry and coffee-like to somewhat chocolaty."
-                       :og-max          1.044
-                       :color-min       25.0
-                       :abv-max         0.045
-                       :color-max       40.0
-                       :profile         "Aroma: Moderate coffee-like aroma typically dominates; may have slight dark chocolate, cocoa and/or roasted grain secondary notes. Esters medium-low to none. Hop aroma low to none, may be lightly earthy or floral, but is typically absent. Appearance: Jet black to very deep brown with garnet highlights in color. According to Guinness, \"Guinness beer may appear black, but it is actually a very dark shade of ruby.\" Opaque. A thick, creamy, long-lasting, tan- to brown-colored head is characteristic when served on nitro, but don't expect the tight, creamy head on a bottled beer. Flavor: Moderate roasted grain or malt flavor with a medium to high hop bitterness. The finish can be dry and coffee-like to moderately balanced with a touch of caramel or malty sweetness. Typically has coffee-like flavors, but also may have a bittersweet or unsweetened chocolate character in the palate, lasting into the finish. Balancing factors may include some creaminess, medium-low to no fruitiness, and medium to no hop flavor (often earthy). The level of bitterness is somewhat variable, as is the roasted character and the dryness of the finish; allow for interpretation by brewers. Mouthfeel: Medium-light to medium-full body, with a somewhat creamy character (particularly when served with a nitro pour). Low to moderate carbonation. For the high hop bitterness and significant proportion of dark grains present, this beer is remarkably smooth. May have a light astringency from the roasted grains, although harshness is undesirable."
-                       :ibu-min         25}))
+                      {cbf/category        "Irish Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.011
+                       cbf/og-min          1.036
+                       cbf/name            "Irish Stout"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.04
+                       cbf/fg-min          1.007
+                       cbf/category-number "15"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         45
+                       cbf/ingredients     "Guinness is made using roasted barley, flaked barley, and pale malt, but other breweries don't necessarily use roasted barley; they can use chocolate or other dark and specialty malts. Whatever combination of malts or grains is used, the resulting product should be black. Cork-type stouts are perhaps closer to historical London-type stouts in composition with a varied grist not dominated by roasted barley."
+                       cbf/examples        "Beamish Irish Stout, Guinness Draught, Harpoon Boston Irish Stout, Murphy's Irish Stout, O'Hara's Irish Stout, Porterhouse Wrasslers 4X"
+                       cbf/notes           "A black beer with a pronounced roasted flavor, often similar to coffee. The balance can range from fairly even to quite bitter, with the more balanced versions having a little malty sweetness and the bitter versions being quite dry. Draught versions typically are creamy from a nitro pour, but bottled versions will not have this dispense-derived character. The roasted flavor can be dry and coffee-like to somewhat chocolaty."
+                       cbf/og-max          1.044
+                       cbf/color-min       25.0
+                       cbf/abv-max         0.045
+                       cbf/color-max       40.0
+                       cbf/profile         "Aroma: Moderate coffee-like aroma typically dominates; may have slight dark chocolate, cocoa and/or roasted grain secondary notes. Esters medium-low to none. Hop aroma low to none, may be lightly earthy or floral, but is typically absent. Appearance: Jet black to very deep brown with garnet highlights in color. According to Guinness, \"Guinness beer may appear black, but it is actually a very dark shade of ruby.\" Opaque. A thick, creamy, long-lasting, tan- to brown-colored head is characteristic when served on nitro, but don't expect the tight, creamy head on a bottled beer. Flavor: Moderate roasted grain or malt flavor with a medium to high hop bitterness. The finish can be dry and coffee-like to moderately balanced with a touch of caramel or malty sweetness. Typically has coffee-like flavors, but also may have a bittersweet or unsweetened chocolate character in the palate, lasting into the finish. Balancing factors may include some creaminess, medium-low to no fruitiness, and medium to no hop flavor (often earthy). The level of bitterness is somewhat variable, as is the roasted character and the dryness of the finish; allow for interpretation by brewers. Mouthfeel: Medium-light to medium-full body, with a somewhat creamy character (particularly when served with a nitro pour). Low to moderate carbonation. For the high hop bitterness and significant proportion of dark grains present, this beer is remarkably smooth. May have a light astringency from the roasted grains, although harshness is undesirable."
+                       cbf/ibu-min         25}))
 
 
 (def irish-extra-stout
@@ -67,27 +68,27 @@
    
    The balance can range from moderately bittersweet to bitter, with the more balanced versions having up to moderate malty richness and the bitter versions being quite dry."
   (styles/build-style :irish-extra-stout
-                      {:category        "Irish Beer"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.052
-                       :name            "Irish Extra Stout"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.055
-                       :fg-min          1.01
-                       :category-number "15"
-                       :carb-max        3.0
-                       :ibu-max         50
-                       :ingredients     "Similar to Irish Stout."
-                       :examples        "Guinness Extra Stout (US version), O'Hara's Leann Folláin, Sheaf Stout"
-                       :notes           "A fuller-bodied black beer with a pronounced roasted flavor, often similar to coffee and dark chocolate with some malty complexity. The balance can range from moderately bittersweet to bitter, with the more balanced versions having up to moderate malty richness and the bitter versions being quite dry."
-                       :og-max          1.062
-                       :color-min       25.0
-                       :abv-max         0.065
-                       :color-max       40.0
-                       :profile         "Aroma: Moderate to moderately high coffee-like aroma, often with slight dark chocolate, cocoa, biscuit, vanilla and/or roasted grain secondary notes. Esters medium-low to none. Hop aroma low to none, may be lightly earthy or spicy, but is typically absent. Malt and roast dominate the aroma. Appearance: Jet black. Opaque. A thick, creamy, tan head is characteristic. Flavor: Moderate to moderately high dark-roasted grain or malt flavor with a medium to medium-high hop bitterness. The finish can be dry and coffee-like to moderately balanced with up to moderate caramel or malty sweetness. Typically has roasted coffee-like flavors, but also often has a dark chocolate character in the palate, lasting into the finish. Background mocha, biscuit, or vanilla flavors are often present and add complexity. Medium-low to no fruitiness. Medium to no hop flavor (often earthy or spicy). The level of bitterness is somewhat variable, as is the roasted character and the dryness of the finish; allow for interpretation by brewers. Mouthfeel: Medium-full to full body, with a somewhat creamy character. Moderate carbonation. Very smooth. May have a light astringency from the roasted grains, although harshness is undesirable. A slightly warming character may be detected."
-                       :ibu-min         35}))
+                      {cbf/category        "Irish Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.052
+                       cbf/name            "Irish Extra Stout"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.055
+                       cbf/fg-min          1.01
+                       cbf/category-number "15"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         50
+                       cbf/ingredients     "Similar to Irish Stout."
+                       cbf/examples        "Guinness Extra Stout (US version), O'Hara's Leann Folláin, Sheaf Stout"
+                       cbf/notes           "A fuller-bodied black beer with a pronounced roasted flavor, often similar to coffee and dark chocolate with some malty complexity. The balance can range from moderately bittersweet to bitter, with the more balanced versions having up to moderate malty richness and the bitter versions being quite dry."
+                       cbf/og-max          1.062
+                       cbf/color-min       25.0
+                       cbf/abv-max         0.065
+                       cbf/color-max       40.0
+                       cbf/profile         "Aroma: Moderate to moderately high coffee-like aroma, often with slight dark chocolate, cocoa, biscuit, vanilla and/or roasted grain secondary notes. Esters medium-low to none. Hop aroma low to none, may be lightly earthy or spicy, but is typically absent. Malt and roast dominate the aroma. Appearance: Jet black. Opaque. A thick, creamy, tan head is characteristic. Flavor: Moderate to moderately high dark-roasted grain or malt flavor with a medium to medium-high hop bitterness. The finish can be dry and coffee-like to moderately balanced with up to moderate caramel or malty sweetness. Typically has roasted coffee-like flavors, but also often has a dark chocolate character in the palate, lasting into the finish. Background mocha, biscuit, or vanilla flavors are often present and add complexity. Medium-low to no fruitiness. Medium to no hop flavor (often earthy or spicy). The level of bitterness is somewhat variable, as is the roasted character and the dryness of the finish; allow for interpretation by brewers. Mouthfeel: Medium-full to full body, with a somewhat creamy character. Moderate carbonation. Very smooth. May have a light astringency from the roasted grains, although harshness is undesirable. A slightly warming character may be detected."
+                       cbf/ibu-min         35}))
 
 
 (def irish-beer

--- a/src/common_beer_data/styles/bjcp_2015/pale_american_ale.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/pale_american_ale.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.pale-american-ale
   "2015 BJCP guidelines on Pale American Ale."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def blonde-ale
@@ -8,27 +9,27 @@
 
    Well-balanced and clean, is a refreshing pint without aggressive flavors."
   (styles/build-style :blonde-ale
-                      {:category        "Pale American Ale"
-                       :carb-min        1.5
-                       :fg-max          1.013
-                       :og-min          1.038
-                       :name            "Blonde Ale"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.038
-                       :fg-min          1.008
-                       :category-number "18"
-                       :carb-max        3.0
-                       :ibu-max         28
-                       :ingredients     "Generally all malt, but can include up to 25% wheat malt and some sugar adjuncts. Any hop variety can be used. Clean American, lightly fruity English, or Kölsch yeast. May also be made with lager yeast, or cold-conditioned. Some versions may have honey, spices and/or fruit added, although if any of these ingredients are stronger than a background flavor they should be entered in those specialty categories instead."
-                       :examples        "Kona Big Wave Golden Ale, Pelican Kiwanda Cream Ale, Russian River Aud Blonde, Victory Summer Love, Widmer Citra Summer Blonde Brew"
-                       :notes           "Easy-drinking, approachable, malt-oriented American craft beer, often with interesting fruit, hop, or character malt notes. Well-balanced and clean, is a refreshing pint without aggressive flavors."
-                       :og-max          1.054
-                       :color-min       3.0
-                       :abv-max         0.055
-                       :color-max       6.0
-                       :profile         "Aroma: Light to moderate sweet malty aroma, possibly with a light bready or caramelly note. Low to moderate fruitiness is optional, but acceptable. May have a low to medium hop aroma, and can reflect almost any hop variety although citrusy, floral, fruity, and spicy notes are common. Appearance: Light yellow to deep gold in color. Clear to brilliant. Low to medium white head with fair to good retention. Flavor: Initial soft malty sweetness, but optionally some light character malt flavor (e.g., bread, toast, biscuit, wheat) can also be present. Caramel flavors typically absent; if present, they are typically low-color caramel notes. Low to medium fruity esters optional, but are welcome. Light to moderate hop flavor (any variety), but shouldn't be overly aggressive. Medium-low to medium bitterness, but the balance is normally towards the malt or even between malt and hops. Finishes medium-dry to slightly malty-sweet; impression of sweetness is often an expression of lower bitterness than actual residual sweetness. Mouthfeel: Medium-light to medium body. Medium to high carbonation. Smooth without being heavy."
-                       :ibu-min         15}))
+                      {cbf/category        "Pale American Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.013
+                       cbf/og-min          1.038
+                       cbf/name            "Blonde Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.038
+                       cbf/fg-min          1.008
+                       cbf/category-number "18"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         28
+                       cbf/ingredients     "Generally all malt, but can include up to 25% wheat malt and some sugar adjuncts. Any hop variety can be used. Clean American, lightly fruity English, or Kölsch yeast. May also be made with lager yeast, or cold-conditioned. Some versions may have honey, spices and/or fruit added, although if any of these ingredients are stronger than a background flavor they should be entered in those specialty categories instead."
+                       cbf/examples        "Kona Big Wave Golden Ale, Pelican Kiwanda Cream Ale, Russian River Aud Blonde, Victory Summer Love, Widmer Citra Summer Blonde Brew"
+                       cbf/notes           "Easy-drinking, approachable, malt-oriented American craft beer, often with interesting fruit, hop, or character malt notes. Well-balanced and clean, is a refreshing pint without aggressive flavors."
+                       cbf/og-max          1.054
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.055
+                       cbf/color-max       6.0
+                       cbf/profile         "Aroma: Light to moderate sweet malty aroma, possibly with a light bready or caramelly note. Low to moderate fruitiness is optional, but acceptable. May have a low to medium hop aroma, and can reflect almost any hop variety although citrusy, floral, fruity, and spicy notes are common. Appearance: Light yellow to deep gold in color. Clear to brilliant. Low to medium white head with fair to good retention. Flavor: Initial soft malty sweetness, but optionally some light character malt flavor (e.g., bread, toast, biscuit, wheat) can also be present. Caramel flavors typically absent; if present, they are typically low-color caramel notes. Low to medium fruity esters optional, but are welcome. Light to moderate hop flavor (any variety), but shouldn't be overly aggressive. Medium-low to medium bitterness, but the balance is normally towards the malt or even between malt and hops. Finishes medium-dry to slightly malty-sweet; impression of sweetness is often an expression of lower bitterness than actual residual sweetness. Mouthfeel: Medium-light to medium body. Medium to high carbonation. Smooth without being heavy."
+                       cbf/ibu-min         15}))
 
 
 (def american-pale-ale
@@ -37,27 +38,27 @@
    The clean hop presence can reflect classic or modern American or New World hop varieties with a wide range of characteristics. 
    An average-strength hop-forward pale American craft beer, generally balanced to be more accessible than modern American IPAs."
   (styles/build-style :american-pale-ale
-                      {:category        "Pale American Ale"
-                       :carb-min        1.5
-                       :fg-max          1.015
-                       :og-min          1.045
-                       :name            "American Pale Ale"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.045
-                       :fg-min          1.01
-                       :category-number "18"
-                       :carb-max        3.0
-                       :ibu-max         50
-                       :ingredients     "Pale ale malt, typically North American two-row. American or New World hops, with a wide range of allowable characteristics. American or English ale yeast (neutral to lightly fruity). Specialty grains may add character and complexity, but generally make up a relatively small portion of the grist. Grains that add malt flavor and richness, light sweetness, and toasty or bready notes are often used (along with late hops) to differentiate brands."
-                       :examples        "Ballast Point Grunion Pale Ale, Firestone Walker Pale 31, Great Lakes Burning River, Sierra Nevada Pale Ale, Stone Pale Ale, Tröegs Pale Ale"
-                       :notes           "A pale, refreshing and hoppy ale, yet with sufficient supporting malt to make the beer balanced and drinkable. The clean hop presence can reflect classic or modern American or New World hop varieties with a wide range of characteristics. An average-strength hop-forward pale American craft beer, generally balanced to be more accessible than modern American IPAs."
-                       :og-max          1.06
-                       :color-min       5.0
-                       :abv-max         0.062
-                       :color-max       10.0
-                       :profile         "Aroma: Moderate to strong hop aroma from American or New World hop varieties with a wide range of possible characteristics, including citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, or melon. None of these specific characteristics are required, but hops should be apparent. Low to moderate maltiness supports the hop presentation, and may optionally show small amounts of specialty malt character (bready, toasty, biscuit, caramelly). Fruity esters vary from moderate to none. Dry hopping (if used) may add grassy notes, although this character should not be excessive. Appearance: Pale golden to light amber. Moderately large white to off-white head with good retention. Generally quite clear, although dry-hopped versions may be slightly hazy. Flavor: Moderate to high hop flavor, typically showing an American or New World hop character (citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, melon, etc.). Low to moderate clean grainy-malt character supports the hop presentation, and may optionally show small amounts of specialty malt character (bready, toasty, biscuity). The balance is typically towards the late hops and bitterness, but the malt presence should be supportive, not distracting. Caramel flavors are often absent or fairly restrained (but are acceptable as long as they don't clash with the hops). Fruity yeast esters can be moderate to none, although many hop varieties are quite fruity. Moderate to high hop bitterness with a medium to dry finish. Hop flavor and bitterness often lingers into the finish, but the aftertaste should generally be clean and not harsh. Dry hopping (if used) may add grassy notes, although this character should not be excessive. Mouthfeel: Medium-light to medium body. Moderate to high carbonation. Overall smooth finish without astringency and harshness."
-                       :ibu-min         30}))
+                      {cbf/category        "Pale American Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.015
+                       cbf/og-min          1.045
+                       cbf/name            "American Pale Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.045
+                       cbf/fg-min          1.01
+                       cbf/category-number "18"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         50
+                       cbf/ingredients     "Pale ale malt, typically North American two-row. American or New World hops, with a wide range of allowable characteristics. American or English ale yeast (neutral to lightly fruity). Specialty grains may add character and complexity, but generally make up a relatively small portion of the grist. Grains that add malt flavor and richness, light sweetness, and toasty or bready notes are often used (along with late hops) to differentiate brands."
+                       cbf/examples        "Ballast Point Grunion Pale Ale, Firestone Walker Pale 31, Great Lakes Burning River, Sierra Nevada Pale Ale, Stone Pale Ale, Tröegs Pale Ale"
+                       cbf/notes           "A pale, refreshing and hoppy ale, yet with sufficient supporting malt to make the beer balanced and drinkable. The clean hop presence can reflect classic or modern American or New World hop varieties with a wide range of characteristics. An average-strength hop-forward pale American craft beer, generally balanced to be more accessible than modern American IPAs."
+                       cbf/og-max          1.06
+                       cbf/color-min       5.0
+                       cbf/abv-max         0.062
+                       cbf/color-max       10.0
+                       cbf/profile         "Aroma: Moderate to strong hop aroma from American or New World hop varieties with a wide range of possible characteristics, including citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, or melon. None of these specific characteristics are required, but hops should be apparent. Low to moderate maltiness supports the hop presentation, and may optionally show small amounts of specialty malt character (bready, toasty, biscuit, caramelly). Fruity esters vary from moderate to none. Dry hopping (if used) may add grassy notes, although this character should not be excessive. Appearance: Pale golden to light amber. Moderately large white to off-white head with good retention. Generally quite clear, although dry-hopped versions may be slightly hazy. Flavor: Moderate to high hop flavor, typically showing an American or New World hop character (citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, melon, etc.). Low to moderate clean grainy-malt character supports the hop presentation, and may optionally show small amounts of specialty malt character (bready, toasty, biscuity). The balance is typically towards the late hops and bitterness, but the malt presence should be supportive, not distracting. Caramel flavors are often absent or fairly restrained (but are acceptable as long as they don't clash with the hops). Fruity yeast esters can be moderate to none, although many hop varieties are quite fruity. Moderate to high hop bitterness with a medium to dry finish. Hop flavor and bitterness often lingers into the finish, but the aftertaste should generally be clean and not harsh. Dry hopping (if used) may add grassy notes, although this character should not be excessive. Mouthfeel: Medium-light to medium body. Moderate to high carbonation. Overall smooth finish without astringency and harshness."
+                       cbf/ibu-min         30}))
 
 
 (def pale-american-ale

--- a/src/common_beer_data/styles/bjcp_2015/pale_bitter_european_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/pale_bitter_european_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.pale-bitter-european-beer
   "2015 BJCP guidelines on Pale Bitter European Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def german-leichtbier
@@ -8,27 +9,27 @@
    
    Moderately bitter with noticeable malt and hop flavors, the beer is still interesting to drink."
   (styles/build-style :german-leichtbier
-                      {:category        "Pale Bitter European Beer"
-                       :carb-min        1.5
-                       :fg-max          1.01
-                       :og-min          1.026
-                       :name            "German Leichtbier"
-                       :type            "Lager"
-                       :style-letter    "A"
-                       :abv-min         0.024
-                       :fg-min          1.006
-                       :category-number "5"
-                       :carb-max        3.0
-                       :ibu-max         28
-                       :ingredients     "Similar to a German Pils or Helles, continental Pils malt, German lager yeast, Saazer-type hops."
-                       :examples        "Beck's Light, Bitburger Light, Mahr's Leicht, Paulaner Münchner Hell Leicht, Paulaner Premium Leicht"
-                       :notes           "A pale, highly-attenuated, light-bodied German lager with lower alcohol and calories than normal-strength beers. Moderately bitter with noticeable malt and hop flavors, the beer is still interesting to drink."
-                       :og-max          1.034
-                       :color-min       2.0
-                       :abv-max         0.036
-                       :color-max       5.0
-                       :profile         "Aroma: Low to medium hop aroma, with a spicy, herbal, or floral character. Low to medium-low grainy-sweet or slightly crackery malt aroma. Clean fermentation profile. Appearance: Straw to pale gold in color. Brilliant clarity. Moderate white head with average to below average persistence. Flavor: Low to medium grainy-sweet malt flavor initially. Medium hop bitterness. Low to medium hop flavor, with a spicy, herbal, or floral quality. Clean fermentation character, well-lagered. Dry finish with a light malty and hoppy aftertaste. Mouthfeel: Light to very light body. Medium to high carbonation. Smooth, well-attenuated."
-                       :ibu-min         15}))
+                      {cbf/category        "Pale Bitter European Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.01
+                       cbf/og-min          1.026
+                       cbf/name            "German Leichtbier"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.024
+                       cbf/fg-min          1.006
+                       cbf/category-number "5"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         28
+                       cbf/ingredients     "Similar to a German Pils or Helles, continental Pils malt, German lager yeast, Saazer-type hops."
+                       cbf/examples        "Beck's Light, Bitburger Light, Mahr's Leicht, Paulaner Münchner Hell Leicht, Paulaner Premium Leicht"
+                       cbf/notes           "A pale, highly-attenuated, light-bodied German lager with lower alcohol and calories than normal-strength beers. Moderately bitter with noticeable malt and hop flavors, the beer is still interesting to drink."
+                       cbf/og-max          1.034
+                       cbf/color-min       2.0
+                       cbf/abv-max         0.036
+                       cbf/color-max       5.0
+                       cbf/profile         "Aroma: Low to medium hop aroma, with a spicy, herbal, or floral character. Low to medium-low grainy-sweet or slightly crackery malt aroma. Clean fermentation profile. Appearance: Straw to pale gold in color. Brilliant clarity. Moderate white head with average to below average persistence. Flavor: Low to medium grainy-sweet malt flavor initially. Medium hop bitterness. Low to medium hop flavor, with a spicy, herbal, or floral quality. Clean fermentation character, well-lagered. Dry finish with a light malty and hoppy aftertaste. Mouthfeel: Light to very light body. Medium to high carbonation. Smooth, well-attenuated."
+                       cbf/ibu-min         15}))
 
 
 (def kölsch
@@ -38,53 +39,53 @@
    Freshness makes a huge difference with this beer, as the delicate character can fade quickly with age. 
    Brilliant clarity is characteristic."
   (styles/build-style :kölsch
-                      {:category        "Pale Bitter European Beer"
-                       :carb-min        1.5
-                       :fg-max          1.011
-                       :og-min          1.044
-                       :name            "Kölsch"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.044
-                       :fg-min          1.007
-                       :category-number "5"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "Traditional German hops (Hallertau, Tettnang, Spalt or Hersbrucker). German Pils or pale malt. Attenuative, clean ale yeast. Up to 20% wheat malt may be used, but this is quite rare in authentic versions. Current commercial practice is to ferment warm, cold condition for a short period of time, and serve young."
-                       :examples        "Früh Kölsch, Gaffel Kölsch, Mühlen Kölsch, Reissdorf Kölsch, Sion Kölsch, Sünner Kölsch"
-                       :notes           "A clean, crisp, delicately-balanced beer usually with a very subtle fruit and hop character. Subdued maltiness throughout leads into a pleasantly well-attenuated and refreshing finish. Freshness makes a huge difference with this beer, as the delicate character can fade quickly with age. Brilliant clarity is characteristic."
-                       :og-max          1.05
-                       :color-min       3.5
-                       :abv-max         0.052
-                       :color-max       5.0
-                       :profile         "Aroma: Low to very low malt aroma, with a grainy-sweet character. A pleasant, subtle fruit aroma from fermentation (apple, cherry or pear) is acceptable, but not always present. A low floral, spicy or herbal hop aroma is optional but not out of style. Some yeast strains may give a slight winy or sulfury character (this characteristic is also optional, but not a fault). Overall, the intensity of aromatics is fairly subtle but generally balanced, clean, and fresh. Appearance: Very pale gold to light gold. Very clear (authentic commercial versions are filtered to a brilliant clarity). Has a delicate white head that may not persist. Flavor: Soft, rounded palate comprised of a delicate flavor balance between soft yet attenuated malt, an almost imperceptible fruity sweetness from fermentation, and a medium-low to medium bitterness with a delicate dryness and slight crispness in the finish (but no harsh aftertaste). The malt tends to be grainy-sweet, possibly with a very light bready or honey quality. The hop flavor is variable, and can range from low to moderately-high; most are medium-low to medium intensity and have a floral, spicy, or herbal character. May have a malty-sweet impression at the start, but this is not required. No noticeable residual sweetness. May have a slightly winy, minerally, or sulfury accent that accentuates the dryness and flavor balance. A slight wheat taste is rare but not a fault. Otherwise, very clean. Mouthfeel: Medium-light to medium body (most are medium-light). Medium to medium-high carbonation. Smooth and generally crisp and well-attenuated."
-                       :ibu-min         18}))
+                      {cbf/category        "Pale Bitter European Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.011
+                       cbf/og-min          1.044
+                       cbf/name            "Kölsch"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.044
+                       cbf/fg-min          1.007
+                       cbf/category-number "5"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "Traditional German hops (Hallertau, Tettnang, Spalt or Hersbrucker). German Pils or pale malt. Attenuative, clean ale yeast. Up to 20% wheat malt may be used, but this is quite rare in authentic versions. Current commercial practice is to ferment warm, cold condition for a short period of time, and serve young."
+                       cbf/examples        "Früh Kölsch, Gaffel Kölsch, Mühlen Kölsch, Reissdorf Kölsch, Sion Kölsch, Sünner Kölsch"
+                       cbf/notes           "A clean, crisp, delicately-balanced beer usually with a very subtle fruit and hop character. Subdued maltiness throughout leads into a pleasantly well-attenuated and refreshing finish. Freshness makes a huge difference with this beer, as the delicate character can fade quickly with age. Brilliant clarity is characteristic."
+                       cbf/og-max          1.05
+                       cbf/color-min       3.5
+                       cbf/abv-max         0.052
+                       cbf/color-max       5.0
+                       cbf/profile         "Aroma: Low to very low malt aroma, with a grainy-sweet character. A pleasant, subtle fruit aroma from fermentation (apple, cherry or pear) is acceptable, but not always present. A low floral, spicy or herbal hop aroma is optional but not out of style. Some yeast strains may give a slight winy or sulfury character (this characteristic is also optional, but not a fault). Overall, the intensity of aromatics is fairly subtle but generally balanced, clean, and fresh. Appearance: Very pale gold to light gold. Very clear (authentic commercial versions are filtered to a brilliant clarity). Has a delicate white head that may not persist. Flavor: Soft, rounded palate comprised of a delicate flavor balance between soft yet attenuated malt, an almost imperceptible fruity sweetness from fermentation, and a medium-low to medium bitterness with a delicate dryness and slight crispness in the finish (but no harsh aftertaste). The malt tends to be grainy-sweet, possibly with a very light bready or honey quality. The hop flavor is variable, and can range from low to moderately-high; most are medium-low to medium intensity and have a floral, spicy, or herbal character. May have a malty-sweet impression at the start, but this is not required. No noticeable residual sweetness. May have a slightly winy, minerally, or sulfury accent that accentuates the dryness and flavor balance. A slight wheat taste is rare but not a fault. Otherwise, very clean. Mouthfeel: Medium-light to medium body (most are medium-light). Medium to medium-high carbonation. Smooth and generally crisp and well-attenuated."
+                       cbf/ibu-min         18}))
 
 
 (def german-helles-exportbier
   "A pale, well-balanced, smooth German lager that is slightly stronger than the average beer with a moderate body and a mild, aromatic hop and malt character."
   (styles/build-style :german-helles-exportbier
-                      {:category        "Pale Bitter European Beer"
-                       :carb-min        1.5
-                       :fg-max          1.015
-                       :og-min          1.048
-                       :name            "German Helles Exportbier"
-                       :type            "Lager"
-                       :style-letter    "C"
-                       :abv-min         0.048
-                       :fg-min          1.01
-                       :category-number "5"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "Minerally water with high levels of sulfates, carbonates and chlorides, German or Czech noble hops, Pilsner malt, German lager yeast. Newer commercial versions can contain adjuncts and hop extract."
-                       :examples        "DAB Original, Dortmunder Kronen, Dortmunder Union Export, Flensburger Gold, Gordon Biersch Golden Export, Great Lakes Dortmunder Gold"
-                       :notes           "A pale, well-balanced, smooth German lager that is slightly stronger than the average beer with a moderate body and a mild, aromatic hop and malt character."
-                       :og-max          1.056
-                       :color-min       4.0
-                       :abv-max         0.06
-                       :color-max       7.0
-                       :profile         "Aroma: Low to medium hop aroma, typically floral, spicy, or herbal in character. Moderate grainy-sweet malt aroma. Clean fermentation profile. A slight sulfury note at the start that dissipates is not a fault, neither is a low background note of DMS. Appearance: Light gold to deep gold. Clear. Persistent white head. Flavor: Neither grainy-sweet malt nor floral, spicy, or herbal hops dominate, but both are in good balance with a touch of malty sweetness, providing a smooth yet crisply refreshing beer. Balance continues through the finish and the hop bitterness lingers in aftertaste (although some examples may finish slightly sweet). Clean fermentation character. Some mineral character might be noted from the water, although it usually does not come across as an overt minerally flavor. Mouthfeel: Medium body, medium carbonation. Smooth but crisp."
-                       :ibu-min         20}))
+                      {cbf/category        "Pale Bitter European Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.015
+                       cbf/og-min          1.048
+                       cbf/name            "German Helles Exportbier"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.048
+                       cbf/fg-min          1.01
+                       cbf/category-number "5"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "Minerally water with high levels of sulfates, carbonates and chlorides, German or Czech noble hops, Pilsner malt, German lager yeast. Newer commercial versions can contain adjuncts and hop extract."
+                       cbf/examples        "DAB Original, Dortmunder Kronen, Dortmunder Union Export, Flensburger Gold, Gordon Biersch Golden Export, Great Lakes Dortmunder Gold"
+                       cbf/notes           "A pale, well-balanced, smooth German lager that is slightly stronger than the average beer with a moderate body and a mild, aromatic hop and malt character."
+                       cbf/og-max          1.056
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.06
+                       cbf/color-max       7.0
+                       cbf/profile         "Aroma: Low to medium hop aroma, typically floral, spicy, or herbal in character. Moderate grainy-sweet malt aroma. Clean fermentation profile. A slight sulfury note at the start that dissipates is not a fault, neither is a low background note of DMS. Appearance: Light gold to deep gold. Clear. Persistent white head. Flavor: Neither grainy-sweet malt nor floral, spicy, or herbal hops dominate, but both are in good balance with a touch of malty sweetness, providing a smooth yet crisply refreshing beer. Balance continues through the finish and the hop bitterness lingers in aftertaste (although some examples may finish slightly sweet). Clean fermentation character. Some mineral character might be noted from the water, although it usually does not come across as an overt minerally flavor. Mouthfeel: Medium body, medium carbonation. Smooth but crisp."
+                       cbf/ibu-min         20}))
 
 
 (def german-pils
@@ -92,27 +93,27 @@
    
    Crisp, clean, and refreshing, a German Pils showcases the finest quality German malt and hops."
   (styles/build-style :german-pils
-                      {:category        "Pale Bitter European Beer"
-                       :carb-min        1.5
-                       :fg-max          1.013
-                       :og-min          1.044
-                       :name            "German Pils"
-                       :type            "Lager"
-                       :style-letter    "D"
-                       :abv-min         0.044
-                       :fg-min          1.008
-                       :category-number "5"
-                       :carb-max        3.0
-                       :ibu-max         40
-                       :ingredients     "Continental Pilsner malt, German hop varieties (especially Saazer-type varieties such as Tettnanger, Hallertauer, and Spalt for taste and aroma; Saaz is less common), German lager yeast."
-                       :examples        "König Pilsener, Left Hand Polestar Pils, Paulaner Premium Pils, Schönramer Pils, Stoudt Pils, Tröegs Sunshine Pils, Trumer Pils"
-                       :notes           "A light-bodied, highly-attenuated, gold-colored, bottom-fermented bitter German beer showing excellent head retention and an elegant, floral hop aroma. Crisp, clean, and refreshing, a German Pils showcases the finest quality German malt and hops."
-                       :og-max          1.05
-                       :color-min       2.0
-                       :abv-max         0.052
-                       :color-max       5.0
-                       :profile         "Aroma: Medium-low to low grainy-sweet-rich malt character (often with a light honey and slightly toasted cracker quality) and distinctive flowery, spicy, or herbal hops. Clean fermentation profile. May optionally have a very light sulfury note that comes from water as much as yeast. The hops are moderately-low to moderately-high, but should not totally dominate the malt presence. One-dimensional examples are inferior to the more complex qualities when all ingredients are sensed. May have a very low background note of DMS. Appearance: Straw to light gold, brilliant to very clear, with a creamy, long-lasting white head. Flavor: Medium to high hop bitterness dominates the palate and lingers into the aftertaste. Moderate to moderately-low grainy-sweet malt character supports the hop bitterness. Low to high floral, spicy, or herbal hop flavor. Clean fermentation profile. Dry to medium-dry, crisp, well-attenuated finish with a bitter aftertaste and light malt flavor. Examples made with water with higher sulfate levels often will have a low sulfury flavor that accentuates the dryness and lengthens the finish; this is acceptable but not mandatory. Some versions have a soft finish with more of a malt flavor, but still with noticeable hop bitterness and flavor, with the balance still towards bitterness. Mouthfeel: Medium-light body. Medium to high carbonation."
-                       :ibu-min         22}))
+                      {cbf/category        "Pale Bitter European Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.013
+                       cbf/og-min          1.044
+                       cbf/name            "German Pils"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "D"
+                       cbf/abv-min         0.044
+                       cbf/fg-min          1.008
+                       cbf/category-number "5"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         40
+                       cbf/ingredients     "Continental Pilsner malt, German hop varieties (especially Saazer-type varieties such as Tettnanger, Hallertauer, and Spalt for taste and aroma; Saaz is less common), German lager yeast."
+                       cbf/examples        "König Pilsener, Left Hand Polestar Pils, Paulaner Premium Pils, Schönramer Pils, Stoudt Pils, Tröegs Sunshine Pils, Trumer Pils"
+                       cbf/notes           "A light-bodied, highly-attenuated, gold-colored, bottom-fermented bitter German beer showing excellent head retention and an elegant, floral hop aroma. Crisp, clean, and refreshing, a German Pils showcases the finest quality German malt and hops."
+                       cbf/og-max          1.05
+                       cbf/color-min       2.0
+                       cbf/abv-max         0.052
+                       cbf/color-max       5.0
+                       cbf/profile         "Aroma: Medium-low to low grainy-sweet-rich malt character (often with a light honey and slightly toasted cracker quality) and distinctive flowery, spicy, or herbal hops. Clean fermentation profile. May optionally have a very light sulfury note that comes from water as much as yeast. The hops are moderately-low to moderately-high, but should not totally dominate the malt presence. One-dimensional examples are inferior to the more complex qualities when all ingredients are sensed. May have a very low background note of DMS. Appearance: Straw to light gold, brilliant to very clear, with a creamy, long-lasting white head. Flavor: Medium to high hop bitterness dominates the palate and lingers into the aftertaste. Moderate to moderately-low grainy-sweet malt character supports the hop bitterness. Low to high floral, spicy, or herbal hop flavor. Clean fermentation profile. Dry to medium-dry, crisp, well-attenuated finish with a bitter aftertaste and light malt flavor. Examples made with water with higher sulfate levels often will have a low sulfury flavor that accentuates the dryness and lengthens the finish; this is acceptable but not mandatory. Some versions have a soft finish with more of a malt flavor, but still with noticeable hop bitterness and flavor, with the balance still towards bitterness. Mouthfeel: Medium-light body. Medium to high carbonation."
+                       cbf/ibu-min         22}))
 
 
 (def pale-bitter-european-beer

--- a/src/common_beer_data/styles/bjcp_2015/pale_commonwealth_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/pale_commonwealth_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.pale-commonwealth-beer
   "2015 BJCP guidelines on Pale Commonwealth Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def british-golden-ale
@@ -8,27 +9,27 @@
    
    Drinkability and a refreshing quality are critical components of the style."
   (styles/build-style :british-golden-ale
-                      {:category        "Pale Commonwealth Beer"
-                       :carb-min        1.5
-                       :fg-max          1.012
-                       :og-min          1.038
-                       :name            "British Golden Ale"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.038
-                       :fg-min          1.006
-                       :category-number "12"
-                       :carb-max        3.0
-                       :ibu-max         45
-                       :ingredients     "Low-color pale or lager malt acting as a blank canvas for the hop character. May use sugar adjuncts, corn or wheat. English hops frequently used, although citrusy American varietals are becoming more common. Somewhat clean-fermenting British yeast."
-                       :examples        "Crouch Vale Brewers Gold, Fuller's Discovery, Golden Hill Exmoor Gold, Hop Back Summer Lightning, Kelham Island Pale Rider, Morland Old Golden Hen, Oakham JHB"
-                       :notes           "A hop-forward, average-strength to moderately-strong pale bitter. Drinkability and a refreshing quality are critical components of the style."
-                       :og-max          1.053
-                       :color-min       2.0
-                       :abv-max         0.05
-                       :color-max       6.0
-                       :profile         "Aroma: Hop aroma is moderately low to moderately high, and can use any variety of hops - floral, herbal, or earthy English hops and citrusy American hops are most common. Frequently a single hop varietal will be showcased. Little to no malt aroma; no caramel. Medium-low to low fruity aroma from the hops rather than esters. Little to no diacetyl. Appearance: Straw to golden in color. Good to brilliant clarity. Low to moderate white head. A low head is acceptable when carbonation is also low. Flavor: Medium to medium-high bitterness. Hop flavor is moderate to moderately high of any hop variety, although citrus flavors are increasingly common. Medium-low to low malt character, generally bready with perhaps a little biscuity flavor. Caramel flavors are typically absent. Little to no diacetyl. Hop bitterness and flavor should be pronounced. Moderately-low to low esters. Medium-dry to dry finish. Bitterness increases with alcohol level, but is always balanced. Mouthfeel: Light to medium body. Low to moderate carbonation on draught, although bottled commercial versions will be higher. Stronger versions may have a slight alcohol warmth, but this character should not be too high."
-                       :ibu-min         20}))
+                      {cbf/category        "Pale Commonwealth Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.012
+                       cbf/og-min          1.038
+                       cbf/name            "British Golden Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.038
+                       cbf/fg-min          1.006
+                       cbf/category-number "12"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         45
+                       cbf/ingredients     "Low-color pale or lager malt acting as a blank canvas for the hop character. May use sugar adjuncts, corn or wheat. English hops frequently used, although citrusy American varietals are becoming more common. Somewhat clean-fermenting British yeast."
+                       cbf/examples        "Crouch Vale Brewers Gold, Fuller's Discovery, Golden Hill Exmoor Gold, Hop Back Summer Lightning, Kelham Island Pale Rider, Morland Old Golden Hen, Oakham JHB"
+                       cbf/notes           "A hop-forward, average-strength to moderately-strong pale bitter. Drinkability and a refreshing quality are critical components of the style."
+                       cbf/og-max          1.053
+                       cbf/color-min       2.0
+                       cbf/abv-max         0.05
+                       cbf/color-max       6.0
+                       cbf/profile         "Aroma: Hop aroma is moderately low to moderately high, and can use any variety of hops - floral, herbal, or earthy English hops and citrusy American hops are most common. Frequently a single hop varietal will be showcased. Little to no malt aroma; no caramel. Medium-low to low fruity aroma from the hops rather than esters. Little to no diacetyl. Appearance: Straw to golden in color. Good to brilliant clarity. Low to moderate white head. A low head is acceptable when carbonation is also low. Flavor: Medium to medium-high bitterness. Hop flavor is moderate to moderately high of any hop variety, although citrus flavors are increasingly common. Medium-low to low malt character, generally bready with perhaps a little biscuity flavor. Caramel flavors are typically absent. Little to no diacetyl. Hop bitterness and flavor should be pronounced. Moderately-low to low esters. Medium-dry to dry finish. Bitterness increases with alcohol level, but is always balanced. Mouthfeel: Light to medium body. Low to moderate carbonation on draught, although bottled commercial versions will be higher. Stronger versions may have a slight alcohol warmth, but this character should not be too high."
+                       cbf/ibu-min         20}))
 
 
 (def australian-sparkling-ale
@@ -39,27 +40,27 @@
    Very drinkable, suited to a hot climate. 
    Relies on yeast character."
   (styles/build-style :australian-sparkling-ale
-                      {:category        "Pale Commonwealth Beer"
-                       :carb-min        1.5
-                       :fg-max          1.006
-                       :og-min          1.038
-                       :name            "Australian Sparkling Ale"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.045
-                       :fg-min          1.004
-                       :category-number "12"
-                       :carb-max        3.0
-                       :ibu-max         35
-                       :ingredients     "Lightly kilned Australian 2-row pale malt, lager varieties may be used. Small amounts of crystal malt for color adjustment only. Modern examples use no adjuncts, cane sugar for priming only. Historical examples using 45% 2 row, 30% higher protein malt (6 row) would use around 25% sugar to dilute the nitrogen content. Traditionally used Australian hops, Cluster, and Goldings until replaced from mid-1960s by Pride of Ringwood. Highly attenuative Burton-type yeast (Australian-type strain typical). Variable water profile, typically with low carbonate and moderate sulfate."
-                       :examples        "Coopers Original Pale Ale, Coopers Sparkling Ale"
-                       :notes           "Smooth and balanced, all components merge together with similar intensities. Moderate flavors showcasing Australian ingredients. Large flavor dimension. Very drinkable, suited to a hot climate. Relies on yeast character."
-                       :og-max          1.05
-                       :color-min       4.0
-                       :abv-max         0.06
-                       :color-max       7.0
-                       :profile         "Aroma: Fairly soft, clean aroma with a balanced mix of esters, hops, malt, and yeast - all moderate to low in intensity. The esters are frequently pears and apples, possibly with a very light touch of banana (optional). The hops are earthy, herbaceous, or might show the characteristic iron-like Pride of Ringwood nose. The malt can range from neutral grainy to moderately sweet to lightly bready; no caramel should be evident. Very fresh examples can have a lightly yeasty, sulfury nose. Appearance: Deep yellow to light amber in color, often medium gold. Tall, frothy, persistent white head with tiny bubbles. Noticeable effervescence due to high carbonation. Brilliant clarity if decanted, but typically poured with yeast to have a cloudy appearance. Not typically cloudy unless yeast roused during the pour. Flavor: Medium to low rounded, grainy to bready malt flavor, initially mild to malty-sweet but a medium to medium-high bitterness rises mid-palate to balance the malt. Caramel flavors typically absent. Highly attenuated, giving a dry finish with lingering bitterness, although the body gives an impression of fullness. Medium to medium-high hop flavor, somewhat earthy and possibly herbal, resinous, peppery, or iron-like but not floral, lasting into aftertaste. Medium-high to medium-low esters, often pears and apples. Banana is optional, but should never dominate. May be lightly minerally or sulfury, especially if yeast is present. Should not be bland. Mouthfeel: High to very high carbonation, giving mouth-filling bubbles and a crisp, spritzy carbonic bite. Medium to medium-full body, tending to the higher side if poured with yeast. Smooth but gassy. Stronger versions may have a light alcohol warmth, but lower alcohol versions will not. Very well-attenuated; should not have any residual sweetness."
-                       :ibu-min         20}))
+                      {cbf/category        "Pale Commonwealth Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.006
+                       cbf/og-min          1.038
+                       cbf/name            "Australian Sparkling Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.045
+                       cbf/fg-min          1.004
+                       cbf/category-number "12"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         35
+                       cbf/ingredients     "Lightly kilned Australian 2-row pale malt, lager varieties may be used. Small amounts of crystal malt for color adjustment only. Modern examples use no adjuncts, cane sugar for priming only. Historical examples using 45% 2 row, 30% higher protein malt (6 row) would use around 25% sugar to dilute the nitrogen content. Traditionally used Australian hops, Cluster, and Goldings until replaced from mid-1960s by Pride of Ringwood. Highly attenuative Burton-type yeast (Australian-type strain typical). Variable water profile, typically with low carbonate and moderate sulfate."
+                       cbf/examples        "Coopers Original Pale Ale, Coopers Sparkling Ale"
+                       cbf/notes           "Smooth and balanced, all components merge together with similar intensities. Moderate flavors showcasing Australian ingredients. Large flavor dimension. Very drinkable, suited to a hot climate. Relies on yeast character."
+                       cbf/og-max          1.05
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.06
+                       cbf/color-max       7.0
+                       cbf/profile         "Aroma: Fairly soft, clean aroma with a balanced mix of esters, hops, malt, and yeast - all moderate to low in intensity. The esters are frequently pears and apples, possibly with a very light touch of banana (optional). The hops are earthy, herbaceous, or might show the characteristic iron-like Pride of Ringwood nose. The malt can range from neutral grainy to moderately sweet to lightly bready; no caramel should be evident. Very fresh examples can have a lightly yeasty, sulfury nose. Appearance: Deep yellow to light amber in color, often medium gold. Tall, frothy, persistent white head with tiny bubbles. Noticeable effervescence due to high carbonation. Brilliant clarity if decanted, but typically poured with yeast to have a cloudy appearance. Not typically cloudy unless yeast roused during the pour. Flavor: Medium to low rounded, grainy to bready malt flavor, initially mild to malty-sweet but a medium to medium-high bitterness rises mid-palate to balance the malt. Caramel flavors typically absent. Highly attenuated, giving a dry finish with lingering bitterness, although the body gives an impression of fullness. Medium to medium-high hop flavor, somewhat earthy and possibly herbal, resinous, peppery, or iron-like but not floral, lasting into aftertaste. Medium-high to medium-low esters, often pears and apples. Banana is optional, but should never dominate. May be lightly minerally or sulfury, especially if yeast is present. Should not be bland. Mouthfeel: High to very high carbonation, giving mouth-filling bubbles and a crisp, spritzy carbonic bite. Medium to medium-full body, tending to the higher side if poured with yeast. Smooth but gassy. Stronger versions may have a light alcohol warmth, but lower alcohol versions will not. Very well-attenuated; should not have any residual sweetness."
+                       cbf/ibu-min         20}))
 
 
 (def english-ipa
@@ -67,27 +68,27 @@
     
     Classic British ingredients provide the best flavor profile."
   (styles/build-style :english-ipa
-                      {:category        "Pale Commonwealth Beer"
-                       :carb-min        1.5
-                       :fg-max          1.018
-                       :og-min          1.05
-                       :name            "English IPA"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.05
-                       :fg-min          1.01
-                       :category-number "12"
-                       :carb-max        3.0
-                       :ibu-max         60
-                       :ingredients     "Pale ale malt. English hops are traditional, particularly as finishing hops. Attenuative British ale yeast. Refined sugar may be used in some versions. Some versions may show a sulfate character from Burton-type water, but this is not essential to the style."
-                       :examples        "Freeminer Trafalgar IPA, Fuller's Bengal Lancer IPA, Meantime India Pale Ale, Ridgeway IPA, Summit True Brit IPA, Thornbridge Jaipur, Worthington White Shield"
-                       :notes           "A hoppy, moderately-strong, very well-attenuated pale British ale with a dry finish and a hoppy aroma and flavor. Classic British ingredients provide the best flavor profile."
-                       :og-max          1.075
-                       :color-min       6.0
-                       :abv-max         0.075
-                       :color-max       14.0
-                       :profile         "Aroma: A moderate to moderately-high hop aroma of floral, spicy-peppery or citrus-orange in nature is typical. A slightly grassy dry-hop aroma is acceptable, but not required. A moderately-low caramel-like or toasty malt presence is optional. Low to moderate fruitiness is acceptable. Some versions may have a sulfury note, although this character is not mandatory. Appearance: Color ranges from golden to deep amber, but most are fairly pale. Should be clear, although unfiltered dry-hopped versions may be a bit hazy. Moderate-sized, persistent head stand with off-white color. Flavor: Hop flavor is medium to high, with a moderate to assertive hop bitterness. The hop flavor should be similar to the aroma (floral, spicy-peppery, citrus-orange, and/or slightly grassy). Malt flavor should be medium-low to medium, and be somewhat bready, optionally with light to medium-light biscuit-like, toasty, toffee-like and/or caramelly aspects. Medium-low to medium fruitiness. Finish is medium-dry to very dry, and the bitterness may linger into the aftertaste but should not be harsh. The balance is toward the hops, but the malt should still be noticeable in support. If high sulfate water is used, a distinctively minerally, dry finish, some sulfur flavor, and a lingering bitterness are usually present. Some clean alcohol flavor can be noted in stronger versions. Oak is inappropriate in this style. Mouthfeel: Smooth, medium-light to medium-bodied mouthfeel without hop-derived astringency, although moderate to medium-high carbonation can combine to render an overall dry sensation despite a supportive malt presence. A low, smooth alcohol warming can and should be sensed in stronger (but not all) versions."
-                       :ibu-min         40}))
+                      {cbf/category        "Pale Commonwealth Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.018
+                       cbf/og-min          1.05
+                       cbf/name            "English IPA"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.05
+                       cbf/fg-min          1.01
+                       cbf/category-number "12"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         60
+                       cbf/ingredients     "Pale ale malt. English hops are traditional, particularly as finishing hops. Attenuative British ale yeast. Refined sugar may be used in some versions. Some versions may show a sulfate character from Burton-type water, but this is not essential to the style."
+                       cbf/examples        "Freeminer Trafalgar IPA, Fuller's Bengal Lancer IPA, Meantime India Pale Ale, Ridgeway IPA, Summit True Brit IPA, Thornbridge Jaipur, Worthington White Shield"
+                       cbf/notes           "A hoppy, moderately-strong, very well-attenuated pale British ale with a dry finish and a hoppy aroma and flavor. Classic British ingredients provide the best flavor profile."
+                       cbf/og-max          1.075
+                       cbf/color-min       6.0
+                       cbf/abv-max         0.075
+                       cbf/color-max       14.0
+                       cbf/profile         "Aroma: A moderate to moderately-high hop aroma of floral, spicy-peppery or citrus-orange in nature is typical. A slightly grassy dry-hop aroma is acceptable, but not required. A moderately-low caramel-like or toasty malt presence is optional. Low to moderate fruitiness is acceptable. Some versions may have a sulfury note, although this character is not mandatory. Appearance: Color ranges from golden to deep amber, but most are fairly pale. Should be clear, although unfiltered dry-hopped versions may be a bit hazy. Moderate-sized, persistent head stand with off-white color. Flavor: Hop flavor is medium to high, with a moderate to assertive hop bitterness. The hop flavor should be similar to the aroma (floral, spicy-peppery, citrus-orange, and/or slightly grassy). Malt flavor should be medium-low to medium, and be somewhat bready, optionally with light to medium-light biscuit-like, toasty, toffee-like and/or caramelly aspects. Medium-low to medium fruitiness. Finish is medium-dry to very dry, and the bitterness may linger into the aftertaste but should not be harsh. The balance is toward the hops, but the malt should still be noticeable in support. If high sulfate water is used, a distinctively minerally, dry finish, some sulfur flavor, and a lingering bitterness are usually present. Some clean alcohol flavor can be noted in stronger versions. Oak is inappropriate in this style. Mouthfeel: Smooth, medium-light to medium-bodied mouthfeel without hop-derived astringency, although moderate to medium-high carbonation can combine to render an overall dry sensation despite a supportive malt presence. A low, smooth alcohol warming can and should be sensed in stronger (but not all) versions."
+                       cbf/ibu-min         40}))
 
 
 (def pale-commonwealth-beer

--- a/src/common_beer_data/styles/bjcp_2015/pale_malty_european_lager.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/pale_malty_european_lager.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.pale-malty-european-lager
   "2015 BJCP guidelines on Pale Malty European Lagers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def munich-helles
@@ -8,27 +9,27 @@
    
    Subtle spicy, floral, or herbal hops and restrained bitterness help keep the balance malty but not sweet, which helps make this beer a refreshing, everyday drink."
   (styles/build-style :munich-helles
-                      {:category        "Pale Malty European Lager"
-                       :carb-min        1.5
-                       :fg-max          1.012
-                       :og-min          1.044
-                       :name            "Munich Helles"
-                       :type            "Lager"
-                       :style-letter    "A"
-                       :abv-min         0.047
-                       :fg-min          1.006
-                       :category-number "4"
-                       :carb-max        3.0
-                       :ibu-max         22
-                       :ingredients     "Continental Pilsner malt, traditional German Saazer-type hop varieties, clean German lager yeast."
-                       :examples        "Augustiner Lagerbier Hell, Bürgerbräu Wolznacher Hell Naturtrüb, Hacker-Pschorr Münchner Gold, Löwenbraü Original, Paulaner Premium Lager, Spaten Premium Lager, Weihenstephaner Original"
-                       :notes           "A clean, malty, gold-colored German lager with a smooth grainy-sweet malty flavor and a soft, dry finish. Subtle spicy, floral, or herbal hops and restrained bitterness help keep the balance malty but not sweet, which helps make this beer a refreshing, everyday drink."
-                       :og-max          1.048
-                       :color-min       3.0
-                       :abv-max         0.054
-                       :color-max       5.0
-                       :profile         "Aroma: Moderate grainy-sweet malt aroma. Low to moderately-low spicy, floral, or herbal hop aroma. While a clean aroma is most desirable, a very low background note of DMS is not a fault. Pleasant, clean fermentation profile, with malt dominating the balance. The freshest examples will have more of a malty-sweet aroma. Appearance: Medium yellow to pale gold. Clear. Persistent creamy white head. Flavor: Moderately malty start with the suggestion of sweetness, moderate grainy-sweet malt flavor with a soft, rounded palate impression, supported by a low to medium-low hop bitterness. The finish is soft and dry, not crisp and biting. Low to moderately-low spicy, floral or herbal hop flavor. The malt dominates the hops in the palate, finish, and aftertaste, but the hops should be noticeable. There should not be any residual sweetness, simply the impression of maltiness with restrained bitterness. Very fresh examples will seem sweeter due to the fresh, rich malt character that can fade with time. Clean fermentation profile. Mouthfeel: Medium body. Medium carbonation. Smooth, well-lagered character."
-                       :ibu-min         16}))
+                      {cbf/category        "Pale Malty European Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.012
+                       cbf/og-min          1.044
+                       cbf/name            "Munich Helles"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.047
+                       cbf/fg-min          1.006
+                       cbf/category-number "4"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         22
+                       cbf/ingredients     "Continental Pilsner malt, traditional German Saazer-type hop varieties, clean German lager yeast."
+                       cbf/examples        "Augustiner Lagerbier Hell, Bürgerbräu Wolznacher Hell Naturtrüb, Hacker-Pschorr Münchner Gold, Löwenbraü Original, Paulaner Premium Lager, Spaten Premium Lager, Weihenstephaner Original"
+                       cbf/notes           "A clean, malty, gold-colored German lager with a smooth grainy-sweet malty flavor and a soft, dry finish. Subtle spicy, floral, or herbal hops and restrained bitterness help keep the balance malty but not sweet, which helps make this beer a refreshing, everyday drink."
+                       cbf/og-max          1.048
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.054
+                       cbf/color-max       5.0
+                       cbf/profile         "Aroma: Moderate grainy-sweet malt aroma. Low to moderately-low spicy, floral, or herbal hop aroma. While a clean aroma is most desirable, a very low background note of DMS is not a fault. Pleasant, clean fermentation profile, with malt dominating the balance. The freshest examples will have more of a malty-sweet aroma. Appearance: Medium yellow to pale gold. Clear. Persistent creamy white head. Flavor: Moderately malty start with the suggestion of sweetness, moderate grainy-sweet malt flavor with a soft, rounded palate impression, supported by a low to medium-low hop bitterness. The finish is soft and dry, not crisp and biting. Low to moderately-low spicy, floral or herbal hop flavor. The malt dominates the hops in the palate, finish, and aftertaste, but the hops should be noticeable. There should not be any residual sweetness, simply the impression of maltiness with restrained bitterness. Very fresh examples will seem sweeter due to the fresh, rich malt character that can fade with time. Clean fermentation profile. Mouthfeel: Medium body. Medium carbonation. Smooth, well-lagered character."
+                       cbf/ibu-min         16}))
 
 
 (def festbier
@@ -37,27 +38,27 @@
    Deftly balances strength and drinkability, with a palate impression and finish that encourages drinking. 
    Showcases elegant German malt flavors without becoming too heavy or filling."
   (styles/build-style :festbier
-                      {:category        "Pale Malty European Lager"
-                       :carb-min        1.5
-                       :fg-max          1.012
-                       :og-min          1.054
-                       :name            "Festbier"
-                       :type            "Lager"
-                       :style-letter    "B"
-                       :abv-min         0.058
-                       :fg-min          1.01
-                       :category-number "4"
-                       :carb-max        3.0
-                       :ibu-max         25
-                       :ingredients     "Majority Pils malt, but with some Vienna and/or Munich malt to increase maltiness. Differences in commercial examples are mostly due to different maltsters and yeast, not major grist differences."
-                       :examples        "Augustiner Oktoberfest, Hacker-Pschorr Superior Festbier, Hofbräu Festbier, Löwenbräu Oktoberfestbier, Paulaner Wiesn, Schönramer Gold, Weihenstephaner Festbier"
-                       :notes           "A smooth, clean, pale German lager with a moderately strong malty flavor and a light hop character. Deftly balances strength and drinkability, with a palate impression and finish that encourages drinking. Showcases elegant German malt flavors without becoming too heavy or filling."
-                       :og-max          1.057
-                       :color-min       4.0
-                       :abv-max         0.063
-                       :color-max       7.0
-                       :profile         "Aroma: Moderate malty richness, with an emphasis on toasty-doughy aromatics and an impression of sweetness. Low to medium-low floral, herbal, or spicy hops. The malt should not have a deeply toasted, caramel, or biscuity quality. Clean lager fermentation character. Appearance: Deep yellow to deep gold color; should not have amber hues. Bright clarity. Persistent white to off-white foam stand. Most commercial examples are medium gold in color. Flavor: Medium to medium-high malty flavor initially, with a lightly toasty, bread dough quality and an impression of soft sweetness. Medium to medium-low bitterness, definitely malty in the balance. Well-attenuated and crisp, but not dry. Medium-low to medium floral, herbal, or spicy hop flavor. Clean lager fermentation character. The taste is mostly of Pils malt, but with slightly toasty hints. The bitterness is supportive, but still should yield a malty, flavorful finish. Mouthfeel: Medium body, with a smooth, somewhat creamy texture. Medium carbonation. Alcohol strength barely noticeable as warming, if at all."
-                       :ibu-min         18}))
+                      {cbf/category        "Pale Malty European Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.012
+                       cbf/og-min          1.054
+                       cbf/name            "Festbier"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.058
+                       cbf/fg-min          1.01
+                       cbf/category-number "4"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         25
+                       cbf/ingredients     "Majority Pils malt, but with some Vienna and/or Munich malt to increase maltiness. Differences in commercial examples are mostly due to different maltsters and yeast, not major grist differences."
+                       cbf/examples        "Augustiner Oktoberfest, Hacker-Pschorr Superior Festbier, Hofbräu Festbier, Löwenbräu Oktoberfestbier, Paulaner Wiesn, Schönramer Gold, Weihenstephaner Festbier"
+                       cbf/notes           "A smooth, clean, pale German lager with a moderately strong malty flavor and a light hop character. Deftly balances strength and drinkability, with a palate impression and finish that encourages drinking. Showcases elegant German malt flavors without becoming too heavy or filling."
+                       cbf/og-max          1.057
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.063
+                       cbf/color-max       7.0
+                       cbf/profile         "Aroma: Moderate malty richness, with an emphasis on toasty-doughy aromatics and an impression of sweetness. Low to medium-low floral, herbal, or spicy hops. The malt should not have a deeply toasted, caramel, or biscuity quality. Clean lager fermentation character. Appearance: Deep yellow to deep gold color; should not have amber hues. Bright clarity. Persistent white to off-white foam stand. Most commercial examples are medium gold in color. Flavor: Medium to medium-high malty flavor initially, with a lightly toasty, bread dough quality and an impression of soft sweetness. Medium to medium-low bitterness, definitely malty in the balance. Well-attenuated and crisp, but not dry. Medium-low to medium floral, herbal, or spicy hop flavor. Clean lager fermentation character. The taste is mostly of Pils malt, but with slightly toasty hints. The bitterness is supportive, but still should yield a malty, flavorful finish. Mouthfeel: Medium body, with a smooth, somewhat creamy texture. Medium carbonation. Alcohol strength barely noticeable as warming, if at all."
+                       cbf/ibu-min         18}))
 
 
 (def helles-bock
@@ -65,27 +66,27 @@
    
    The hop character is generally more apparent than in other bocks."
   (styles/build-style :helles-bock
-                      {:category        "Pale Malty European Lager"
-                       :carb-min        1.5
-                       :fg-max          1.018
-                       :og-min          1.064
-                       :name            "Helles Bock"
-                       :type            "Lager"
-                       :style-letter    "C"
-                       :abv-min         0.063
-                       :fg-min          1.011
-                       :category-number "4"
-                       :carb-max        3.0
-                       :ibu-max         35
-                       :ingredients     "Base of Pils and/or Vienna malt with some Munich malt to add character (although much less than in a traditional bock). No non-malt adjuncts. Saazer-type hops. Clean lager yeast. Decoction mash is typical, but boiling is less than in Dunkles Bock to restrain color development."
-                       :examples        "Altenmünster Maibock, Ayinger Maibock, Capital Maibock, Blind Tiger Maibock, Einbecker Mai-Urbock, Hacker-Pschorr Hubertus Bock, Mahr's Bock"
-                       :notes           "A relatively pale, strong, malty German lager beer with a nicely attenuated finish that enhances drinkability. The hop character is generally more apparent than in other bocks."
-                       :og-max          1.072
-                       :color-min       6.0
-                       :abv-max         0.074
-                       :color-max       11.0
-                       :profile         "Aroma: Moderate to strong grainy-sweet malt aroma, often with a lightly toasted quality and low Maillard products. Moderately-low to no hop aroma, often with a spicy, herbal, or floral quality. Clean fermentation profile. Fruity esters should be low to none. Very light alcohol may be noticeable. May have a light DMS aroma. Appearance: Deep gold to light amber in color. Bright to clear clarity. Large, creamy, persistent, white head. Flavor: Moderately to moderately strong grainy-sweet malt flavor dominates with some toasty notes and/or Maillard products providing added interest. Little to no caramel flavors. May have a light DMS flavor. Moderate to no hop flavor (spicy, herbal, floral, peppery). Moderate hop bitterness (more so in the balance than in other bocks). Clean fermentation profile. Well-attenuated, not cloying, with a moderately-dry finish that may taste of both malt and hops. Mouthfeel: Medium-bodied. Moderate to moderately-high carbonation. Smooth and clean with no harshness or astringency, despite the increased hop bitterness. A light alcohol warming may be present."
-                       :ibu-min         23}))
+                      {cbf/category        "Pale Malty European Lager"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.018
+                       cbf/og-min          1.064
+                       cbf/name            "Helles Bock"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.063
+                       cbf/fg-min          1.011
+                       cbf/category-number "4"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         35
+                       cbf/ingredients     "Base of Pils and/or Vienna malt with some Munich malt to add character (although much less than in a traditional bock). No non-malt adjuncts. Saazer-type hops. Clean lager yeast. Decoction mash is typical, but boiling is less than in Dunkles Bock to restrain color development."
+                       cbf/examples        "Altenmünster Maibock, Ayinger Maibock, Capital Maibock, Blind Tiger Maibock, Einbecker Mai-Urbock, Hacker-Pschorr Hubertus Bock, Mahr's Bock"
+                       cbf/notes           "A relatively pale, strong, malty German lager beer with a nicely attenuated finish that enhances drinkability. The hop character is generally more apparent than in other bocks."
+                       cbf/og-max          1.072
+                       cbf/color-min       6.0
+                       cbf/abv-max         0.074
+                       cbf/color-max       11.0
+                       cbf/profile         "Aroma: Moderate to strong grainy-sweet malt aroma, often with a lightly toasted quality and low Maillard products. Moderately-low to no hop aroma, often with a spicy, herbal, or floral quality. Clean fermentation profile. Fruity esters should be low to none. Very light alcohol may be noticeable. May have a light DMS aroma. Appearance: Deep gold to light amber in color. Bright to clear clarity. Large, creamy, persistent, white head. Flavor: Moderately to moderately strong grainy-sweet malt flavor dominates with some toasty notes and/or Maillard products providing added interest. Little to no caramel flavors. May have a light DMS flavor. Moderate to no hop flavor (spicy, herbal, floral, peppery). Moderate hop bitterness (more so in the balance than in other bocks). Clean fermentation profile. Well-attenuated, not cloying, with a moderately-dry finish that may taste of both malt and hops. Mouthfeel: Medium-bodied. Moderate to moderately-high carbonation. Smooth and clean with no harshness or astringency, despite the increased hop bitterness. A light alcohol warming may be present."
+                       cbf/ibu-min         23}))
 
 
 (def pale-malty-european-lager

--- a/src/common_beer_data/styles/bjcp_2015/scottish_ale.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/scottish_ale.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.scottish-ale
   "2015 BJCP guidelines on Scottish Ales."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def scottish-light
@@ -9,27 +10,27 @@
    Hops only to balance and support the malt. The malt character can range from dry and grainy to rich, toasty, and caramelly, but is never roasty and especially never has a peat smoke character. 
    Traditionally the darkest of the Scottish ales, sometimes nearly black but lacking any burnt, overtly roasted character."
   (styles/build-style :scottish-light
-                      {:category        "Scottish Ale"
-                       :carb-min        1.5
-                       :fg-max          1.013
-                       :og-min          1.03
-                       :name            "Scottish Light"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.025
-                       :fg-min          1.01
-                       :category-number "14"
-                       :carb-max        3.0
-                       :ibu-max         20
-                       :ingredients     "Originally used Scottish pale malt, grits or flaked maize, and brewers caramel for color. Later adapted to use additional ingredients, such as amber and brown malts, crystal and wheat malts, and roasted grains or dark sugars for color but not for the 'roasty' flavor. Sugar adjuncts are traditional. Clean or slightly fruity yeast. Peat-smoked malt is inauthentic and inappropriate."
-                       :examples        "McEwan's 60"
-                       :notes           "A malt-focused, generally caramelly beer with perhaps a few esters and occasionally a butterscotch aftertaste. Hops only to balance and support the malt. The malt character can range from dry and grainy to rich, toasty, and caramelly, but is never roasty and especially never has a peat smoke character. Traditionally the darkest of the Scottish ales, sometimes nearly black but lacking any burnt, overtly roasted character."
-                       :og-max          1.035
-                       :color-min       17.0
-                       :abv-max         0.032
-                       :color-max       22.0
-                       :profile         "Aroma: Low to medium maltiness, often with flavors of toasted breadcrumbs, lady fingers, and English biscuits. Low to medium caramel and low butterscotch is allowable. Light pome fruitiness in best examples. May have low traditional English hop aroma (earthy, floral, orange-citrus, spicy, etc.). Peat smoke is inappropriate. Appearance: Pale copper to very dark brown. Clear. Low to moderate, creamy off-white. Flavor: Entirely malt-focused, with flavors ranging from pale, bready malt with caramel overtones to rich-toasty malt with roasted accents (but never roasty) or a combination thereof. Fruity esters are not required but add depth yet are never high. Hop bitterness to balance the malt. No to low hop flavor is also allowed and should of traditional English character (earthy, floral, orange-citrus, spicy, etc.). Finish ranges from rich and malty to dry and grainy. A subtle butterscotch character is acceptable; however, burnt sugars are not. The malt-hop balance tilts toward malt. Peat smoke is inappropriate. Mouthfeel: Medium-low to medium body. Low to moderate carbonation. Can be relatively rich and creamy to dry and grainy."
-                       :ibu-min         10}))
+                      {cbf/category        "Scottish Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.013
+                       cbf/og-min          1.03
+                       cbf/name            "Scottish Light"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.025
+                       cbf/fg-min          1.01
+                       cbf/category-number "14"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         20
+                       cbf/ingredients     "Originally used Scottish pale malt, grits or flaked maize, and brewers caramel for color. Later adapted to use additional ingredients, such as amber and brown malts, crystal and wheat malts, and roasted grains or dark sugars for color but not for the 'roasty' flavor. Sugar adjuncts are traditional. Clean or slightly fruity yeast. Peat-smoked malt is inauthentic and inappropriate."
+                       cbf/examples        "McEwan's 60"
+                       cbf/notes           "A malt-focused, generally caramelly beer with perhaps a few esters and occasionally a butterscotch aftertaste. Hops only to balance and support the malt. The malt character can range from dry and grainy to rich, toasty, and caramelly, but is never roasty and especially never has a peat smoke character. Traditionally the darkest of the Scottish ales, sometimes nearly black but lacking any burnt, overtly roasted character."
+                       cbf/og-max          1.035
+                       cbf/color-min       17.0
+                       cbf/abv-max         0.032
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Low to medium maltiness, often with flavors of toasted breadcrumbs, lady fingers, and English biscuits. Low to medium caramel and low butterscotch is allowable. Light pome fruitiness in best examples. May have low traditional English hop aroma (earthy, floral, orange-citrus, spicy, etc.). Peat smoke is inappropriate. Appearance: Pale copper to very dark brown. Clear. Low to moderate, creamy off-white. Flavor: Entirely malt-focused, with flavors ranging from pale, bready malt with caramel overtones to rich-toasty malt with roasted accents (but never roasty) or a combination thereof. Fruity esters are not required but add depth yet are never high. Hop bitterness to balance the malt. No to low hop flavor is also allowed and should of traditional English character (earthy, floral, orange-citrus, spicy, etc.). Finish ranges from rich and malty to dry and grainy. A subtle butterscotch character is acceptable; however, burnt sugars are not. The malt-hop balance tilts toward malt. Peat smoke is inappropriate. Mouthfeel: Medium-low to medium body. Low to moderate carbonation. Can be relatively rich and creamy to dry and grainy."
+                       cbf/ibu-min         10}))
 
 
 (def scottish-heavy
@@ -38,27 +39,27 @@
    Hops only to balance and support the malt. 
    The malt character can range from dry and grainy to rich, toasty, and caramelly, but is never roasty and especially never has a peat smoke character."
   (styles/build-style :scottish-heavy
-                      {:category        "Scottish Ale"
-                       :carb-min        1.5
-                       :fg-max          1.015
-                       :og-min          1.035
-                       :name            "Scottish Heavy"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.032
-                       :fg-min          1.01
-                       :category-number "14"
-                       :carb-max        3.0
-                       :ibu-max         20
-                       :ingredients     "Originally used Scottish pale malt, grits or flaked maize, and brewers caramel for color. Later adapted to use additional ingredients, such as amber and brown malts, crystal and wheat malts, and roasted grains or dark sugars for color but not for the 'roasty' flavor. Sugar adjuncts are traditional. Clean or slightly fruity yeast. Peat-smoked malt is inauthentic and inappropriate."
-                       :examples        "Broughton Greenmantle Ale, Caledonia Smooth, McEwan's 70, Orkney Raven Ale, Tennent's Special Ale"
-                       :notes           "A malt-focused, generally caramelly beer with perhaps a few esters and occasionally a butterscotch aftertaste. Hops only to balance and support the malt. The malt character can range from dry and grainy to rich, toasty, and caramelly, but is never roasty and especially never has a peat smoke character."
-                       :og-max          1.04
-                       :color-min       13.0
-                       :abv-max         0.039
-                       :color-max       22.0
-                       :profile         "Aroma: Low to medium maltiness, often with flavors of toasted breadcrumbs, lady fingers, and English biscuits. Low to medium caramel and low butterscotch is allowable. Light pome fruitiness in best examples. May have low traditional English hop aroma (earthy, floral, orange-citrus, spicy, etc.). Peat smoke is inappropriate. Appearance: Pale copper to very dark brown. Clear. Low to moderate, creamy off-white. Flavor: Entirely malt-focused, with flavors ranging from pale, bready malt with caramel overtones to rich-toasty malt with roasted accents (but never roasty) or a combination thereof. Fruity esters are not required but add depth yet are never high. Hop bitterness to balance the malt. No to low hop flavor is also allowed and should of traditional English character (earthy, floral, orange-citrus, spicy, etc.). Finish ranges from rich and malty to dry and grainy. A subtle butterscotch character is acceptable; however, burnt sugars are not. The malt-hop balance tilts toward malt. Peat smoke is inappropriate. Mouthfeel: Medium-low to medium body. Low to moderate carbonation. Can be relatively rich and creamy to dry and grainy."
-                       :ibu-min         10}))
+                      {cbf/category        "Scottish Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.015
+                       cbf/og-min          1.035
+                       cbf/name            "Scottish Heavy"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.032
+                       cbf/fg-min          1.01
+                       cbf/category-number "14"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         20
+                       cbf/ingredients     "Originally used Scottish pale malt, grits or flaked maize, and brewers caramel for color. Later adapted to use additional ingredients, such as amber and brown malts, crystal and wheat malts, and roasted grains or dark sugars for color but not for the 'roasty' flavor. Sugar adjuncts are traditional. Clean or slightly fruity yeast. Peat-smoked malt is inauthentic and inappropriate."
+                       cbf/examples        "Broughton Greenmantle Ale, Caledonia Smooth, McEwan's 70, Orkney Raven Ale, Tennent's Special Ale"
+                       cbf/notes           "A malt-focused, generally caramelly beer with perhaps a few esters and occasionally a butterscotch aftertaste. Hops only to balance and support the malt. The malt character can range from dry and grainy to rich, toasty, and caramelly, but is never roasty and especially never has a peat smoke character."
+                       cbf/og-max          1.04
+                       cbf/color-min       13.0
+                       cbf/abv-max         0.039
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Low to medium maltiness, often with flavors of toasted breadcrumbs, lady fingers, and English biscuits. Low to medium caramel and low butterscotch is allowable. Light pome fruitiness in best examples. May have low traditional English hop aroma (earthy, floral, orange-citrus, spicy, etc.). Peat smoke is inappropriate. Appearance: Pale copper to very dark brown. Clear. Low to moderate, creamy off-white. Flavor: Entirely malt-focused, with flavors ranging from pale, bready malt with caramel overtones to rich-toasty malt with roasted accents (but never roasty) or a combination thereof. Fruity esters are not required but add depth yet are never high. Hop bitterness to balance the malt. No to low hop flavor is also allowed and should of traditional English character (earthy, floral, orange-citrus, spicy, etc.). Finish ranges from rich and malty to dry and grainy. A subtle butterscotch character is acceptable; however, burnt sugars are not. The malt-hop balance tilts toward malt. Peat smoke is inappropriate. Mouthfeel: Medium-low to medium body. Low to moderate carbonation. Can be relatively rich and creamy to dry and grainy."
+                       cbf/ibu-min         10}))
 
 
 (def scottish-export
@@ -67,27 +68,27 @@
    Hops only to balance and support the malt. 
    The malt character can range from dry and grainy to rich, toasty, and caramelly, but is never roasty and especially never has a peat smoke character."
   (styles/build-style :scottish-export
-                      {:category        "Scottish Ale"
-                       :carb-min        1.5
-                       :fg-max          1.016
-                       :og-min          1.04
-                       :name            "Scottish Export"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.039
-                       :fg-min          1.01
-                       :category-number "14"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "Originally used Scottish pale malt, grits or flaked maize, and brewers caramel for color. Later adapted to use additional ingredients, such as amber and brown malts, crystal and wheat malts, and roasted grains or dark sugars for color but not for the 'roasty' flavor. Sugar adjuncts are traditional. Clean or slightly fruity yeast. Peat-smoked malt is inauthentic and inappropriate."
-                       :examples        "Belhaven Scottish Ale, Broughton Exciseman's Ale, Orkney Dark Island, Pelican MacPelican's Scottish Style Ale, Weasel Boy Plaid Ferret Scottish Ale"
-                       :notes           "A malt-focused, generally caramelly beer with perhaps a few esters and occasionally a butterscotch aftertaste. Hops only to balance and support the malt. The malt character can range from dry and grainy to rich, toasty, and caramelly, but is never roasty and especially never has a peat smoke character."
-                       :og-max          1.06
-                       :color-min       13.0
-                       :abv-max         0.06
-                       :color-max       22.0
-                       :profile         "Aroma: Low to medium maltiness, often with flavors of toasted breadcrumbs, lady fingers, and English biscuits. Low to medium caramel and low butterscotch is allowable. Light pome fruitiness in best examples. May have low traditional English hop aroma (earthy, floral, orange-citrus, spicy, etc.). Peat smoke is inappropriate. Appearance: Pale copper to very dark brown. Clear. Low to moderate, creamy off-white. Flavor: Entirely malt-focused, with flavors ranging from pale, bready malt with caramel overtones to rich-toasty malt with roasted accents (but never roasty) or a combination thereof. Fruity esters are not required but add depth yet are never high. Hop bitterness to balance the malt. No to low hop flavor is also allowed and should of traditional English character (earthy, floral, orange-citrus, spicy, etc.). Finish ranges from rich and malty to dry and grainy. A subtle butterscotch character is acceptable; however, burnt sugars are not. The malt-hop balance tilts toward malt. Peat smoke is inappropriate. Mouthfeel: Medium-low to medium body. Low to moderate carbonation. Can be relatively rich and creamy to dry and grainy."
-                       :ibu-min         15}))
+                      {cbf/category        "Scottish Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.016
+                       cbf/og-min          1.04
+                       cbf/name            "Scottish Export"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.039
+                       cbf/fg-min          1.01
+                       cbf/category-number "14"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "Originally used Scottish pale malt, grits or flaked maize, and brewers caramel for color. Later adapted to use additional ingredients, such as amber and brown malts, crystal and wheat malts, and roasted grains or dark sugars for color but not for the 'roasty' flavor. Sugar adjuncts are traditional. Clean or slightly fruity yeast. Peat-smoked malt is inauthentic and inappropriate."
+                       cbf/examples        "Belhaven Scottish Ale, Broughton Exciseman's Ale, Orkney Dark Island, Pelican MacPelican's Scottish Style Ale, Weasel Boy Plaid Ferret Scottish Ale"
+                       cbf/notes           "A malt-focused, generally caramelly beer with perhaps a few esters and occasionally a butterscotch aftertaste. Hops only to balance and support the malt. The malt character can range from dry and grainy to rich, toasty, and caramelly, but is never roasty and especially never has a peat smoke character."
+                       cbf/og-max          1.06
+                       cbf/color-min       13.0
+                       cbf/abv-max         0.06
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Low to medium maltiness, often with flavors of toasted breadcrumbs, lady fingers, and English biscuits. Low to medium caramel and low butterscotch is allowable. Light pome fruitiness in best examples. May have low traditional English hop aroma (earthy, floral, orange-citrus, spicy, etc.). Peat smoke is inappropriate. Appearance: Pale copper to very dark brown. Clear. Low to moderate, creamy off-white. Flavor: Entirely malt-focused, with flavors ranging from pale, bready malt with caramel overtones to rich-toasty malt with roasted accents (but never roasty) or a combination thereof. Fruity esters are not required but add depth yet are never high. Hop bitterness to balance the malt. No to low hop flavor is also allowed and should of traditional English character (earthy, floral, orange-citrus, spicy, etc.). Finish ranges from rich and malty to dry and grainy. A subtle butterscotch character is acceptable; however, burnt sugars are not. The malt-hop balance tilts toward malt. Peat smoke is inappropriate. Mouthfeel: Medium-low to medium body. Low to moderate carbonation. Can be relatively rich and creamy to dry and grainy."
+                       cbf/ibu-min         15}))
 
 
 (def scottish-ale

--- a/src/common_beer_data/styles/bjcp_2015/smoked_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/smoked_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.smoked-beer
   "2015 BJCP guidelines on Smoked Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def classic-style-smoked-beer
@@ -8,27 +9,27 @@
    
    Balance in the use of smoke, hops and malt character is exhibited by the better examples."
   (styles/build-style :classic-style-smoked-beer
-                      {:category        "Smoked Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Classic Style Smoked Beer"
-                       :type            "Mixed"
-                       :style-letter    "A"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "32"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Different materials used to smoke malt result in unique flavor and aroma characteristics. Beechwood, or other hardwood (oak, maple, mesquite, alder, pecan, apple, cherry, other fruitwoods) smoked malts may be used. The various woods may remind one of certain smoked products due to their food association (e.g., hickory with ribs, maple with bacon or sausage, and alder with salmon). Evergreen wood should never be used since it adds a medicinal, piney flavor to the malt. Noticeable peat-smoked malt is universally undesirable due to its sharp, piercing phenolics and dirt-like earthiness. The remaining ingredients vary with the base style. If smoked malts are combined with other unusual ingredients (fruits, vegetables, spices, honey, etc.) in noticeable quantities, the resulting beer should be entered in the Specialty Smoked Beer."
-                       :examples        "Alaskan Smoked Porter, Schlenkerla Weizen Rauchbier and Ur-Bock Rauchbier, Spezial Lagerbier, Weissbier and Bockbier, Stone Smoked Porter"
-                       :notes           "A smoke-enhanced beer showing good balance between the smoke and beer character, while remaining pleasant to drink. Balance in the use of smoke, hops and malt character is exhibited by the better examples."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: The aroma should be a pleasant balance between the expected aroma of the base beer and the smokiness imparted by the use of smoked malts. The intensity and character of the smoke and base beer style can vary, with either being prominent in the balance. Smokiness may vary from low to assertive; however, balance in the overall presentation is the key to well-made examples. The quality and secondary characteristics of the smoke are reflective of the source of the smoke (e.g., alder, oak, beechwood). Sharp, phenolic, harsh, rubbery, or burnt smoke-derived aromatics are inappropriate. Appearance: Variable. The appearance should reflect the base beer style, although the color of the beer is often a bit darker than the plain base style. Flavor: As with aroma, there should be a balance between smokiness and the expected flavor characteristics of the base beer style. Smokiness may vary from low to assertive. Smoky flavors may range from woody to somewhat bacon-like depending on the type of malts used. The balance of underlying beer characteristics and smoke can vary, although the resulting blend should be somewhat balanced and enjoyable. Smoke can add some dryness to the finish. Harsh, bitter, burnt, charred, rubbery, sulfury, medicinal, or phenolic smoky characteristics are generally inappropriate (although some of these characteristics may be present in some base styles; however, the smoked malt shouldn't contribute these flavors). Mouthfeel: Varies with the base beer style. Significant astringent, phenolic smoke-derived harshness is inappropriate."
-                       :ibu-min         7}))
+                      {cbf/category        "Smoked Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Classic Style Smoked Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "32"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Different materials used to smoke malt result in unique flavor and aroma characteristics. Beechwood, or other hardwood (oak, maple, mesquite, alder, pecan, apple, cherry, other fruitwoods) smoked malts may be used. The various woods may remind one of certain smoked products due to their food association (e.g., hickory with ribs, maple with bacon or sausage, and alder with salmon). Evergreen wood should never be used since it adds a medicinal, piney flavor to the malt. Noticeable peat-smoked malt is universally undesirable due to its sharp, piercing phenolics and dirt-like earthiness. The remaining ingredients vary with the base style. If smoked malts are combined with other unusual ingredients (fruits, vegetables, spices, honey, etc.) in noticeable quantities, the resulting beer should be entered in the Specialty Smoked Beer."
+                       cbf/examples        "Alaskan Smoked Porter, Schlenkerla Weizen Rauchbier and Ur-Bock Rauchbier, Spezial Lagerbier, Weissbier and Bockbier, Stone Smoked Porter"
+                       cbf/notes           "A smoke-enhanced beer showing good balance between the smoke and beer character, while remaining pleasant to drink. Balance in the use of smoke, hops and malt character is exhibited by the better examples."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: The aroma should be a pleasant balance between the expected aroma of the base beer and the smokiness imparted by the use of smoked malts. The intensity and character of the smoke and base beer style can vary, with either being prominent in the balance. Smokiness may vary from low to assertive; however, balance in the overall presentation is the key to well-made examples. The quality and secondary characteristics of the smoke are reflective of the source of the smoke (e.g., alder, oak, beechwood). Sharp, phenolic, harsh, rubbery, or burnt smoke-derived aromatics are inappropriate. Appearance: Variable. The appearance should reflect the base beer style, although the color of the beer is often a bit darker than the plain base style. Flavor: As with aroma, there should be a balance between smokiness and the expected flavor characteristics of the base beer style. Smokiness may vary from low to assertive. Smoky flavors may range from woody to somewhat bacon-like depending on the type of malts used. The balance of underlying beer characteristics and smoke can vary, although the resulting blend should be somewhat balanced and enjoyable. Smoke can add some dryness to the finish. Harsh, bitter, burnt, charred, rubbery, sulfury, medicinal, or phenolic smoky characteristics are generally inappropriate (although some of these characteristics may be present in some base styles; however, the smoked malt shouldn't contribute these flavors). Mouthfeel: Varies with the base beer style. Significant astringent, phenolic smoke-derived harshness is inappropriate."
+                       cbf/ibu-min         7}))
 
 
 (def specialty-smoked-beer
@@ -36,27 +37,27 @@
    
    Balance in the use of smoke, hops and malt character is exhibited by the better examples."
   (styles/build-style :specialty-smoked-beer
-                      {:category        "Smoked Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Specialty Smoked Beer"
-                       :type            "Mixed"
-                       :style-letter    "B"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "32"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Different materials used to smoke malt result in unique flavor and aroma characteristics. Beechwood, or other hardwood (oak, maple, mesquite, alder, pecan, apple, cherry, other fruitwoods) smoked malts may be used. The various woods may remind one of certain smoked products due to their food association (e.g., hickory with ribs, maple with bacon or sausage, and alder with salmon). Evergreen wood should never be used since it adds a medicinal, piney flavor to the malt. Noticeable peat-smoked malt is universally undesirable due to its sharp, piercing phenolics and dirt-like earthiness. The beer ingredients vary with the base style. Other unusual ingredients (fruits, vegetables, spices, honey, etc.) used in noticeable quantities."
-                       :examples        "Alaskan Smoked Porter, Schlenkerla Weizen Rauchbier and Ur-Bock Rauchbier, Spezial Lagerbier, Weissbier and Bockbier, Stone Smoked Porter"
-                       :notes           "A smoke-enhanced beer showing good balance between the smoke, the beer character, and the added ingredients, while remaining pleasant to drink. Balance in the use of smoke, hops and malt character is exhibited by the better examples."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: The aroma should be a pleasant balance between the expected aroma of the base beer, the smokiness imparted by the use of smoked malts, and any additional ingredients. The intensity and character of the smoke, base beer style, and additional ingredients can vary, with any being more prominent in the balance. Smokiness may vary from low to assertive; however, balance in the overall presentation is the key to well-made examples. The quality and secondary characteristics of the smoke are reflective of the source of the smoke (e.g., alder, oak, beechwood). Sharp, phenolic, harsh, rubbery, or burnt smoke-derived aromatics are inappropriate. Appearance: Variable. The appearance should reflect the base beer style, although the color of the beer is often a bit darker than the plain base style. The use of certain fruits and spices may affect the color and hue of the beer as well. Flavor: As with aroma, there should be a balance between smokiness, the expected flavor characteristics of the base beer style, and the additional ingredients. Smokiness may vary from low to assertive. Smoky flavors may range from woody to somewhat bacon-like depending on the type of malts used. The balance of underlying beer characteristics and smoke can vary, although the resulting blend should be somewhat balanced and enjoyable. Smoke can add some dryness to the finish. Harsh, bitter, burnt, charred, rubbery, sulfury, medicinal, or phenolic smoky characteristics are generally inappropriate (although some of these characteristics may be present in some base styles; however, the smoked malt shouldn't contribute these flavors). Mouthfeel: Varies with the base beer style. Significant astringent, phenolic smoke-derived harshness is inappropriate."
-                       :ibu-min         7}))
+                      {cbf/category        "Smoked Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Specialty Smoked Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "32"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Different materials used to smoke malt result in unique flavor and aroma characteristics. Beechwood, or other hardwood (oak, maple, mesquite, alder, pecan, apple, cherry, other fruitwoods) smoked malts may be used. The various woods may remind one of certain smoked products due to their food association (e.g., hickory with ribs, maple with bacon or sausage, and alder with salmon). Evergreen wood should never be used since it adds a medicinal, piney flavor to the malt. Noticeable peat-smoked malt is universally undesirable due to its sharp, piercing phenolics and dirt-like earthiness. The beer ingredients vary with the base style. Other unusual ingredients (fruits, vegetables, spices, honey, etc.) used in noticeable quantities."
+                       cbf/examples        "Alaskan Smoked Porter, Schlenkerla Weizen Rauchbier and Ur-Bock Rauchbier, Spezial Lagerbier, Weissbier and Bockbier, Stone Smoked Porter"
+                       cbf/notes           "A smoke-enhanced beer showing good balance between the smoke, the beer character, and the added ingredients, while remaining pleasant to drink. Balance in the use of smoke, hops and malt character is exhibited by the better examples."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: The aroma should be a pleasant balance between the expected aroma of the base beer, the smokiness imparted by the use of smoked malts, and any additional ingredients. The intensity and character of the smoke, base beer style, and additional ingredients can vary, with any being more prominent in the balance. Smokiness may vary from low to assertive; however, balance in the overall presentation is the key to well-made examples. The quality and secondary characteristics of the smoke are reflective of the source of the smoke (e.g., alder, oak, beechwood). Sharp, phenolic, harsh, rubbery, or burnt smoke-derived aromatics are inappropriate. Appearance: Variable. The appearance should reflect the base beer style, although the color of the beer is often a bit darker than the plain base style. The use of certain fruits and spices may affect the color and hue of the beer as well. Flavor: As with aroma, there should be a balance between smokiness, the expected flavor characteristics of the base beer style, and the additional ingredients. Smokiness may vary from low to assertive. Smoky flavors may range from woody to somewhat bacon-like depending on the type of malts used. The balance of underlying beer characteristics and smoke can vary, although the resulting blend should be somewhat balanced and enjoyable. Smoke can add some dryness to the finish. Harsh, bitter, burnt, charred, rubbery, sulfury, medicinal, or phenolic smoky characteristics are generally inappropriate (although some of these characteristics may be present in some base styles; however, the smoked malt shouldn't contribute these flavors). Mouthfeel: Varies with the base beer style. Significant astringent, phenolic smoke-derived harshness is inappropriate."
+                       cbf/ibu-min         7}))
 
 
 (def smoked-beer

--- a/src/common_beer_data/styles/bjcp_2015/specialty_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/specialty_beer.cljc
@@ -1,32 +1,33 @@
 (ns common-beer-data.styles.bjcp-2015.specialty-beer
   "2015 BJCP guidelines on Specialty Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def clone-beer
   "Based on declared clone beer."
   (styles/build-style :clone-beer
-                      {:category        "Specialty Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Clone Beer"
-                       :type            "Mixed"
-                       :style-letter    "A"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "34"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Varies with base style. Aged in wooden casks or barrels previously used to store alcohol (e.g., whiskey, bourbon, port, sherry, Madeira, wine, etc). Fuller-bodied, higher-gravity base styles often are used since they can best stand up to the additional flavors, although experimentation is encouraged."
-                       :examples        "Founders Kentucky Breakfast Stout, Goose Island Bourbon County Stout, J.W. Lees Harvest Ale in Port, Sherry, Lagavulin Whisky or Calvados Casks, The Lost Abbey Angel's Share Ale; many microbreweries have specialty beers served only on premises often directly from the cask."
-                       :notes           "Based on declared clone beer."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: Based on declared clone beer. Appearance: Based on declared clone beer. Flavor: Based on declared clone beer. Mouthfeel: Based on declared clone beer."
-                       :ibu-min         7}))
+                      {cbf/category        "Specialty Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Clone Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "34"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Varies with base style. Aged in wooden casks or barrels previously used to store alcohol (e.g., whiskey, bourbon, port, sherry, Madeira, wine, etc). Fuller-bodied, higher-gravity base styles often are used since they can best stand up to the additional flavors, although experimentation is encouraged."
+                       cbf/examples        "Founders Kentucky Breakfast Stout, Goose Island Bourbon County Stout, J.W. Lees Harvest Ale in Port, Sherry, Lagavulin Whisky or Calvados Casks, The Lost Abbey Angel's Share Ale; many microbreweries have specialty beers served only on premises often directly from the cask."
+                       cbf/notes           "Based on declared clone beer."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Based on declared clone beer. Appearance: Based on declared clone beer. Flavor: Based on declared clone beer. Mouthfeel: Based on declared clone beer."
+                       cbf/ibu-min         7}))
 
 
 (def mixed-style-beer
@@ -34,53 +35,53 @@
    
    As with all Specialty-Type Beers, the resulting combination of beer styles needs to be harmonious and balanced, and be pleasant to drink."
   (styles/build-style :mixed-style-beer
-                      {:category        "Specialty Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Mixed-Style Beer"
-                       :type            "Mixed"
-                       :style-letter    "B"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "34"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Varies with base style. Aged in wooden casks or barrels previously used to store alcohol (e.g., whiskey, bourbon, port, sherry, Madeira, wine, etc). Fuller-bodied, higher-gravity base styles often are used since they can best stand up to the additional flavors, although experimentation is encouraged."
-                       :examples        "Founders Kentucky Breakfast Stout, Goose Island Bourbon County Stout, J.W. Lees Harvest Ale in Port, Sherry, Lagavulin Whisky or Calvados Casks, The Lost Abbey Angel's Share Ale; many microbreweries have specialty beers served only on premises often directly from the cask."
-                       :notes           "Based on the declared base styles. As with all Specialty-Type Beers, the resulting combination of beer styles needs to be harmonious and balanced, and be pleasant to drink."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: Based on the declared base styles. Appearance: Based on the declared base styles. Flavor: Based on the declared base styles. Mouthfeel: Based on the declared base styles."
-                       :ibu-min         7}))
+                      {cbf/category        "Specialty Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Mixed-Style Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "34"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Varies with base style. Aged in wooden casks or barrels previously used to store alcohol (e.g., whiskey, bourbon, port, sherry, Madeira, wine, etc). Fuller-bodied, higher-gravity base styles often are used since they can best stand up to the additional flavors, although experimentation is encouraged."
+                       cbf/examples        "Founders Kentucky Breakfast Stout, Goose Island Bourbon County Stout, J.W. Lees Harvest Ale in Port, Sherry, Lagavulin Whisky or Calvados Casks, The Lost Abbey Angel's Share Ale; many microbreweries have specialty beers served only on premises often directly from the cask."
+                       cbf/notes           "Based on the declared base styles. As with all Specialty-Type Beers, the resulting combination of beer styles needs to be harmonious and balanced, and be pleasant to drink."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Based on the declared base styles. Appearance: Based on the declared base styles. Flavor: Based on the declared base styles. Mouthfeel: Based on the declared base styles."
+                       cbf/ibu-min         7}))
 
 
 (def experimental-beer
   "Varies, but should be a unique experience."
   (styles/build-style :experimental-beer
-                      {:category        "Specialty Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Experimental Beer"
-                       :type            "Mixed"
-                       :style-letter    "C"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "34"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Varies with base style. Aged in wooden casks or barrels previously used to store alcohol (e.g., whiskey, bourbon, port, sherry, Madeira, wine, etc). Fuller-bodied, higher-gravity base styles often are used since they can best stand up to the additional flavors, although experimentation is encouraged."
-                       :examples        "None"
-                       :notes           "Varies, but should be a unique experience."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: Varies. Appearance: Varies. Flavor: Varies. Mouthfeel: Varies."
-                       :ibu-min         7}))
+                      {cbf/category        "Specialty Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Experimental Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "34"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Varies with base style. Aged in wooden casks or barrels previously used to store alcohol (e.g., whiskey, bourbon, port, sherry, Madeira, wine, etc). Fuller-bodied, higher-gravity base styles often are used since they can best stand up to the additional flavors, although experimentation is encouraged."
+                       cbf/examples        "None"
+                       cbf/notes           "Varies, but should be a unique experience."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Varies. Appearance: Varies. Flavor: Varies. Mouthfeel: Varies."
+                       cbf/ibu-min         7}))
 
 
 (def specialty-beer

--- a/src/common_beer_data/styles/bjcp_2015/spiced_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/spiced_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.spiced-beer
   "2015 BJCP guidelines on Spiced Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def spice-herb-or-vegetable-beer
@@ -8,79 +9,79 @@
    
    The SHV character should be evident but in balance with the beer, not so forward as to suggest an artificial product."
   (styles/build-style :spice-herb-or-vegetable-beer
-                      {:category        "Spiced Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Spice, Herb, or Vegetable Beer"
-                       :type            "Mixed"
-                       :style-letter    "A"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "30"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Virtually any style of beer. Any combination of Saccharomyces, Brettanomyces, Lactobacillus, Pediococcus, or other similar fermenters. Can also be a blend of styles. While cherries, raspberries, and peaches are most common, other fruits can be used as well. Vegetables with fruit-like characteristics (chile, rhubarb, pumpkin, etc.) may also be used. Wood or barrel aging is very common, but not required."
-                       :examples        "Alesmith Speedway Stout, Bell's Java Stout, Elysian Avatar Jasmine IPA, Founders Breakfast Stout, Rogue Chipotle Ale, Traquair Jacobite Ale, Young's Double Chocolate Stout,"
-                       :notes           "A harmonious marriage of SHV and beer, but still recognizable as a beer. The SHV character should be evident but in balance with the beer, not so forward as to suggest an artificial product."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: The character of the particular spices, herbs and/or vegetables (SHV) should be noticeable in the aroma; however, note that some SHV (e.g., ginger, cinnamon) have stronger aromas and are more distinctive than others (e.g., some vegetables) - allow for a range of SHV character and intensity from subtle to aggressive. The individual character of each SHV(s) may not always be identifiable when used in combination. Hop aroma may be absent or balanced with SHV, depending on the style. The SHV(s) should add an extra complexity to the beer, but not be so prominent as to unbalance the resulting presentation. Appearance: Appearance should be appropriate to the declared base beer and declared special ingredients. For lighter-colored beers with spices, herbs or vegetables that exhibit distinctive colors, the colors may be noticeable in the beer and possibly the head. May have some haze or be clear. Head formation may be adversely affected by some ingredients, such as chocolate. Flavor: As with aroma, the distinctive flavor character associated with the particular SHV(s) should be noticeable, and may range in intensity from subtle to aggressive. The individual character of each SHV(s) may not always be identifiable when used in combination. The balance of SHV with the underlying beer is vital, and the SHV character should not be so artificial and/or overpowering as to overwhelm the beer. Hop bitterness, flavor, malt flavors, alcohol content, and fermentation by-products, such as esters, should be appropriate to the base beer and be harmonious and balanced with the distinctive SHV flavors present. Some SHV(s) are inherently bitter and may result in a beer more bitter than the declared base style. Mouthfeel: Mouthfeel may vary depending on the base beer selected and as appropriate to that base beer. Body and carbonation levels should be appropriate to the base beer style being presented. Some SHV(s) may add additional body, although fermentable additions may thin out the beer. Some SHV(s) may add a bit of astringency, although a \"raw\" spice character is undesirable."
-                       :ibu-min         7}))
+                      {cbf/category        "Spiced Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Spice, Herb, or Vegetable Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "30"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Virtually any style of beer. Any combination of Saccharomyces, Brettanomyces, Lactobacillus, Pediococcus, or other similar fermenters. Can also be a blend of styles. While cherries, raspberries, and peaches are most common, other fruits can be used as well. Vegetables with fruit-like characteristics (chile, rhubarb, pumpkin, etc.) may also be used. Wood or barrel aging is very common, but not required."
+                       cbf/examples        "Alesmith Speedway Stout, Bell's Java Stout, Elysian Avatar Jasmine IPA, Founders Breakfast Stout, Rogue Chipotle Ale, Traquair Jacobite Ale, Young's Double Chocolate Stout,"
+                       cbf/notes           "A harmonious marriage of SHV and beer, but still recognizable as a beer. The SHV character should be evident but in balance with the beer, not so forward as to suggest an artificial product."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: The character of the particular spices, herbs and/or vegetables (SHV) should be noticeable in the aroma; however, note that some SHV (e.g., ginger, cinnamon) have stronger aromas and are more distinctive than others (e.g., some vegetables) - allow for a range of SHV character and intensity from subtle to aggressive. The individual character of each SHV(s) may not always be identifiable when used in combination. Hop aroma may be absent or balanced with SHV, depending on the style. The SHV(s) should add an extra complexity to the beer, but not be so prominent as to unbalance the resulting presentation. Appearance: Appearance should be appropriate to the declared base beer and declared special ingredients. For lighter-colored beers with spices, herbs or vegetables that exhibit distinctive colors, the colors may be noticeable in the beer and possibly the head. May have some haze or be clear. Head formation may be adversely affected by some ingredients, such as chocolate. Flavor: As with aroma, the distinctive flavor character associated with the particular SHV(s) should be noticeable, and may range in intensity from subtle to aggressive. The individual character of each SHV(s) may not always be identifiable when used in combination. The balance of SHV with the underlying beer is vital, and the SHV character should not be so artificial and/or overpowering as to overwhelm the beer. Hop bitterness, flavor, malt flavors, alcohol content, and fermentation by-products, such as esters, should be appropriate to the base beer and be harmonious and balanced with the distinctive SHV flavors present. Some SHV(s) are inherently bitter and may result in a beer more bitter than the declared base style. Mouthfeel: Mouthfeel may vary depending on the base beer selected and as appropriate to that base beer. Body and carbonation levels should be appropriate to the base beer style being presented. Some SHV(s) may add additional body, although fermentable additions may thin out the beer. Some SHV(s) may add a bit of astringency, although a \"raw\" spice character is undesirable."
+                       cbf/ibu-min         7}))
 
 
 (def autumn-seasonal-beer
   "An amber to copper, spiced beer that often has a moderately rich body and slightly warming finish suggesting a good accompaniment for the cool fall season, and often evocative of Thanksgiving traditions."
   (styles/build-style :autumn-seasonal-beer
-                      {:category        "Spiced Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Autumn Seasonal Beer"
-                       :type            "Mixed"
-                       :style-letter    "B"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "30"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Spices are required, and often include those evocative of the fall or Thanksgiving season (e.g., allspice, nutmeg, cinnamon, cloves, ginger) but any combination is possible and creativity is encouraged. Flavorful adjuncts are often used (e.g., molasses, invert sugar, brown sugar, honey, maple syrup, etc.). Squash-type or gourd-type vegetables (most frequently pumpkin) are often used."
-                       :examples        "Dogfish Head Punkin Ale, Schlafly Pumpkin Ale, Southampton Pumpkin Ale"
-                       :notes           "An amber to copper, spiced beer that often has a moderately rich body and slightly warming finish suggesting a good accompaniment for the cool fall season, and often evocative of Thanksgiving traditions."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: A wide range of aromatics is possible, although many examples are reminiscent of pumpkin pie, candied yams, or similar harvest or (US) Thanksgiving themed dishes. Any combination of aromatics that suggests the fall season is welcome. The base beer style often has a malty profile that supports the balanced presentation of the aromatics from spices and possibly other special ingredients. Additional fermentables (e.g., brown sugar, honey, molasses, maple syrup, etc.) may lend their own unique aromatics. Hop aromatics are often absent, subdued, or slightly spicy. Alcohol aromatics may be found in some examples, but this character should be restrained. The overall aroma should be balanced and harmonious, and is often fairly complex and inviting. Appearance: Generally medium amber to coppery-brown (lighter versions are more common). Usually clear, although darker versions may be virtually opaque. Some chill haze is acceptable. Generally has a well-formed head that is often off-white to tan. Some versions with squashes will take on an unusual hue for beer, with orange-like hints. Flavor: Many interpretations are possible; allow for brewer creativity as long as the resulting product is balanced and provides some spice (and optionally, sugar and vegetable) presentation. Spices associated with the fall season are typical (as mentioned in the Aroma section). The spices and optional fermentables should be supportive and blend well with the base beer style. Rich, malty and/or sweet malt-based flavors are common, and may include caramel, toasty, biscuity, or nutty flavors (toasted bread crust or cooked pie crust flavors are welcome). May include distinctive flavors from specific fermentables (molasses, honey, brown sugar, etc.), although these elements are not required. Flavor derived from squash-based vegetables are often elusive. The wide range of special ingredients should be supportive and balanced, not so prominent as to overshadow the base beer. Bitterness and hop flavor are generally restrained so as to not interfere with the spices and special ingredients. Generally finishes rather full and satisfying, and often has some alcohol flavor. Roasted malt characteristics are typically absent. Mouthfeel: A wide range of interpretations is possible. Body is generally medium to full, and a certain malty and/or vegetable-based chewiness is often present. Moderately low to moderately high carbonation is typical. Many examples will show some well-aged, warming alcohol content, but without being overly hot. The beers do not have to be overly strong to show some warming effects."
-                       :ibu-min         7}))
+                      {cbf/category        "Spiced Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Autumn Seasonal Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "30"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Spices are required, and often include those evocative of the fall or Thanksgiving season (e.g., allspice, nutmeg, cinnamon, cloves, ginger) but any combination is possible and creativity is encouraged. Flavorful adjuncts are often used (e.g., molasses, invert sugar, brown sugar, honey, maple syrup, etc.). Squash-type or gourd-type vegetables (most frequently pumpkin) are often used."
+                       cbf/examples        "Dogfish Head Punkin Ale, Schlafly Pumpkin Ale, Southampton Pumpkin Ale"
+                       cbf/notes           "An amber to copper, spiced beer that often has a moderately rich body and slightly warming finish suggesting a good accompaniment for the cool fall season, and often evocative of Thanksgiving traditions."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: A wide range of aromatics is possible, although many examples are reminiscent of pumpkin pie, candied yams, or similar harvest or (US) Thanksgiving themed dishes. Any combination of aromatics that suggests the fall season is welcome. The base beer style often has a malty profile that supports the balanced presentation of the aromatics from spices and possibly other special ingredients. Additional fermentables (e.g., brown sugar, honey, molasses, maple syrup, etc.) may lend their own unique aromatics. Hop aromatics are often absent, subdued, or slightly spicy. Alcohol aromatics may be found in some examples, but this character should be restrained. The overall aroma should be balanced and harmonious, and is often fairly complex and inviting. Appearance: Generally medium amber to coppery-brown (lighter versions are more common). Usually clear, although darker versions may be virtually opaque. Some chill haze is acceptable. Generally has a well-formed head that is often off-white to tan. Some versions with squashes will take on an unusual hue for beer, with orange-like hints. Flavor: Many interpretations are possible; allow for brewer creativity as long as the resulting product is balanced and provides some spice (and optionally, sugar and vegetable) presentation. Spices associated with the fall season are typical (as mentioned in the Aroma section). The spices and optional fermentables should be supportive and blend well with the base beer style. Rich, malty and/or sweet malt-based flavors are common, and may include caramel, toasty, biscuity, or nutty flavors (toasted bread crust or cooked pie crust flavors are welcome). May include distinctive flavors from specific fermentables (molasses, honey, brown sugar, etc.), although these elements are not required. Flavor derived from squash-based vegetables are often elusive. The wide range of special ingredients should be supportive and balanced, not so prominent as to overshadow the base beer. Bitterness and hop flavor are generally restrained so as to not interfere with the spices and special ingredients. Generally finishes rather full and satisfying, and often has some alcohol flavor. Roasted malt characteristics are typically absent. Mouthfeel: A wide range of interpretations is possible. Body is generally medium to full, and a certain malty and/or vegetable-based chewiness is often present. Moderately low to moderately high carbonation is typical. Many examples will show some well-aged, warming alcohol content, but without being overly hot. The beers do not have to be overly strong to show some warming effects."
+                       cbf/ibu-min         7}))
 
 
 (def winter-seasonal-beer
   "A stronger, darker, spiced beer that often has a rich body and warming finish suggesting a good accompaniment for the cold winter season."
   (styles/build-style :winter-seasonal-beer
-                      {:category        "Spiced Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Winter Seasonal Beer"
-                       :type            "Mixed"
-                       :style-letter    "C"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "30"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Generally ales, although some dark strong lagers exist. Spices are required, and often include those evocative of the Christmas season (e.g., allspice, nutmeg, cinnamon, cloves, ginger) but any combination is possible and creativity is encouraged. Fruit peel (e.g., oranges, lemon) may be used, as may subtle additions of other fruits. Flavorful adjuncts are often used (e.g., molasses, treacle, invert sugar, brown sugar, honey, maple syrup, etc.)."
-                       :examples        "Anchor Our Special Ale, Goose Island Christmas Ale, Great Lakes Christmas Ale, Harpoon Winter Warmer, Lakefront Holiday Spice Lager Beer, Weyerbacher Winter Ale"
-                       :notes           "A stronger, darker, spiced beer that often has a rich body and warming finish suggesting a good accompaniment for the cold winter season."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: A wide range of aromatics is possible, although many examples are reminiscent of Christmas cookies, gingerbread, English-type Christmas pudding, evergreen trees, or mulling spices. Any combination of aromatics that suggests the holiday season is welcome. The base beer style often has a malty profile that supports the balanced presentation of the aromatics from spices and possibly other special ingredients. Additional fermentables (e.g., honey, molasses, maple syrup, etc.) may lend their own unique aromatics. Hop aromatics are often absent, subdued, or slightly spicy. Some fruit character (often of dried citrus peel, or dried fruit such as raisins or plums) is optional but acceptable. Alcohol aromatics may be found in some examples, but this character should be restrained. The overall aroma should be balanced and harmonious, and is often fairly complex and inviting. Appearance: Generally medium amber to very dark brown (darker versions are more common). Usually clear, although darker versions may be virtually opaque. Some chill haze is acceptable. Generally has a well-formed head that is often off-white to tan. Flavor: Many interpretations are possible; allow for brewer creativity as long as the resulting product is balanced and provides some spice presentation. Spices associated with the holiday season are typical (as mentioned in the Aroma section). The spices and optional fermentables should be supportive and blend well with the base beer style. Rich, malty and/or sweet malt-based flavors are common, and may include caramel, toast, nutty, or chocolate flavors. May include some dried fruit or dried fruit peel flavors such as raisin, plum, fig, orange peel or lemon peel. May include distinctive flavors from specific fermentables (molasses, honey, brown sugar, etc.), although these elements are not required. A light evergreen tree character is optional but found in some examples. The wide range of special ingredients should be supportive and balanced, not so prominent as to overshadow the base beer. Bitterness and hop flavor are generally restrained so as to not interfere with the spices and special ingredients. Generally finishes rather full and satisfying, and often has some alcohol flavor. Roasted malt characteristics are rare, and not usually stronger than chocolate. Mouthfeel: A wide range of interpretations is possible. Body is generally medium to full, and a certain malty chewiness is often present. Moderately low to moderately high carbonation is typical. Many examples will show some well-aged, warming alcohol content, but without being overly hot. The beers do not have to be overly strong to show some warming effects."
-                       :ibu-min         7}))
+                      {cbf/category        "Spiced Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Winter Seasonal Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "30"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Generally ales, although some dark strong lagers exist. Spices are required, and often include those evocative of the Christmas season (e.g., allspice, nutmeg, cinnamon, cloves, ginger) but any combination is possible and creativity is encouraged. Fruit peel (e.g., oranges, lemon) may be used, as may subtle additions of other fruits. Flavorful adjuncts are often used (e.g., molasses, treacle, invert sugar, brown sugar, honey, maple syrup, etc.)."
+                       cbf/examples        "Anchor Our Special Ale, Goose Island Christmas Ale, Great Lakes Christmas Ale, Harpoon Winter Warmer, Lakefront Holiday Spice Lager Beer, Weyerbacher Winter Ale"
+                       cbf/notes           "A stronger, darker, spiced beer that often has a rich body and warming finish suggesting a good accompaniment for the cold winter season."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: A wide range of aromatics is possible, although many examples are reminiscent of Christmas cookies, gingerbread, English-type Christmas pudding, evergreen trees, or mulling spices. Any combination of aromatics that suggests the holiday season is welcome. The base beer style often has a malty profile that supports the balanced presentation of the aromatics from spices and possibly other special ingredients. Additional fermentables (e.g., honey, molasses, maple syrup, etc.) may lend their own unique aromatics. Hop aromatics are often absent, subdued, or slightly spicy. Some fruit character (often of dried citrus peel, or dried fruit such as raisins or plums) is optional but acceptable. Alcohol aromatics may be found in some examples, but this character should be restrained. The overall aroma should be balanced and harmonious, and is often fairly complex and inviting. Appearance: Generally medium amber to very dark brown (darker versions are more common). Usually clear, although darker versions may be virtually opaque. Some chill haze is acceptable. Generally has a well-formed head that is often off-white to tan. Flavor: Many interpretations are possible; allow for brewer creativity as long as the resulting product is balanced and provides some spice presentation. Spices associated with the holiday season are typical (as mentioned in the Aroma section). The spices and optional fermentables should be supportive and blend well with the base beer style. Rich, malty and/or sweet malt-based flavors are common, and may include caramel, toast, nutty, or chocolate flavors. May include some dried fruit or dried fruit peel flavors such as raisin, plum, fig, orange peel or lemon peel. May include distinctive flavors from specific fermentables (molasses, honey, brown sugar, etc.), although these elements are not required. A light evergreen tree character is optional but found in some examples. The wide range of special ingredients should be supportive and balanced, not so prominent as to overshadow the base beer. Bitterness and hop flavor are generally restrained so as to not interfere with the spices and special ingredients. Generally finishes rather full and satisfying, and often has some alcohol flavor. Roasted malt characteristics are rare, and not usually stronger than chocolate. Mouthfeel: A wide range of interpretations is possible. Body is generally medium to full, and a certain malty chewiness is often present. Moderately low to moderately high carbonation is typical. Many examples will show some well-aged, warming alcohol content, but without being overly hot. The beers do not have to be overly strong to show some warming effects."
+                       cbf/ibu-min         7}))
 
 
 (def spiced-beer

--- a/src/common_beer_data/styles/bjcp_2015/standard_american_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/standard_american_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.standard-american-beer
   "2015 BJCP guidelines on Standard American Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def american-light-lager
@@ -8,27 +9,27 @@
    
    Very refreshing and thirst quenching."
   (styles/build-style :american-light-lager
-                      {:category        "Standard American Beer"
-                       :carb-min        1.5
-                       :fg-max          1.008
-                       :og-min          1.028
-                       :name            "American Light Lager"
-                       :type            "Lager"
-                       :style-letter    "A"
-                       :abv-min         0.028
-                       :fg-min          0.998
-                       :category-number "1"
-                       :carb-max        3.0
-                       :ibu-max         12
-                       :ingredients     "Two- or six-row barley with high percentage (up to 40%) of rice or corn as adjuncts. Additional enzymes can further lighten the body and lower carbohydrates."
-                       :examples        "Bud Light, Coors Light, Keystone Light, Michelob Light, Miller Lite, Old Milwaukee Light"
-                       :notes           "Highly carbonated, very light-bodied, nearly flavorless lager designed to be consumed very cold. Very refreshing and thirst quenching."
-                       :og-max          1.04
-                       :color-min       2
-                       :abv-max         0.042
-                       :color-max       3
-                       :profile         "Aroma: Low to no malt aroma, although it can be perceived as grainy, sweet, or corn-like if present. Hop aroma is light to none, with a spicy or floral hop character if present. While a clean fermentation character is desirable, a light amount of yeast character (particularly a light apple fruitiness) is not a fault. Light DMS is not a fault. Appearance: Very pale straw to pale yellow color. White, frothy head seldom persists. Very clear. Flavor: Relatively neutral palate with a crisp and dry finish and a low to very low grainy or corn-like flavor that might be perceived as sweetness due to the low bitterness. Hop flavor ranges from none to low levels, and can have a floral, spicy, or herbal quality (although rarely strong enough to detect). Low to very low hop bitterness. Balance may vary from slightly malty to slightly bitter, but is relatively close to even. High levels of carbonation may accentuate the crispness of the dry finish. Clean lager fermentation character. Mouthfeel: Very light (sometimes watery) body. Very highly carbonated with slight carbonic bite on the tongue."
-                       :ibu-min         8}))
+                      {cbf/category        "Standard American Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.008
+                       cbf/og-min          1.028
+                       cbf/name            "American Light Lager"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.028
+                       cbf/fg-min          0.998
+                       cbf/category-number "1"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         12
+                       cbf/ingredients     "Two- or six-row barley with high percentage (up to 40%) of rice or corn as adjuncts. Additional enzymes can further lighten the body and lower carbohydrates."
+                       cbf/examples        "Bud Light, Coors Light, Keystone Light, Michelob Light, Miller Lite, Old Milwaukee Light"
+                       cbf/notes           "Highly carbonated, very light-bodied, nearly flavorless lager designed to be consumed very cold. Very refreshing and thirst quenching."
+                       cbf/og-max          1.04
+                       cbf/color-min       2
+                       cbf/abv-max         0.042
+                       cbf/color-max       3
+                       cbf/profile         "Aroma: Low to no malt aroma, although it can be perceived as grainy, sweet, or corn-like if present. Hop aroma is light to none, with a spicy or floral hop character if present. While a clean fermentation character is desirable, a light amount of yeast character (particularly a light apple fruitiness) is not a fault. Light DMS is not a fault. Appearance: Very pale straw to pale yellow color. White, frothy head seldom persists. Very clear. Flavor: Relatively neutral palate with a crisp and dry finish and a low to very low grainy or corn-like flavor that might be perceived as sweetness due to the low bitterness. Hop flavor ranges from none to low levels, and can have a floral, spicy, or herbal quality (although rarely strong enough to detect). Low to very low hop bitterness. Balance may vary from slightly malty to slightly bitter, but is relatively close to even. High levels of carbonation may accentuate the crispness of the dry finish. Clean lager fermentation character. Mouthfeel: Very light (sometimes watery) body. Very highly carbonated with slight carbonic bite on the tongue."
+                       cbf/ibu-min         8}))
 
 
 (def american-lager
@@ -36,27 +37,27 @@
    
    Served very cold, it can be a very refreshing and thirst quenching drink."
   (styles/build-style :american-lager
-                      {:category        "Standard American Beer"
-                       :carb-min        1.5
-                       :fg-max          1.01
-                       :og-min          1.04
-                       :name            "American Lager"
-                       :type            "Lager"
-                       :style-letter    "B"
-                       :abv-min         0.042
-                       :fg-min          1.004
-                       :category-number "1"
-                       :carb-max        3.0
-                       :ibu-max         18
-                       :ingredients     "Two- or six-row barley with high percentage (up to 40%) of rice or corn as adjuncts."
-                       :examples        "Budweiser, Coors Original, Grain Belt Premium Lager, Miller High Life, Pabst Blue Ribbon, Special Export"
-                       :notes           "A very pale, highly-carbonated, light-bodied, well-attenuated lager with a very neutral flavor profile and low bitterness. Served very cold, it can be a very refreshing and thirst quenching drink."
-                       :og-max          1.05
-                       :color-min       2
-                       :abv-max         0.053
-                       :color-max       4
-                       :profile         "Aroma: Low to no malt aroma, although it can be perceived as grainy, sweet or corn-like if present. Hop aroma may range from none to a light, spicy or floral hop presence. While a clean fermentation character is desirable, a light amount of yeast character (particularly a light apple character) is not a fault. Light DMS is also not a fault. Appearance: Very pale straw to medium yellow color. White, frothy head seldom persists. Very clear. Flavor: Relatively neutral palate with a crisp and dry finish and a moderately-low to low grainy or corn-like flavor that might be perceived as sweetness due to the low bitterness. Hop flavor ranges from none to moderately-low levels, and can have a floral, spicy, or herbal quality (although often not strong enough to distinguish). Hop bitterness at low to medium-low level. Balance may vary from slightly malty to slightly bitter, but is relatively close to even. High levels of carbonation may accentuate the crispness of the dry finish. Clean lager fermentation character. Mouthfeel: Low to medium-low body. Very highly carbonated with slight carbonic bite on the tongue."
-                       :ibu-min         8}))
+                      {cbf/category        "Standard American Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.01
+                       cbf/og-min          1.04
+                       cbf/name            "American Lager"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.042
+                       cbf/fg-min          1.004
+                       cbf/category-number "1"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         18
+                       cbf/ingredients     "Two- or six-row barley with high percentage (up to 40%) of rice or corn as adjuncts."
+                       cbf/examples        "Budweiser, Coors Original, Grain Belt Premium Lager, Miller High Life, Pabst Blue Ribbon, Special Export"
+                       cbf/notes           "A very pale, highly-carbonated, light-bodied, well-attenuated lager with a very neutral flavor profile and low bitterness. Served very cold, it can be a very refreshing and thirst quenching drink."
+                       cbf/og-max          1.05
+                       cbf/color-min       2
+                       cbf/abv-max         0.053
+                       cbf/color-max       4
+                       cbf/profile         "Aroma: Low to no malt aroma, although it can be perceived as grainy, sweet or corn-like if present. Hop aroma may range from none to a light, spicy or floral hop presence. While a clean fermentation character is desirable, a light amount of yeast character (particularly a light apple character) is not a fault. Light DMS is also not a fault. Appearance: Very pale straw to medium yellow color. White, frothy head seldom persists. Very clear. Flavor: Relatively neutral palate with a crisp and dry finish and a moderately-low to low grainy or corn-like flavor that might be perceived as sweetness due to the low bitterness. Hop flavor ranges from none to moderately-low levels, and can have a floral, spicy, or herbal quality (although often not strong enough to distinguish). Hop bitterness at low to medium-low level. Balance may vary from slightly malty to slightly bitter, but is relatively close to even. High levels of carbonation may accentuate the crispness of the dry finish. Clean lager fermentation character. Mouthfeel: Low to medium-low body. Very highly carbonated with slight carbonic bite on the tongue."
+                       cbf/ibu-min         8}))
 
 
 (def cream-ale
@@ -64,27 +65,27 @@
    
    Easily drinkable and refreshing, with more character than typical American lagers."
   (styles/build-style :cream-ale
-                      {:category        "Standard American Beer"
-                       :carb-min        1.5
-                       :fg-max          1.012
-                       :og-min          1.042
-                       :name            "Cream Ale"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.042
-                       :fg-min          1.006
-                       :category-number "1"
-                       :carb-max        3.0
-                       :ibu-max         20
-                       :ingredients     "American ingredients most commonly used. A grain bill of six-row malt, or a combination of six-row and North American two-row, is common. Adjuncts can include up to 20% maize in the mash, and up to 20% glucose or other sugars in the boil. Any variety of hops can be used for bittering and finishing."
-                       :examples        "Genesee Cream Ale, Liebotschaner Cream Ale, Little Kings Cream Ale, New Glarus Spotted Cow, Old Style, Sleeman Cream Ale"
-                       :notes           "A clean, well-attenuated, flavorful American \"lawnmower\" beer. Easily drinkable and refreshing, with more character than typical American lagers."
-                       :og-max          1.055
-                       :color-min       2.5
-                       :abv-max         0.056
-                       :color-max       5.0
-                       :profile         "Aroma: Medium-low to low malt notes, with a sweet, corn-like aroma. Low levels of DMS are allowable, but are not required. Hop aroma medium low to none, and can be of any variety although floral, spicy, or herbal notes are most common. Overall, a subtle aroma with neither hops nor malt dominating. Low fruity esters are optional. Appearance: Pale straw to moderate gold color, although usually on the pale side. Low to medium head with medium to high carbonation. Fair head retention. Brilliant, sparkling clarity. Flavor: Low to medium-low hop bitterness. Low to moderate maltiness and sweetness, varying with gravity and attenuation. Usually well-attenuated. Neither malt nor hops dominate the palate. A low to moderate corny flavor is commonly found, as is light DMS (optional). Finish can vary from somewhat dry to faintly sweet. Low fruity esters are optional. Low to medium-low hop flavor (any variety, but typically floral, spicy, or herbal). Mouthfeel: Generally light and crisp, although body can reach medium. Smooth mouthfeel with medium to high attenuation; higher attenuation levels can lend a \"thirst quenching\" quality. High carbonation."
-                       :ibu-min         8}))
+                      {cbf/category        "Standard American Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.012
+                       cbf/og-min          1.042
+                       cbf/name            "Cream Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.042
+                       cbf/fg-min          1.006
+                       cbf/category-number "1"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         20
+                       cbf/ingredients     "American ingredients most commonly used. A grain bill of six-row malt, or a combination of six-row and North American two-row, is common. Adjuncts can include up to 20% maize in the mash, and up to 20% glucose or other sugars in the boil. Any variety of hops can be used for bittering and finishing."
+                       cbf/examples        "Genesee Cream Ale, Liebotschaner Cream Ale, Little Kings Cream Ale, New Glarus Spotted Cow, Old Style, Sleeman Cream Ale"
+                       cbf/notes           "A clean, well-attenuated, flavorful American \"lawnmower\" beer. Easily drinkable and refreshing, with more character than typical American lagers."
+                       cbf/og-max          1.055
+                       cbf/color-min       2.5
+                       cbf/abv-max         0.056
+                       cbf/color-max       5.0
+                       cbf/profile         "Aroma: Medium-low to low malt notes, with a sweet, corn-like aroma. Low levels of DMS are allowable, but are not required. Hop aroma medium low to none, and can be of any variety although floral, spicy, or herbal notes are most common. Overall, a subtle aroma with neither hops nor malt dominating. Low fruity esters are optional. Appearance: Pale straw to moderate gold color, although usually on the pale side. Low to medium head with medium to high carbonation. Fair head retention. Brilliant, sparkling clarity. Flavor: Low to medium-low hop bitterness. Low to moderate maltiness and sweetness, varying with gravity and attenuation. Usually well-attenuated. Neither malt nor hops dominate the palate. A low to moderate corny flavor is commonly found, as is light DMS (optional). Finish can vary from somewhat dry to faintly sweet. Low fruity esters are optional. Low to medium-low hop flavor (any variety, but typically floral, spicy, or herbal). Mouthfeel: Generally light and crisp, although body can reach medium. Smooth mouthfeel with medium to high attenuation; higher attenuation levels can lend a \"thirst quenching\" quality. High carbonation."
+                       cbf/ibu-min         8}))
 
 
 (def american-wheat-beer
@@ -92,27 +93,27 @@
    
    A clean fermentation character allows bready, doughy, or grainy wheat flavors to be complemented by hop flavor and bitterness rather than yeast qualities."
   (styles/build-style :american-wheat-beer
-                      {:category        "Standard American Beer"
-                       :carb-min        1.5
-                       :fg-max          1.013
-                       :og-min          1.04
-                       :name            "American Wheat Beer"
-                       :type            "Ale"
-                       :style-letter    "D"
-                       :abv-min         0.04
-                       :fg-min          1.008
-                       :category-number "1"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "Clean American ale or lager yeast (German weissbier yeast is inappropriate). Large proportion of wheat malt (often 30-50%, which is lower than is typical in German weissbiers). American, German, or New World hops are typical."
-                       :examples        "Bell's Oberon, Boulevard Unfiltered Wheat Beer, Goose Island 312 Urban Wheat Ale, Widmer Hefeweizen"
-                       :notes           "Refreshing wheat beers that can display more hop character and less yeast character than their German cousins. A clean fermentation character allows bready, doughy, or grainy wheat flavors to be complemented by hop flavor and bitterness rather than yeast qualities."
-                       :og-max          1.055
-                       :color-min       3.0
-                       :abv-max         0.055
-                       :color-max       6.0
-                       :profile         "Aroma: Low to moderate grainy, bready, or doughy wheat character. A light to moderate malty sweetness is acceptable. Esters can be moderate to none, although should reflect relatively neutral yeast strains; banana is inappropriate. Hop aroma may be low to moderate, and can have a citrusy, spicy, floral, or fruity character. No clove phenols. Appearance: Usually pale yellow to gold. Clarity may range from brilliant to hazy with yeast approximating the German weissbier style of beer. Big, long-lasting white head. Flavor: Light to moderately-strong bready, doughy, or grainy wheat flavor, which can linger into the finish. May have a moderate malty sweetness or finish quite dry. Low to moderate hop bitterness, which sometimes lasts into the finish. Balance is usually even, but may be slightly bitter. Low to moderate hop flavor (citrusy, spicy, floral, or fruity). Esters can be moderate to none, but should not include banana. No clove phenols. May have a slightly crisp finish. Mouthfeel: Medium-light to medium body. Medium-high to high carbonation. Slight creaminess is optional; wheat beers sometimes have a soft, 'fluffy' impression."
-                       :ibu-min         15}))
+                      {cbf/category        "Standard American Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.013
+                       cbf/og-min          1.04
+                       cbf/name            "American Wheat Beer"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "D"
+                       cbf/abv-min         0.04
+                       cbf/fg-min          1.008
+                       cbf/category-number "1"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "Clean American ale or lager yeast (German weissbier yeast is inappropriate). Large proportion of wheat malt (often 30-50%, which is lower than is typical in German weissbiers). American, German, or New World hops are typical."
+                       cbf/examples        "Bell's Oberon, Boulevard Unfiltered Wheat Beer, Goose Island 312 Urban Wheat Ale, Widmer Hefeweizen"
+                       cbf/notes           "Refreshing wheat beers that can display more hop character and less yeast character than their German cousins. A clean fermentation character allows bready, doughy, or grainy wheat flavors to be complemented by hop flavor and bitterness rather than yeast qualities."
+                       cbf/og-max          1.055
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.055
+                       cbf/color-max       6.0
+                       cbf/profile         "Aroma: Low to moderate grainy, bready, or doughy wheat character. A light to moderate malty sweetness is acceptable. Esters can be moderate to none, although should reflect relatively neutral yeast strains; banana is inappropriate. Hop aroma may be low to moderate, and can have a citrusy, spicy, floral, or fruity character. No clove phenols. Appearance: Usually pale yellow to gold. Clarity may range from brilliant to hazy with yeast approximating the German weissbier style of beer. Big, long-lasting white head. Flavor: Light to moderately-strong bready, doughy, or grainy wheat flavor, which can linger into the finish. May have a moderate malty sweetness or finish quite dry. Low to moderate hop bitterness, which sometimes lasts into the finish. Balance is usually even, but may be slightly bitter. Low to moderate hop flavor (citrusy, spicy, floral, or fruity). Esters can be moderate to none, but should not include banana. No clove phenols. May have a slightly crisp finish. Mouthfeel: Medium-light to medium body. Medium-high to high carbonation. Slight creaminess is optional; wheat beers sometimes have a soft, 'fluffy' impression."
+                       cbf/ibu-min         15}))
 
 
 (def standard-american-beer

--- a/src/common_beer_data/styles/bjcp_2015/strong_american_ale.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/strong_american_ale.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.strong-american-ale
   "2015 BJCP guidelines on Strong American Ales, and also an IPA."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def double-ipa
@@ -9,27 +10,27 @@
    Strongly hopped, but clean, dry, and lacking harshness. 
    Drinkability is an important characteristic; this should not be a heavy, sipping beer."
   (styles/build-style :double-ipa
-                      {:category        "Strong American Ale"
-                       :carb-min        1.5
-                       :fg-max          1.018
-                       :og-min          1.065
-                       :name            "Double IPA"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.075
-                       :fg-min          1.008
-                       :category-number "22"
-                       :carb-max        3.0
-                       :ibu-max         120
-                       :ingredients     "Clean 2-row malt is typical as a base grain; an excessively complex grist can be distracting. Crystal-type malts often muddy the hop flavors, and are generally considered undesirable in significant quantities. Sugar or other highly fermentable adjuncts are often used to increase attenuation, as are lower-temperature mash rests. Can use a complex variety of hops, typically American or New World, often with cutting-edge profiles providing distinctive differences. Modern hops with unusual characteristics are not out of style. American yeast that can give a clean or slightly fruity profile."
-                       :examples        "Avery Maharaja, Fat Heads Hop Juju, Firestone Walker Double Jack, Port Brewing Hop 15, Russian River Pliny the Elder, Stone Ruination IPA, Three Floyds Dreadnaught"
-                       :notes           "An intensely hoppy, fairly strong pale ale without the big, rich, complex maltiness and residual sweetness and body of an American barleywine. Strongly hopped, but clean, dry, and lacking harshness. Drinkability is an important characteristic; this should not be a heavy, sipping beer."
-                       :og-max          1.085
-                       :color-min       6.0
-                       :abv-max         0.1
-                       :color-max       14.0
-                       :profile         "Aroma: A prominent to intense hop aroma that typically showcases American or New World hop characteristics (citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, melon, etc.). Most versions are dry hopped and can have an additional resinous or grassy aroma, although this is not absolutely required. Some clean malty sweetness may be found in the background. Fruitiness, either from esters or hops, may also be detected in some versions, although a neutral fermentation character is typical. Some alcohol can usually be noted, but it should not have a \"hot\" character. Appearance: Color ranges from golden to light orange-copper; most modern versions are fairly pale. Good clarity, although unfiltered dry-hopped versions may be a bit hazy. Moderate-sized, persistent, white to off-white head. Flavor: Hop flavor is strong and complex, and can reflect the characteristics of modern American or New World hop varieties (citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, melon, etc.). High to absurdly high hop bitterness. Low to medium malt flavor, generally clean and grainy-malty although low levels of caramel or toasty flavors are acceptable. Low to medium fruitiness is acceptable but not required. A long, lingering bitterness is usually present in the aftertaste but should not be harsh. Dry to medium-dry finish; should not finish sweet or heavy. A light, clean, smooth alcohol flavor is not a fault. Oak is inappropriate in this style. May be slightly sulfury, but most examples do not exhibit this character. Mouthfeel: Medium-light to medium body, with a smooth texture. Medium to medium-high carbonation. No harsh hop-derived astringency. Restrained, smooth alcohol warming acceptable."
-                       :ibu-min         60}))
+                      {cbf/category        "Strong American Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.018
+                       cbf/og-min          1.065
+                       cbf/name            "Double IPA"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.075
+                       cbf/fg-min          1.008
+                       cbf/category-number "22"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         120
+                       cbf/ingredients     "Clean 2-row malt is typical as a base grain; an excessively complex grist can be distracting. Crystal-type malts often muddy the hop flavors, and are generally considered undesirable in significant quantities. Sugar or other highly fermentable adjuncts are often used to increase attenuation, as are lower-temperature mash rests. Can use a complex variety of hops, typically American or New World, often with cutting-edge profiles providing distinctive differences. Modern hops with unusual characteristics are not out of style. American yeast that can give a clean or slightly fruity profile."
+                       cbf/examples        "Avery Maharaja, Fat Heads Hop Juju, Firestone Walker Double Jack, Port Brewing Hop 15, Russian River Pliny the Elder, Stone Ruination IPA, Three Floyds Dreadnaught"
+                       cbf/notes           "An intensely hoppy, fairly strong pale ale without the big, rich, complex maltiness and residual sweetness and body of an American barleywine. Strongly hopped, but clean, dry, and lacking harshness. Drinkability is an important characteristic; this should not be a heavy, sipping beer."
+                       cbf/og-max          1.085
+                       cbf/color-min       6.0
+                       cbf/abv-max         0.1
+                       cbf/color-max       14.0
+                       cbf/profile         "Aroma: A prominent to intense hop aroma that typically showcases American or New World hop characteristics (citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, melon, etc.). Most versions are dry hopped and can have an additional resinous or grassy aroma, although this is not absolutely required. Some clean malty sweetness may be found in the background. Fruitiness, either from esters or hops, may also be detected in some versions, although a neutral fermentation character is typical. Some alcohol can usually be noted, but it should not have a \"hot\" character. Appearance: Color ranges from golden to light orange-copper; most modern versions are fairly pale. Good clarity, although unfiltered dry-hopped versions may be a bit hazy. Moderate-sized, persistent, white to off-white head. Flavor: Hop flavor is strong and complex, and can reflect the characteristics of modern American or New World hop varieties (citrus, floral, pine, resinous, spicy, tropical fruit, stone fruit, berry, melon, etc.). High to absurdly high hop bitterness. Low to medium malt flavor, generally clean and grainy-malty although low levels of caramel or toasty flavors are acceptable. Low to medium fruitiness is acceptable but not required. A long, lingering bitterness is usually present in the aftertaste but should not be harsh. Dry to medium-dry finish; should not finish sweet or heavy. A light, clean, smooth alcohol flavor is not a fault. Oak is inappropriate in this style. May be slightly sulfury, but most examples do not exhibit this character. Mouthfeel: Medium-light to medium body, with a smooth texture. Medium to medium-high carbonation. No harsh hop-derived astringency. Restrained, smooth alcohol warming acceptable."
+                       cbf/ibu-min         60}))
 
 
 (def american-strong-ale
@@ -37,27 +38,27 @@
    
    The flavors are bold but complementary, and are stronger and richer than average-strength pale and amber American ales."
   (styles/build-style :american-strong-ale
-                      {:category        "Strong American Ale"
-                       :carb-min        1.5
-                       :fg-max          1.024
-                       :og-min          1.062
-                       :name            "American Strong Ale"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.063
-                       :fg-min          1.014
-                       :category-number "22"
-                       :carb-max        3.0
-                       :ibu-max         100
-                       :ingredients     "Well-modified pale malt as a base; some character malts would be appropriate, medium to dark crystal malts are typical. Citrusy or piney American hops are common, although any American or New World varieties can be used in quantity, provided they do not clash with the malt character. Generally uses an attenuative American yeast."
-                       :examples        "Bear Republic Red Rocket Ale, Great Lakes Nosferatu, Terrapin Big Hoppy Monster, Port Brewing Shark Attack Double Red, Stone Arrogant Bastard,"
-                       :notes           "A strong, full-flavored American ale that challenges and rewards the palate with full malty and hoppy flavors and substantial bitterness. The flavors are bold but complementary, and are stronger and richer than average-strength pale and amber American ales."
-                       :og-max          1.09
-                       :color-min       7.0
-                       :abv-max         0.1
-                       :color-max       19.0
-                       :profile         "Aroma: Medium to high hop aroma, most often presenting citrusy or resiny notes although characteristics associated with other American or New World varieties may be found (tropical, stone fruit, melon, etc.). Moderate to bold maltiness supports hop profile, with medium to dark caramel a common presence, bready or toasty possible and background notes of light roast and/or chocolate noticeable in some examples. Generally exhibits clean to moderately fruity ester profile. Moderate alcohol aromatics may be noticeable, but should not be hot, harsh, or solventy. Appearance: Medium amber to deep copper or light brown. Moderate-low to medium-sized off-white to light tan head; may have low head retention. Good clarity. Alcohol level and viscosity may present \"legs\" when glass is swirled. Flavor: Medium to high dextrinous malt with a full range of caramel, toffee, dark fruit flavors. Low to medium toasty, bready, or Maillard-rich malty flavors are optional, and can add complexity. Medium-high to high hop bitterness. The malt gives a medium to high sweet impression on the palate, although the finish may be slightly sweet to somewhat dry. Moderate to high hop flavor. Low to moderate fruity esters. The hop flavors are similar to the aroma (citrusy, resiny, tropical, stone fruit, melon, etc.). Alcohol presence may be noticeable, but sharp or solventy alcohol flavors are undesirable. Roasted malt flavors are allowable but should be a background note; burnt malt flavors are inappropriate. While strongly malty on the palate, the finish should seem bitter to bittersweet. Should not be syrupy and under-attenuated. The aftertaste typically has malt, hops, and alcohol noticeable. Mouthfeel: Medium to full body. An alcohol warmth may be present, but not be excessively hot. Any astringency present should be attributable to bold hop bitterness and should not be objectionable on the palate. Medium-low to medium carbonation."
-                       :ibu-min         50}))
+                      {cbf/category        "Strong American Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.024
+                       cbf/og-min          1.062
+                       cbf/name            "American Strong Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.063
+                       cbf/fg-min          1.014
+                       cbf/category-number "22"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         100
+                       cbf/ingredients     "Well-modified pale malt as a base; some character malts would be appropriate, medium to dark crystal malts are typical. Citrusy or piney American hops are common, although any American or New World varieties can be used in quantity, provided they do not clash with the malt character. Generally uses an attenuative American yeast."
+                       cbf/examples        "Bear Republic Red Rocket Ale, Great Lakes Nosferatu, Terrapin Big Hoppy Monster, Port Brewing Shark Attack Double Red, Stone Arrogant Bastard,"
+                       cbf/notes           "A strong, full-flavored American ale that challenges and rewards the palate with full malty and hoppy flavors and substantial bitterness. The flavors are bold but complementary, and are stronger and richer than average-strength pale and amber American ales."
+                       cbf/og-max          1.09
+                       cbf/color-min       7.0
+                       cbf/abv-max         0.1
+                       cbf/color-max       19.0
+                       cbf/profile         "Aroma: Medium to high hop aroma, most often presenting citrusy or resiny notes although characteristics associated with other American or New World varieties may be found (tropical, stone fruit, melon, etc.). Moderate to bold maltiness supports hop profile, with medium to dark caramel a common presence, bready or toasty possible and background notes of light roast and/or chocolate noticeable in some examples. Generally exhibits clean to moderately fruity ester profile. Moderate alcohol aromatics may be noticeable, but should not be hot, harsh, or solventy. Appearance: Medium amber to deep copper or light brown. Moderate-low to medium-sized off-white to light tan head; may have low head retention. Good clarity. Alcohol level and viscosity may present \"legs\" when glass is swirled. Flavor: Medium to high dextrinous malt with a full range of caramel, toffee, dark fruit flavors. Low to medium toasty, bready, or Maillard-rich malty flavors are optional, and can add complexity. Medium-high to high hop bitterness. The malt gives a medium to high sweet impression on the palate, although the finish may be slightly sweet to somewhat dry. Moderate to high hop flavor. Low to moderate fruity esters. The hop flavors are similar to the aroma (citrusy, resiny, tropical, stone fruit, melon, etc.). Alcohol presence may be noticeable, but sharp or solventy alcohol flavors are undesirable. Roasted malt flavors are allowable but should be a background note; burnt malt flavors are inappropriate. While strongly malty on the palate, the finish should seem bitter to bittersweet. Should not be syrupy and under-attenuated. The aftertaste typically has malt, hops, and alcohol noticeable. Mouthfeel: Medium to full body. An alcohol warmth may be present, but not be excessively hot. Any astringency present should be attributable to bold hop bitterness and should not be objectionable on the palate. Medium-low to medium carbonation."
+                       cbf/ibu-min         50}))
 
 
 (def american-barleywine
@@ -66,27 +67,27 @@
    The hop character should be evident throughout, but does not have to be unbalanced. 
    The alcohol strength and hop bitterness often combine to leave a very long finish."
   (styles/build-style :american-barleywine
-                      {:category        "Strong American Ale"
-                       :carb-min        1.5
-                       :fg-max          1.03
-                       :og-min          1.08
-                       :name            "American Barleywine"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.08
-                       :fg-min          1.016
-                       :category-number "22"
-                       :carb-max        3.0
-                       :ibu-max         100
-                       :ingredients     "Well-modified pale malt should form the backbone of the grist. Some specialty or character malts may be used. Dark malts should be used with great restraint, if at all, as most of the color arises from a lengthy boil. New World hops are common, although any varieties can be used in quantity. Generally uses an attenuative American ale yeast."
-                       :examples        "Avery Hog Heaven Barleywine, Anchor Old Foghorn, Great Divide Old Ruffian, Rogue Old Crustacean, Sierra Nevada Bigfoot, Victory Old Horizontal"
-                       :notes           "A well-hopped American interpretation of the richest and strongest of the English ales. The hop character should be evident throughout, but does not have to be unbalanced. The alcohol strength and hop bitterness often combine to leave a very long finish."
-                       :og-max          1.12
-                       :color-min       10.0
-                       :abv-max         0.12
-                       :color-max       19.0
-                       :profile         "Aroma: Hop character moderate to assertive and often showcases citrusy, fruity, or resiny New World varieties (although other varieties, such as floral, earthy or spicy English varieties or a blend of varieties, may be used). Rich maltiness, with a character that may be sweet, caramelly, bready, or fairly neutral. Low to moderately-strong fruity esters and alcohol aromatics. However, the intensity of aromatics often subsides with age. Hops tend to be nearly equal to malt in the aroma, with alcohol and esters far behind. Appearance: Color may range from light amber to medium copper; may rarely be as dark as light brown. Often has ruby highlights. Moderately-low to large off-white to light tan head; may have low head retention. May be cloudy with chill haze at cooler temperatures, but generally clears to good to brilliant clarity as it warms. The color may appear to have great depth, as if viewed through a thick glass lens. High alcohol and viscosity may be visible in \"legs\" when beer is swirled in a glass. Flavor: Strong, rich malt flavor with a noticeable hop flavor and bitterness in the balance. Moderately-low to moderately-high malty sweetness on the palate, although the finish may be somewhat sweet to quite dry (depending on aging). Hop bitterness may range from moderately strong to aggressive. While strongly malty, the balance should always seem bitter. Moderate to high hop flavor (any variety, but often showing a range of New World hop characteristics). Low to moderate fruity esters. Noticeable alcohol presence, but well-integrated. Flavors will smooth out and decline over time, but any oxidized character should be muted (and generally be masked by the hop character). May have some bready or caramelly malt flavors, but these should not be high; roasted or burnt malt flavors are inappropriate. Mouthfeel: Full-bodied and chewy, with a velvety, luscious texture (although the body may decline with long conditioning). Alcohol warmth should be noticeable but smooth. Should not be syrupy and under-attenuated. Carbonation may be low to moderate, depending on age and conditioning."
-                       :ibu-min         50}))
+                      {cbf/category        "Strong American Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.03
+                       cbf/og-min          1.08
+                       cbf/name            "American Barleywine"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.08
+                       cbf/fg-min          1.016
+                       cbf/category-number "22"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         100
+                       cbf/ingredients     "Well-modified pale malt should form the backbone of the grist. Some specialty or character malts may be used. Dark malts should be used with great restraint, if at all, as most of the color arises from a lengthy boil. New World hops are common, although any varieties can be used in quantity. Generally uses an attenuative American ale yeast."
+                       cbf/examples        "Avery Hog Heaven Barleywine, Anchor Old Foghorn, Great Divide Old Ruffian, Rogue Old Crustacean, Sierra Nevada Bigfoot, Victory Old Horizontal"
+                       cbf/notes           "A well-hopped American interpretation of the richest and strongest of the English ales. The hop character should be evident throughout, but does not have to be unbalanced. The alcohol strength and hop bitterness often combine to leave a very long finish."
+                       cbf/og-max          1.12
+                       cbf/color-min       10.0
+                       cbf/abv-max         0.12
+                       cbf/color-max       19.0
+                       cbf/profile         "Aroma: Hop character moderate to assertive and often showcases citrusy, fruity, or resiny New World varieties (although other varieties, such as floral, earthy or spicy English varieties or a blend of varieties, may be used). Rich maltiness, with a character that may be sweet, caramelly, bready, or fairly neutral. Low to moderately-strong fruity esters and alcohol aromatics. However, the intensity of aromatics often subsides with age. Hops tend to be nearly equal to malt in the aroma, with alcohol and esters far behind. Appearance: Color may range from light amber to medium copper; may rarely be as dark as light brown. Often has ruby highlights. Moderately-low to large off-white to light tan head; may have low head retention. May be cloudy with chill haze at cooler temperatures, but generally clears to good to brilliant clarity as it warms. The color may appear to have great depth, as if viewed through a thick glass lens. High alcohol and viscosity may be visible in \"legs\" when beer is swirled in a glass. Flavor: Strong, rich malt flavor with a noticeable hop flavor and bitterness in the balance. Moderately-low to moderately-high malty sweetness on the palate, although the finish may be somewhat sweet to quite dry (depending on aging). Hop bitterness may range from moderately strong to aggressive. While strongly malty, the balance should always seem bitter. Moderate to high hop flavor (any variety, but often showing a range of New World hop characteristics). Low to moderate fruity esters. Noticeable alcohol presence, but well-integrated. Flavors will smooth out and decline over time, but any oxidized character should be muted (and generally be masked by the hop character). May have some bready or caramelly malt flavors, but these should not be high; roasted or burnt malt flavors are inappropriate. Mouthfeel: Full-bodied and chewy, with a velvety, luscious texture (although the body may decline with long conditioning). Alcohol warmth should be noticeable but smooth. Should not be syrupy and under-attenuated. Carbonation may be low to moderate, depending on age and conditioning."
+                       cbf/ibu-min         50}))
 
 
 (def wheatwine
@@ -94,27 +95,27 @@
    
    The emphasis is first on the bready, wheaty flavors with interesting complexity from malt, hops, fruity yeast character and alcohol complexity."
   (styles/build-style :wheatwine
-                      {:category        "Strong American Ale"
-                       :carb-min        1.5
-                       :fg-max          1.03
-                       :og-min          1.08
-                       :name            "Wheatwine"
-                       :type            "Ale"
-                       :style-letter    "D"
-                       :abv-min         0.08
-                       :fg-min          1.016
-                       :category-number "22"
-                       :carb-max        3.0
-                       :ibu-max         60
-                       :ingredients     "Typically brewed with a combination of American two-row and American wheat. Style commonly uses 50% or more wheat malt. Any variety of hops may be used. May be oak-aged."
-                       :examples        "Rubicon Winter Wheat Wine, Two Brothers Bare Trees Weiss Wine, Smuttynose Wheat Wine, Portsmouth Wheat Wine"
-                       :notes           "A richly textured, high alcohol sipping beer with a significant grainy, bready flavor and sleek body. The emphasis is first on the bready, wheaty flavors with interesting complexity from malt, hops, fruity yeast character and alcohol complexity."
-                       :og-max          1.12
-                       :color-min       8.0
-                       :abv-max         0.12
-                       :color-max       15.0
-                       :profile         "Aroma: Hop aroma is mild and can represent just about any late hop aromatic. Moderate to moderately-strong bready, wheaty malt character, often with additional malt complexity such as honey and caramel. A light, clean, alcohol aroma may noted. Low to medium fruity notes may be apparent. Very low levels of diacetyl are acceptable but not required. Weizen yeast character (banana/clove) is inappropriate. Appearance: Color ranges from gold to deep amber, often with garnet or ruby highlights. Low to medium off-white head. The head may have creamy texture, and good retention. Chill haze is allowable, but usually clears up as the beer gets warmer. High alcohol and viscosity may be visible in \"legs\" when beer is swirled in a glass. Flavor: Moderate to moderately-high wheaty malt flavor, dominant in the flavor balance over any hop character. Low to moderate bready, toasty, caramel, or honey malt notes are a welcome complexity note, although not required. Hop flavor is low to medium, and can reflect any variety. Moderate to moderately-high fruitiness, often with a dried-fruit character. Hop bitterness may range from low to moderate; balance therefore ranges from malty to evenly balanced. Should not be syrupy and under-attenuated. Some oxidative or vinous flavors may be present, as are light alcohol notes that are clean and smooth but complex. A complementary, supportive oak character is welcome, but not required. Mouthfeel: Medium-full to full bodied and chewy, often with a luscious, velvety texture. Low to moderate carbonation. Light to moderate smooth alcohol warming may also be present."
-                       :ibu-min         30}))
+                      {cbf/category        "Strong American Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.03
+                       cbf/og-min          1.08
+                       cbf/name            "Wheatwine"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "D"
+                       cbf/abv-min         0.08
+                       cbf/fg-min          1.016
+                       cbf/category-number "22"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         60
+                       cbf/ingredients     "Typically brewed with a combination of American two-row and American wheat. Style commonly uses 50% or more wheat malt. Any variety of hops may be used. May be oak-aged."
+                       cbf/examples        "Rubicon Winter Wheat Wine, Two Brothers Bare Trees Weiss Wine, Smuttynose Wheat Wine, Portsmouth Wheat Wine"
+                       cbf/notes           "A richly textured, high alcohol sipping beer with a significant grainy, bready flavor and sleek body. The emphasis is first on the bready, wheaty flavors with interesting complexity from malt, hops, fruity yeast character and alcohol complexity."
+                       cbf/og-max          1.12
+                       cbf/color-min       8.0
+                       cbf/abv-max         0.12
+                       cbf/color-max       15.0
+                       cbf/profile         "Aroma: Hop aroma is mild and can represent just about any late hop aromatic. Moderate to moderately-strong bready, wheaty malt character, often with additional malt complexity such as honey and caramel. A light, clean, alcohol aroma may noted. Low to medium fruity notes may be apparent. Very low levels of diacetyl are acceptable but not required. Weizen yeast character (banana/clove) is inappropriate. Appearance: Color ranges from gold to deep amber, often with garnet or ruby highlights. Low to medium off-white head. The head may have creamy texture, and good retention. Chill haze is allowable, but usually clears up as the beer gets warmer. High alcohol and viscosity may be visible in \"legs\" when beer is swirled in a glass. Flavor: Moderate to moderately-high wheaty malt flavor, dominant in the flavor balance over any hop character. Low to moderate bready, toasty, caramel, or honey malt notes are a welcome complexity note, although not required. Hop flavor is low to medium, and can reflect any variety. Moderate to moderately-high fruitiness, often with a dried-fruit character. Hop bitterness may range from low to moderate; balance therefore ranges from malty to evenly balanced. Should not be syrupy and under-attenuated. Some oxidative or vinous flavors may be present, as are light alcohol notes that are clean and smooth but complex. A complementary, supportive oak character is welcome, but not required. Mouthfeel: Medium-full to full bodied and chewy, often with a luscious, velvety texture. Low to moderate carbonation. Light to moderate smooth alcohol warming may also be present."
+                       cbf/ibu-min         30}))
 
 
 (def strong-american-ale

--- a/src/common_beer_data/styles/bjcp_2015/strong_belgian_ale.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/strong_belgian_ale.cljc
@@ -1,32 +1,33 @@
 (ns common-beer-data.styles.bjcp-2015.strong-belgian-ale
   "2015 BJCP guidelines on Strong Belgian Ales."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def belgian-blond-ale
   "A moderate-strength golden ale that has a subtle fruity-spicy Belgian yeast complexity, slightly malty-sweet flavor, and dry finish."
   (styles/build-style :belgian-blond-ale
-                      {:category        "Strong Belgian Ale"
-                       :carb-min        1.5
-                       :fg-max          1.018
-                       :og-min          1.062
-                       :name            "Belgian Blond Ale"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.06
-                       :fg-min          1.008
-                       :category-number "25"
-                       :carb-max        3.0
-                       :ibu-max         30
-                       :ingredients     "Belgian Pils malt, aromatic malts, sugar, Belgian yeast strains that produce complex alcohol, phenolics and perfumy esters, Saazer-type, Styrian Goldings, or East Kent Goldings hops. Spices are not traditionally used, although the ingredients and fermentation by-products may give an impression of spicing (often reminiscent of oranges or lemons). If spices are present, should be a background character only."
-                       :examples        "Affligem Blond, Grimbergen Blond, La Trappe Blond, Leffe Blond, Val-Dieu Blond"
-                       :notes           "A moderate-strength golden ale that has a subtle fruity-spicy Belgian yeast complexity, slightly malty-sweet flavor, and dry finish."
-                       :og-max          1.075
-                       :color-min       4.0
-                       :abv-max         0.075
-                       :color-max       7.0
-                       :profile         "Aroma: Light earthy or spicy hop nose, along with a lightly grainy-sweet malt character. Shows a subtle yeast character that may include spicy phenolics, perfumy or honey-like alcohol, or yeasty, fruity esters (commonly orange-like or lemony). Light sweetness that may have a slightly sugar-like character. Subtle yet complex. Appearance: Light to deep gold color. Generally very clear. Large, dense, and creamy white to off-white head. Good head retention with Belgian lace. Flavor: Smooth, light to moderate grainy-sweet malt flavor initially, but finishes medium-dry to dry with some smooth alcohol becoming evident in the aftertaste. Medium hop and alcohol bitterness to balance. Light hop flavor, can be spicy or earthy. Very soft yeast character (esters and alcohols, which are sometimes perfumy or orange/lemon-like). Light spicy phenolics optional. Some lightly caramelized sugar or honey-like sweetness on palate. Mouthfeel: Medium-high to high carbonation, can give mouth-filling bubbly sensation. Medium body. Light to moderate alcohol warmth, but smooth. Can be somewhat creamy."
-                       :ibu-min         15}))
+                      {cbf/category        "Strong Belgian Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.018
+                       cbf/og-min          1.062
+                       cbf/name            "Belgian Blond Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.06
+                       cbf/fg-min          1.008
+                       cbf/category-number "25"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         30
+                       cbf/ingredients     "Belgian Pils malt, aromatic malts, sugar, Belgian yeast strains that produce complex alcohol, phenolics and perfumy esters, Saazer-type, Styrian Goldings, or East Kent Goldings hops. Spices are not traditionally used, although the ingredients and fermentation by-products may give an impression of spicing (often reminiscent of oranges or lemons). If spices are present, should be a background character only."
+                       cbf/examples        "Affligem Blond, Grimbergen Blond, La Trappe Blond, Leffe Blond, Val-Dieu Blond"
+                       cbf/notes           "A moderate-strength golden ale that has a subtle fruity-spicy Belgian yeast complexity, slightly malty-sweet flavor, and dry finish."
+                       cbf/og-max          1.075
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.075
+                       cbf/color-max       7.0
+                       cbf/profile         "Aroma: Light earthy or spicy hop nose, along with a lightly grainy-sweet malt character. Shows a subtle yeast character that may include spicy phenolics, perfumy or honey-like alcohol, or yeasty, fruity esters (commonly orange-like or lemony). Light sweetness that may have a slightly sugar-like character. Subtle yet complex. Appearance: Light to deep gold color. Generally very clear. Large, dense, and creamy white to off-white head. Good head retention with Belgian lace. Flavor: Smooth, light to moderate grainy-sweet malt flavor initially, but finishes medium-dry to dry with some smooth alcohol becoming evident in the aftertaste. Medium hop and alcohol bitterness to balance. Light hop flavor, can be spicy or earthy. Very soft yeast character (esters and alcohols, which are sometimes perfumy or orange/lemon-like). Light spicy phenolics optional. Some lightly caramelized sugar or honey-like sweetness on palate. Mouthfeel: Medium-high to high carbonation, can give mouth-filling bubbly sensation. Medium body. Light to moderate alcohol warmth, but smooth. Can be somewhat creamy."
+                       cbf/ibu-min         15}))
 
 
 (def saison
@@ -35,53 +36,53 @@
    Typically highly carbonated, and using non-barley cereal grains and optional spices for complexity, as complements the expressive yeast character that is fruity, spicy, and not overly phenolic. 
    Less common variations include both lower-alcohol and higher-alcohol products, as well as darker versions with additional malt character."
   (styles/build-style :saison
-                      {:category        "Strong Belgian Ale"
-                       :carb-min        1.5
-                       :fg-max          1.008
-                       :og-min          1.048
-                       :name            "Saison"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.035
-                       :fg-min          1.002
-                       :category-number "25"
-                       :carb-max        3.0
-                       :ibu-max         35
-                       :ingredients     "Not typically spiced, with the yeast, hops and grain providing the character; but spices are allowed if they provide a complementary character. Continental base malts are typical, but the grist frequently contains other grains such as wheat, oats, rye, or spelt. Adjuncts such as sugar and honey can also serve to add complexity and dry out the beer. Darker versions will typically use richer, darker malts, but not typically roasted types. Saazer-type, Styrian or East Kent Golding hops are commonly used. A wide range of herbs or spices can add complexity and uniqueness, but should always meld well with the yeast and hop character. Brettanomyces is not typical for this style; Saisons with Brett should be entered in the American Wild Ale category."
-                       :examples        "Ellezelloise Saison, Fantôme Saison, Lefebvre Saison 1900, Saison Dupont Vieille Provision, Saison de Pipaix, Saison Regal, Saison Voisin,Boulevard Tank 7 Farmhouse Ale"
-                       :notes           "Most commonly, a pale, refreshing, highly-attenuated, moderately-bitter, moderate-strength Belgian ale with a very dry finish. Typically highly carbonated, and using non-barley cereal grains and optional spices for complexity, as complements the expressive yeast character that is fruity, spicy, and not overly phenolic. Less common variations include both lower-alcohol and higher-alcohol products, as well as darker versions with additional malt character."
-                       :og-max          1.065
-                       :color-min       5.0
-                       :abv-max         0.05
-                       :color-max       14.0
-                       :profile         "Aroma: Quite aromatic, with fruity, spicy, and hoppy characteristics evident. The esters can be fairly high (moderate to high), and are often reminiscent of citrus fruits such as oranges or lemons. The hops are low to moderate and are often spicy, floral, earthy, or fruity. Stronger versions can have a soft, spicy alcohol note (low intensity). Spicy notes are typically peppery rather than clove-like, and can be up to moderately-strong (typically yeast-derived). Subtle, complementary herb or spice additions are allowable, but should not dominate. The malt character is typically slightly grainy in character and low in intensity. Darker and stronger versions will have more noticeable malt, with darker versions taking characteristics associated with grains of that color (toasty, biscuity, caramelly, chocolate, etc.). In versions where sourness is present instead of bitterness, some of the sour character can be detected (low to moderate). Appearance: Pale versions are often a distinctive pale orange but may be pale golden to amber in color (gold to amber-gold is most common). Darker versions may run from copper to dark brown. Long-lasting, dense, rocky white to ivory head resulting in characteristic Belgian lace on the glass as it fades. Clarity is poor to good, though haze is not unexpected in this type of unfiltered beer. Effervescent. Flavor: Medium-low to medium-high fruity and spicy flavors, supported by a low to medium soft malt character, often with some grainy flavors. Bitterness is typically moderate to high, although sourness can be present in place of bitterness (both should not be strong flavors at the same time). Attenuation is extremely high, which gives a characteristic dry finish essential to the style; a Saison should never finish sweet. The fruity character is frequently citrusy (orange or lemon), and the spices are typically peppery. Allow for a range of balance in the fruity-spicy characteristics; this is often driven by the yeast selection. Hop flavor is low to moderate, and generally spicy or earthy in character. The balance is towards the fruity, spicy, hoppy character, with any bitterness or sourness not overwhelming these flavors. Darker versions will have more malt character, with a range of flavors derived from darker malts (toasty, bready, biscuity, chocolate, etc.) that support the fruity-spicy character of the beer (roasted flavors are not typical). Stronger versions will have more malt flavor in general, as well as a light alcohol impression. Herbs and spices are completely optional, but if present should be used in moderation and not detract from the yeast character. The finish is very dry and the aftertaste is typically bitter and spicy. The hop bitterness can be restrained, although it can seem accentuated due to the high attenuation levels. Mouthfeel: Light to medium body. Alcohol sensation varies with strength, from none in table version to light in standard versions, to moderate in super versions. However, any warming character should be fairly low. Very high carbonation with an effervescent quality. There is enough prickly acidity on the tongue to balance the very dry finish. In versions with sourness, a low to moderate tart character can add a refreshing bite, but not be puckering (optional)."
-                       :ibu-min         20}))
+                      {cbf/category        "Strong Belgian Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.008
+                       cbf/og-min          1.048
+                       cbf/name            "Saison"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.035
+                       cbf/fg-min          1.002
+                       cbf/category-number "25"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         35
+                       cbf/ingredients     "Not typically spiced, with the yeast, hops and grain providing the character; but spices are allowed if they provide a complementary character. Continental base malts are typical, but the grist frequently contains other grains such as wheat, oats, rye, or spelt. Adjuncts such as sugar and honey can also serve to add complexity and dry out the beer. Darker versions will typically use richer, darker malts, but not typically roasted types. Saazer-type, Styrian or East Kent Golding hops are commonly used. A wide range of herbs or spices can add complexity and uniqueness, but should always meld well with the yeast and hop character. Brettanomyces is not typical for this style; Saisons with Brett should be entered in the American Wild Ale category."
+                       cbf/examples        "Ellezelloise Saison, Fantôme Saison, Lefebvre Saison 1900, Saison Dupont Vieille Provision, Saison de Pipaix, Saison Regal, Saison Voisin,Boulevard Tank 7 Farmhouse Ale"
+                       cbf/notes           "Most commonly, a pale, refreshing, highly-attenuated, moderately-bitter, moderate-strength Belgian ale with a very dry finish. Typically highly carbonated, and using non-barley cereal grains and optional spices for complexity, as complements the expressive yeast character that is fruity, spicy, and not overly phenolic. Less common variations include both lower-alcohol and higher-alcohol products, as well as darker versions with additional malt character."
+                       cbf/og-max          1.065
+                       cbf/color-min       5.0
+                       cbf/abv-max         0.05
+                       cbf/color-max       14.0
+                       cbf/profile         "Aroma: Quite aromatic, with fruity, spicy, and hoppy characteristics evident. The esters can be fairly high (moderate to high), and are often reminiscent of citrus fruits such as oranges or lemons. The hops are low to moderate and are often spicy, floral, earthy, or fruity. Stronger versions can have a soft, spicy alcohol note (low intensity). Spicy notes are typically peppery rather than clove-like, and can be up to moderately-strong (typically yeast-derived). Subtle, complementary herb or spice additions are allowable, but should not dominate. The malt character is typically slightly grainy in character and low in intensity. Darker and stronger versions will have more noticeable malt, with darker versions taking characteristics associated with grains of that color (toasty, biscuity, caramelly, chocolate, etc.). In versions where sourness is present instead of bitterness, some of the sour character can be detected (low to moderate). Appearance: Pale versions are often a distinctive pale orange but may be pale golden to amber in color (gold to amber-gold is most common). Darker versions may run from copper to dark brown. Long-lasting, dense, rocky white to ivory head resulting in characteristic Belgian lace on the glass as it fades. Clarity is poor to good, though haze is not unexpected in this type of unfiltered beer. Effervescent. Flavor: Medium-low to medium-high fruity and spicy flavors, supported by a low to medium soft malt character, often with some grainy flavors. Bitterness is typically moderate to high, although sourness can be present in place of bitterness (both should not be strong flavors at the same time). Attenuation is extremely high, which gives a characteristic dry finish essential to the style; a Saison should never finish sweet. The fruity character is frequently citrusy (orange or lemon), and the spices are typically peppery. Allow for a range of balance in the fruity-spicy characteristics; this is often driven by the yeast selection. Hop flavor is low to moderate, and generally spicy or earthy in character. The balance is towards the fruity, spicy, hoppy character, with any bitterness or sourness not overwhelming these flavors. Darker versions will have more malt character, with a range of flavors derived from darker malts (toasty, bready, biscuity, chocolate, etc.) that support the fruity-spicy character of the beer (roasted flavors are not typical). Stronger versions will have more malt flavor in general, as well as a light alcohol impression. Herbs and spices are completely optional, but if present should be used in moderation and not detract from the yeast character. The finish is very dry and the aftertaste is typically bitter and spicy. The hop bitterness can be restrained, although it can seem accentuated due to the high attenuation levels. Mouthfeel: Light to medium body. Alcohol sensation varies with strength, from none in table version to light in standard versions, to moderate in super versions. However, any warming character should be fairly low. Very high carbonation with an effervescent quality. There is enough prickly acidity on the tongue to balance the very dry finish. In versions with sourness, a low to moderate tart character can add a refreshing bite, but not be puckering (optional)."
+                       cbf/ibu-min         20}))
 
 
 (def belgian-golden-strong-ale
   "A pale, complex, effervescent, strong Belgian-style ale that is highly attenuated and features fruity and hoppy notes in preference to phenolics."
   (styles/build-style :belgian-golden-strong-ale
-                      {:category        "Strong Belgian Ale"
-                       :carb-min        1.5
-                       :fg-max          1.016
-                       :og-min          1.07
-                       :name            "Belgian Golden Strong Ale"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.075
-                       :fg-min          1.005
-                       :category-number "25"
-                       :carb-max        3.0
-                       :ibu-max         35
-                       :ingredients     "Pilsner malt with substantial sugary adjuncts. Saazer-type hops or Styrian Goldings are commonly used. Belgian yeast strains are used - those that produce fruity esters, spicy phenolics and higher alcohols - often aided by slightly warmer fermentation temperatures. Fairly soft water. Spicing is not traditional; if present, should be a background character only."
-                       :examples        "Brigand, Delirium Tremens, Dulle Teve, Duvel, Judas, Lucifer, Piraat, Russian River Damnation"
-                       :notes           "A pale, complex, effervescent, strong Belgian-style ale that is highly attenuated and features fruity and hoppy notes in preference to phenolics."
-                       :og-max          1.095
-                       :color-min       3.0
-                       :abv-max         0.105
-                       :color-max       6.0
-                       :profile         "Aroma: Complex with significant fruity esters, moderate spiciness and low to moderate alcohol and hop aromas. Esters are reminiscent of lighter fruits such as pears, oranges or apples. Moderate to moderately low spicy, peppery phenols. A low to moderate yet distinctive perfumy, floral hop character is often present. Alcohols are soft, spicy, perfumy and low-to-moderate in intensity. No hot alcohol or solventy aromas. The malt character is light and slightly grainy-sweet to nearly neutral. Appearance: Yellow to medium gold in color. Good clarity. Effervescent. Massive, long-lasting, rocky, often beady, white head resulting in characteristic Belgian lace on the glass as it fades. Flavor: Marriage of fruity, spicy and alcohol flavors supported by a soft malt character. Esters are reminiscent of pears, oranges or apples. Low to moderately low phenols are peppery in character. A low to moderate spicy hop character is often present. Alcohols are soft and spicy, and are low-to-moderate in intensity. Bitterness is typically medium to high from a combination of hop bitterness and yeast-produced phenolics. Substantial carbonation and bitterness leads to a dry finish with a low to moderately bitter aftertaste. Mouthfeel: Very highly carbonated; effervescent. Light to medium body, although lighter than the substantial gravity would suggest. Smooth but noticeable alcohol warmth. No hot alcohol or solventy character."
-                       :ibu-min         22}))
+                      {cbf/category        "Strong Belgian Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.016
+                       cbf/og-min          1.07
+                       cbf/name            "Belgian Golden Strong Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.075
+                       cbf/fg-min          1.005
+                       cbf/category-number "25"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         35
+                       cbf/ingredients     "Pilsner malt with substantial sugary adjuncts. Saazer-type hops or Styrian Goldings are commonly used. Belgian yeast strains are used - those that produce fruity esters, spicy phenolics and higher alcohols - often aided by slightly warmer fermentation temperatures. Fairly soft water. Spicing is not traditional; if present, should be a background character only."
+                       cbf/examples        "Brigand, Delirium Tremens, Dulle Teve, Duvel, Judas, Lucifer, Piraat, Russian River Damnation"
+                       cbf/notes           "A pale, complex, effervescent, strong Belgian-style ale that is highly attenuated and features fruity and hoppy notes in preference to phenolics."
+                       cbf/og-max          1.095
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.105
+                       cbf/color-max       6.0
+                       cbf/profile         "Aroma: Complex with significant fruity esters, moderate spiciness and low to moderate alcohol and hop aromas. Esters are reminiscent of lighter fruits such as pears, oranges or apples. Moderate to moderately low spicy, peppery phenols. A low to moderate yet distinctive perfumy, floral hop character is often present. Alcohols are soft, spicy, perfumy and low-to-moderate in intensity. No hot alcohol or solventy aromas. The malt character is light and slightly grainy-sweet to nearly neutral. Appearance: Yellow to medium gold in color. Good clarity. Effervescent. Massive, long-lasting, rocky, often beady, white head resulting in characteristic Belgian lace on the glass as it fades. Flavor: Marriage of fruity, spicy and alcohol flavors supported by a soft malt character. Esters are reminiscent of pears, oranges or apples. Low to moderately low phenols are peppery in character. A low to moderate spicy hop character is often present. Alcohols are soft and spicy, and are low-to-moderate in intensity. Bitterness is typically medium to high from a combination of hop bitterness and yeast-produced phenolics. Substantial carbonation and bitterness leads to a dry finish with a low to moderately bitter aftertaste. Mouthfeel: Very highly carbonated; effervescent. Light to medium body, although lighter than the substantial gravity would suggest. Smooth but noticeable alcohol warmth. No hot alcohol or solventy character."
+                       cbf/ibu-min         22}))
 
 
 (def strong-belgian-ale

--- a/src/common_beer_data/styles/bjcp_2015/strong_british_ale.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/strong_british_ale.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.strong-british-ale
   "2015 BJCP guidelines on Strong British Ale."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def british-strong-ale
@@ -10,27 +11,27 @@
    Judges should allow for a significant range in character, as long as the beer is within the alcohol strength range and has an interesting 'British' character, it likely fits the style. 
    The malt and adjunct flavors and intensity can vary widely, but any combination should result in an agreeable palate experience."
   (styles/build-style :british-strong-ale
-                      {:category        "Strong British Ale"
-                       :carb-min        1.5
-                       :fg-max          1.022
-                       :og-min          1.055
-                       :name            "British Strong Ale"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.055
-                       :fg-min          1.015
-                       :category-number "17"
-                       :carb-max        3.0
-                       :ibu-max         60
-                       :ingredients     "Grists vary, often based on pale malt with caramel and specialty malts. Some darker examples suggest that dark malts (e.g., chocolate, black malt) may be appropriate, though sparingly so as to avoid an overly roasted character. Sugary adjuncts are common, as are starchy adjuncts (maize, flaked barley, wheat). Finishing hops are traditionally English."
-                       :examples        "Fuller's 1845, Harvey's Elizabethan Ale, J.W. Lees Manchester Star, Samuel Smith's Winter Welcome, Young's Winter Warmer"
-                       :notes           "An ale of respectable alcoholic strength, traditionally bottled-conditioned and cellared. Can have a wide range of interpretations, but most will have varying degrees of malty richness, late hops and bitterness, fruity esters, and alcohol warmth. Judges should allow for a significant range in character, as long as the beer is within the alcohol strength range and has an interesting 'British' character, it likely fits the style. The malt and adjunct flavors and intensity can vary widely, but any combination should result in an agreeable palate experience."
-                       :og-max          1.08
-                       :color-min       8.0
-                       :abv-max         0.08
-                       :color-max       22.0
-                       :profile         "Aroma: Malty-sweet with fruity esters, often with a complex blend of dried-fruit, caramel, nuts, toffee, and/or other specialty malt aromas. Some alcohol notes are acceptable, but shouldn't be hot or solventy. Hop aromas can vary widely, but typically have earthy, resiny, fruity, and/or floral notes. The balance can vary widely, but most examples will have a blend of malt, fruit, hops, and alcohol in varying intensities. Appearance: Deep gold to dark reddish-brown color (many are fairly dark). Generally clear, although darker versions may be almost opaque. Moderate to low cream- to light tan-colored head; average retention. Flavor: Medium to high malt character often rich with nutty, toffee, or caramel flavors. Light chocolate notes are sometimes found in darker beers. May have interesting flavor complexity from brewing sugars. Balance is often malty, but may be well hopped, which affects the impression of maltiness. Moderate fruity esters are common, often with a dark fruit or dried fruit character. The finish may vary from medium dry to somewhat sweet. Alcoholic strength should be evident, though not overwhelming. Diacetyl low to none, and is generally not desirable. Mouthfeel: Medium to full, chewy body. Alcohol warmth is often evident and always welcome. Low to moderate carbonation. Smooth texture."
-                       :ibu-min         30}))
+                      {cbf/category        "Strong British Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.022
+                       cbf/og-min          1.055
+                       cbf/name            "British Strong Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.055
+                       cbf/fg-min          1.015
+                       cbf/category-number "17"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         60
+                       cbf/ingredients     "Grists vary, often based on pale malt with caramel and specialty malts. Some darker examples suggest that dark malts (e.g., chocolate, black malt) may be appropriate, though sparingly so as to avoid an overly roasted character. Sugary adjuncts are common, as are starchy adjuncts (maize, flaked barley, wheat). Finishing hops are traditionally English."
+                       cbf/examples        "Fuller's 1845, Harvey's Elizabethan Ale, J.W. Lees Manchester Star, Samuel Smith's Winter Welcome, Young's Winter Warmer"
+                       cbf/notes           "An ale of respectable alcoholic strength, traditionally bottled-conditioned and cellared. Can have a wide range of interpretations, but most will have varying degrees of malty richness, late hops and bitterness, fruity esters, and alcohol warmth. Judges should allow for a significant range in character, as long as the beer is within the alcohol strength range and has an interesting 'British' character, it likely fits the style. The malt and adjunct flavors and intensity can vary widely, but any combination should result in an agreeable palate experience."
+                       cbf/og-max          1.08
+                       cbf/color-min       8.0
+                       cbf/abv-max         0.08
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Malty-sweet with fruity esters, often with a complex blend of dried-fruit, caramel, nuts, toffee, and/or other specialty malt aromas. Some alcohol notes are acceptable, but shouldn't be hot or solventy. Hop aromas can vary widely, but typically have earthy, resiny, fruity, and/or floral notes. The balance can vary widely, but most examples will have a blend of malt, fruit, hops, and alcohol in varying intensities. Appearance: Deep gold to dark reddish-brown color (many are fairly dark). Generally clear, although darker versions may be almost opaque. Moderate to low cream- to light tan-colored head; average retention. Flavor: Medium to high malt character often rich with nutty, toffee, or caramel flavors. Light chocolate notes are sometimes found in darker beers. May have interesting flavor complexity from brewing sugars. Balance is often malty, but may be well hopped, which affects the impression of maltiness. Moderate fruity esters are common, often with a dark fruit or dried fruit character. The finish may vary from medium dry to somewhat sweet. Alcoholic strength should be evident, though not overwhelming. Diacetyl low to none, and is generally not desirable. Mouthfeel: Medium to full, chewy body. Alcohol warmth is often evident and always welcome. Low to moderate carbonation. Smooth texture."
+                       cbf/ibu-min         30}))
 
 
 (def old-ale
@@ -39,27 +40,27 @@
    Often tilted towards a maltier balance. 
    \"It should be a warming beer of the type that is best drunk in half pints by a warm fire on a cold winter's night\" - Michael Jackson."
   (styles/build-style :old-ale
-                      {:category        "Strong British Ale"
-                       :carb-min        1.5
-                       :fg-max          1.022
-                       :og-min          1.055
-                       :name            "Old Ale"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.055
-                       :fg-min          1.015
-                       :category-number "17"
-                       :carb-max        3.0
-                       :ibu-max         60
-                       :ingredients     "Composition varies, although generally similar to British Strong Ales. The age character is the biggest driver of the final style profile, which is more handling than brewing. May be aged in wood, but should not have a strong wood character."
-                       :examples        "Burton Bridge Olde Expensive, Gale's Prize Old Ale, Greene King Strong Suffolk Ale, Marston Owd Roger, Theakston Old Peculier"
-                       :notes           "An ale of moderate to fairly significant alcoholic strength, bigger than standard beers, though usually not as strong or rich as barleywine. Often tilted towards a maltier balance. \"It should be a warming beer of the type that is best drunk in half pints by a warm fire on a cold winter's night\" - Michael Jackson."
-                       :og-max          1.088
-                       :color-min       10.0
-                       :abv-max         0.09
-                       :color-max       22.0
-                       :profile         "Aroma: Malty-sweet with fruity esters, often with a complex blend of dried-fruit, vinous, caramelly, molasses, nutty, toffee, light treacle, and/or other specialty malt aromas. Some alcohol and oxidative notes are acceptable, akin to those found in Sherry or Port. Hop aromas not usually present due to extended aging. Appearance: Light amber to very dark reddish-brown color (most are fairly dark). Age and oxidation may darken the beer further. May be almost opaque (if not, should be clear). Moderate to low cream- to light tan-colored head; may be adversely affected by alcohol and age. Flavor: Medium to high malt character with a luscious malt complexity, often with nutty, caramelly and/or molasses-like flavors. Light chocolate or roasted malt flavors are optional, but should never be prominent. Balance is often malty-sweet, but may be well hopped (the impression of bitterness often depends on amount of aging). Moderate to high fruity esters are common, and may take on a dried-fruit or vinous character. The finish may vary from dry to somewhat sweet. Extended aging may contribute oxidative flavors similar to a fine old Sherry, Port or Madeira. Alcoholic strength should be evident, though not overwhelming. Diacetyl low to none. Some wood-aged or blended versions may have a lactic or Brettanomyces character; but this is optional and should not be too strong. Any acidity or tannin from age should be well-integrated and contribute to complexity in the flavor profile, not be a dominant experience. Mouthfeel: Medium to full, chewy body, although older examples may be lower in body due to continued attenuation during conditioning. Alcohol warmth is often evident and always welcome. Low to moderate carbonation, depending on age and conditioning. Light acidity may be present, as well as some tannin if wood-aged; both are optional."
-                       :ibu-min         30}))
+                      {cbf/category        "Strong British Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.022
+                       cbf/og-min          1.055
+                       cbf/name            "Old Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.055
+                       cbf/fg-min          1.015
+                       cbf/category-number "17"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         60
+                       cbf/ingredients     "Composition varies, although generally similar to British Strong Ales. The age character is the biggest driver of the final style profile, which is more handling than brewing. May be aged in wood, but should not have a strong wood character."
+                       cbf/examples        "Burton Bridge Olde Expensive, Gale's Prize Old Ale, Greene King Strong Suffolk Ale, Marston Owd Roger, Theakston Old Peculier"
+                       cbf/notes           "An ale of moderate to fairly significant alcoholic strength, bigger than standard beers, though usually not as strong or rich as barleywine. Often tilted towards a maltier balance. \"It should be a warming beer of the type that is best drunk in half pints by a warm fire on a cold winter's night\" - Michael Jackson."
+                       cbf/og-max          1.088
+                       cbf/color-min       10.0
+                       cbf/abv-max         0.09
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Malty-sweet with fruity esters, often with a complex blend of dried-fruit, vinous, caramelly, molasses, nutty, toffee, light treacle, and/or other specialty malt aromas. Some alcohol and oxidative notes are acceptable, akin to those found in Sherry or Port. Hop aromas not usually present due to extended aging. Appearance: Light amber to very dark reddish-brown color (most are fairly dark). Age and oxidation may darken the beer further. May be almost opaque (if not, should be clear). Moderate to low cream- to light tan-colored head; may be adversely affected by alcohol and age. Flavor: Medium to high malt character with a luscious malt complexity, often with nutty, caramelly and/or molasses-like flavors. Light chocolate or roasted malt flavors are optional, but should never be prominent. Balance is often malty-sweet, but may be well hopped (the impression of bitterness often depends on amount of aging). Moderate to high fruity esters are common, and may take on a dried-fruit or vinous character. The finish may vary from dry to somewhat sweet. Extended aging may contribute oxidative flavors similar to a fine old Sherry, Port or Madeira. Alcoholic strength should be evident, though not overwhelming. Diacetyl low to none. Some wood-aged or blended versions may have a lactic or Brettanomyces character; but this is optional and should not be too strong. Any acidity or tannin from age should be well-integrated and contribute to complexity in the flavor profile, not be a dominant experience. Mouthfeel: Medium to full, chewy body, although older examples may be lower in body due to continued attenuation during conditioning. Alcohol warmth is often evident and always welcome. Low to moderate carbonation, depending on age and conditioning. Light acidity may be present, as well as some tannin if wood-aged; both are optional."
+                       cbf/ibu-min         30}))
 
 
 (def wee-heavy
@@ -67,27 +68,27 @@
    
    Complex secondary malt and alcohol flavors prevent a one-dimensional quality. Strength and maltiness can vary, but should not be cloying or syrupy."
   (styles/build-style :wee-heavy
-                      {:category        "Strong British Ale"
-                       :carb-min        1.5
-                       :fg-max          1.04
-                       :og-min          1.07
-                       :name            "Wee Heavy"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.065
-                       :fg-min          1.018
-                       :category-number "17"
-                       :carb-max        3.0
-                       :ibu-max         35
-                       :ingredients     "Well-modified pale malt, with roasted barley for color. May use some crystal malt for color adjustment. Slight smoke character may be present in some versions, but derives from roasted grains or from the boil. Peated malt is absolutely not traditional."
-                       :examples        "Belhaven Wee Heavy, Gordon Highland Scotch Ale, Inveralmond Blackfriar, McEwan's Scotch Ale, Orkney Skull Splitter, Traquair House Ale"
-                       :notes           "Rich, malty, dextrinous, and usually caramel-sweet, these beers can give an impression that is suggestive of a dessert. Complex secondary malt and alcohol flavors prevent a one-dimensional quality. Strength and maltiness can vary, but should not be cloying or syrupy."
-                       :og-max          1.13
-                       :color-min       14.0
-                       :abv-max         0.1
-                       :color-max       25.0
-                       :profile         "Aroma: Deeply malty, with a strong caramel component. Lightly smoky secondary aromas may also be present, adding complexity; peat smoke is inappropriate. Diacetyl should be low to none. Low to moderate esters and alcohol are often present in stronger versions. Hops are very low to none, and can be slightly earthy or floral. Appearance: Light copper to dark brown color, often with deep ruby highlights. Clear. Usually has a large tan head, which may not persist. Legs may be evident in stronger versions. Flavor: Richly malty with significant caramel (particularly in stronger versions). Hints of roasted malt may be present (sometimes perceived as a faint smoke character), as may some nutty character, all of which may last into the finish. Peat smoke is inappropriate. Hop flavors and bitterness are low to medium-low, so the malt presence should dominate the balance. Diacetyl should be low to none. Low to moderate esters and alcohol are usually present. Esters may suggest plums, raisins or dried fruit. The palate is usually full and sweet, but the finish may be sweet to medium-dry, sometimes with a light roasty-grainy note. Mouthfeel: Medium-full to full-bodied, with some versions (but not all) having a thick, chewy viscosity. A smooth, alcoholic warmth is usually present and is quite welcome since it balances the malty sweetness. Moderate carbonation."
-                       :ibu-min         17}))
+                      {cbf/category        "Strong British Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.04
+                       cbf/og-min          1.07
+                       cbf/name            "Wee Heavy"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.065
+                       cbf/fg-min          1.018
+                       cbf/category-number "17"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         35
+                       cbf/ingredients     "Well-modified pale malt, with roasted barley for color. May use some crystal malt for color adjustment. Slight smoke character may be present in some versions, but derives from roasted grains or from the boil. Peated malt is absolutely not traditional."
+                       cbf/examples        "Belhaven Wee Heavy, Gordon Highland Scotch Ale, Inveralmond Blackfriar, McEwan's Scotch Ale, Orkney Skull Splitter, Traquair House Ale"
+                       cbf/notes           "Rich, malty, dextrinous, and usually caramel-sweet, these beers can give an impression that is suggestive of a dessert. Complex secondary malt and alcohol flavors prevent a one-dimensional quality. Strength and maltiness can vary, but should not be cloying or syrupy."
+                       cbf/og-max          1.13
+                       cbf/color-min       14.0
+                       cbf/abv-max         0.1
+                       cbf/color-max       25.0
+                       cbf/profile         "Aroma: Deeply malty, with a strong caramel component. Lightly smoky secondary aromas may also be present, adding complexity; peat smoke is inappropriate. Diacetyl should be low to none. Low to moderate esters and alcohol are often present in stronger versions. Hops are very low to none, and can be slightly earthy or floral. Appearance: Light copper to dark brown color, often with deep ruby highlights. Clear. Usually has a large tan head, which may not persist. Legs may be evident in stronger versions. Flavor: Richly malty with significant caramel (particularly in stronger versions). Hints of roasted malt may be present (sometimes perceived as a faint smoke character), as may some nutty character, all of which may last into the finish. Peat smoke is inappropriate. Hop flavors and bitterness are low to medium-low, so the malt presence should dominate the balance. Diacetyl should be low to none. Low to moderate esters and alcohol are usually present. Esters may suggest plums, raisins or dried fruit. The palate is usually full and sweet, but the finish may be sweet to medium-dry, sometimes with a light roasty-grainy note. Mouthfeel: Medium-full to full-bodied, with some versions (but not all) having a thick, chewy viscosity. A smooth, alcoholic warmth is usually present and is quite welcome since it balances the malty sweetness. Moderate carbonation."
+                       cbf/ibu-min         17}))
 
 
 (def english-barleywine
@@ -97,27 +98,27 @@
    When aged, it can take on port-like flavors. 
    A wintertime sipper."
   (styles/build-style :english-barleywine
-                      {:category        "Strong British Ale"
-                       :carb-min        1.5
-                       :fg-max          1.03
-                       :og-min          1.08
-                       :name            "English Barleywine"
-                       :type            "Ale"
-                       :style-letter    "D"
-                       :abv-min         0.08
-                       :fg-min          1.018
-                       :category-number "17"
-                       :carb-max        3.0
-                       :ibu-max         70
-                       :ingredients     "High-quality, well-modified pale malt should form the backbone of the grist, with judicious amounts of caramel malts. Dark malts should be used with great restraint, if at all, as most of the color arises from a lengthy boil. English hops such as Northdown, Target, East Kent Goldings and Fuggles are typical. Characterful British yeast."
-                       :examples        "Adnams Tally-Ho, Burton Bridge Thomas Sykes Old Ale, Coniston No. 9 Barley Wine, Fuller's Golden Pride, J.W. Lee's Vintage Harvest Ale, Robinson's Old Tom"
-                       :notes           "A showcase of malty richness and complex, intense flavors. Chewy and rich in body, with warming alcohol and a pleasant fruity or hoppy interest. When aged, it can take on port-like flavors. A wintertime sipper."
-                       :og-max          1.12
-                       :color-min       8.0
-                       :abv-max         0.12
-                       :color-max       22.0
-                       :profile         "Aroma: Very rich and strongly malty, often with a caramel-like aroma in darker versions or a light toffee character in paler versions. May have moderate to strong fruitiness, often with a dark- or dried-fruit character, particularly in dark versions. The hop aroma may range from mild to assertive, and is typically floral, earthy, or marmalade-like. Alcohol aromatics may be low to moderate, but are soft and rounded. The intensity of these aromatics often subsides with age. The aroma may have a rich character including bready, toasty, toffee, and/or molasses notes. Aged versions may have a sherry-like quality, possibly vinous or port-like aromatics, and generally more muted malt aromas. Appearance: Color may range from rich gold to very dark amber or even dark brown (often has ruby highlights, but should not be opaque). Low to moderate off-white head; may have low head retention. May be cloudy with chill haze at cooler temperatures, but generally clears to good to brilliant clarity as it warms. The color may appear to have great depth, as if viewed through a thick glass lens. High alcohol and viscosity may be visible in \"legs\" when beer is swirled in a glass. Flavor: Strong, intense, complex, multi-layered malt flavors ranging from bready, toffee, and biscuity in paler versions through nutty, deep toast, dark caramel, and/or molasses in darker versions. Moderate to high malty sweetness on the palate, although the finish may be moderately sweet to moderately dry (depending on aging). Some oxidative or vinous flavors may be present, and often complex alcohol flavors should be evident. Moderate to fairly high fruitiness, often with a dark- or dried-fruit character. Hop bitterness may range from just enough for balance to a firm presence; balance therefore ranges from malty to somewhat bitter. Pale versions are often more bitter, better attenuated, and might show more hop character than darker versions; however, all versions are malty in the balance. Low to moderately high hop flavor, often floral, earthy, or marmalade-like English varieties. Mouthfeel: Full-bodied and chewy, with a velvety, luscious texture (although the body may decline with long conditioning). A smooth warmth from aged alcohol should be present. Carbonation may be low to moderate, depending on age and conditioning."
-                       :ibu-min         35}))
+                      {cbf/category        "Strong British Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.03
+                       cbf/og-min          1.08
+                       cbf/name            "English Barleywine"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "D"
+                       cbf/abv-min         0.08
+                       cbf/fg-min          1.018
+                       cbf/category-number "17"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         70
+                       cbf/ingredients     "High-quality, well-modified pale malt should form the backbone of the grist, with judicious amounts of caramel malts. Dark malts should be used with great restraint, if at all, as most of the color arises from a lengthy boil. English hops such as Northdown, Target, East Kent Goldings and Fuggles are typical. Characterful British yeast."
+                       cbf/examples        "Adnams Tally-Ho, Burton Bridge Thomas Sykes Old Ale, Coniston No. 9 Barley Wine, Fuller's Golden Pride, J.W. Lee's Vintage Harvest Ale, Robinson's Old Tom"
+                       cbf/notes           "A showcase of malty richness and complex, intense flavors. Chewy and rich in body, with warming alcohol and a pleasant fruity or hoppy interest. When aged, it can take on port-like flavors. A wintertime sipper."
+                       cbf/og-max          1.12
+                       cbf/color-min       8.0
+                       cbf/abv-max         0.12
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Very rich and strongly malty, often with a caramel-like aroma in darker versions or a light toffee character in paler versions. May have moderate to strong fruitiness, often with a dark- or dried-fruit character, particularly in dark versions. The hop aroma may range from mild to assertive, and is typically floral, earthy, or marmalade-like. Alcohol aromatics may be low to moderate, but are soft and rounded. The intensity of these aromatics often subsides with age. The aroma may have a rich character including bready, toasty, toffee, and/or molasses notes. Aged versions may have a sherry-like quality, possibly vinous or port-like aromatics, and generally more muted malt aromas. Appearance: Color may range from rich gold to very dark amber or even dark brown (often has ruby highlights, but should not be opaque). Low to moderate off-white head; may have low head retention. May be cloudy with chill haze at cooler temperatures, but generally clears to good to brilliant clarity as it warms. The color may appear to have great depth, as if viewed through a thick glass lens. High alcohol and viscosity may be visible in \"legs\" when beer is swirled in a glass. Flavor: Strong, intense, complex, multi-layered malt flavors ranging from bready, toffee, and biscuity in paler versions through nutty, deep toast, dark caramel, and/or molasses in darker versions. Moderate to high malty sweetness on the palate, although the finish may be moderately sweet to moderately dry (depending on aging). Some oxidative or vinous flavors may be present, and often complex alcohol flavors should be evident. Moderate to fairly high fruitiness, often with a dark- or dried-fruit character. Hop bitterness may range from just enough for balance to a firm presence; balance therefore ranges from malty to somewhat bitter. Pale versions are often more bitter, better attenuated, and might show more hop character than darker versions; however, all versions are malty in the balance. Low to moderately high hop flavor, often floral, earthy, or marmalade-like English varieties. Mouthfeel: Full-bodied and chewy, with a velvety, luscious texture (although the body may decline with long conditioning). A smooth warmth from aged alcohol should be present. Carbonation may be low to moderate, depending on age and conditioning."
+                       cbf/ibu-min         35}))
 
 
 (def strong-british-ale

--- a/src/common_beer_data/styles/bjcp_2015/strong_european_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/strong_european_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.strong-european-beer
   "2015 BJCP guidelines on Strong European Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def doppelbock
@@ -8,27 +9,27 @@
    
    The darker versions have more richly-developed, deeper malt flavors, while the paler versions have slightly more hops and dryness."
   (styles/build-style :doppelbock
-                      {:category        "Strong European Beer"
-                       :carb-min        1.5
-                       :fg-max          1.024
-                       :og-min          1.072
-                       :name            "Doppelbock"
-                       :type            "Lager"
-                       :style-letter    "A"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "9"
-                       :carb-max        3.0
-                       :ibu-max         26
-                       :ingredients     "Pils and/or Vienna malt for pale versions (with some Munich), Munich and Vienna malts for darker ones and occasionally a tiny bit of darker color malts (such as Carafa). Saazer-type hops. Clean lager yeast. Decoction mashing is traditional."
-                       :examples        "Dark Versions -Andechser Doppelbock Dunkel, Ayinger Celebrator, Paulaner Salvator, Spaten Optimator, Tröegs Troegenator, Weihenstephaner Korbinian,; Pale Versions - Eggenberg Urbock 23º, EKU 28, Plank Bavarian Heller Doppelbock"
-                       :notes           "A strong, rich, and very malty German lager that can have both pale and dark variants. The darker versions have more richly-developed, deeper malt flavors, while the paler versions have slightly more hops and dryness."
-                       :og-max          1.112
-                       :color-min       6.0
-                       :abv-max         0.1
-                       :color-max       25.0
-                       :profile         "Aroma: Very strong maltiness. Darker versions will have significant Maillard products and often some toasty aromas. A light caramel aroma is acceptable. Lighter versions will have a strong malt presence with some Maillard products and toasty notes. Virtually no hop aroma, although a light noble hop aroma is acceptable in pale versions. A moderately low malt-derived dark fruit character may be present (but is optional) in dark versions. A very slight chocolate-like aroma may be present in darker versions, but no roasted or burned aromatics should ever be present. Moderate alcohol aroma may be present. Appearance: Deep gold to dark brown in color. Darker versions often have ruby highlights. Lagering should provide good clarity. Large, creamy, persistent head (color varies with base style: white for pale versions, off-white for dark varieties). Stronger versions might have impaired head retention, and can display noticeable legs. Flavor: Very rich and malty. Darker versions will have significant Maillard products and often some toasty flavors. Lighter versions will have a strong malt flavor with some Maillard products and toasty notes. A very slight chocolate flavor is optional in darker versions, but should never be perceived as roasty or burnt. Clean lager character. A moderately low malt-derived dark fruit character is optional in darker versions. Invariably there will be an impression of alcoholic strength, but this should be smooth and warming rather than harsh or burning. Little to no hop flavor (more is acceptable in pale versions). Hop bitterness varies from moderate to moderately low but always allows malt to dominate the flavor. Most versions are fairly malty-sweet, but should have an impression of attenuation. The sweetness comes from low hopping, not from incomplete fermentation. Paler versions generally have a drier finish. Mouthfeel: Medium-full to full body. Moderate to moderately-low carbonation. Very smooth without harshness, astringency. A light alcohol warmth may be noted, but it should never burn."
-                       :ibu-min         16}))
+                      {cbf/category        "Strong European Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.024
+                       cbf/og-min          1.072
+                       cbf/name            "Doppelbock"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "9"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         26
+                       cbf/ingredients     "Pils and/or Vienna malt for pale versions (with some Munich), Munich and Vienna malts for darker ones and occasionally a tiny bit of darker color malts (such as Carafa). Saazer-type hops. Clean lager yeast. Decoction mashing is traditional."
+                       cbf/examples        "Dark Versions -Andechser Doppelbock Dunkel, Ayinger Celebrator, Paulaner Salvator, Spaten Optimator, Tröegs Troegenator, Weihenstephaner Korbinian,; Pale Versions - Eggenberg Urbock 23º, EKU 28, Plank Bavarian Heller Doppelbock"
+                       cbf/notes           "A strong, rich, and very malty German lager that can have both pale and dark variants. The darker versions have more richly-developed, deeper malt flavors, while the paler versions have slightly more hops and dryness."
+                       cbf/og-max          1.112
+                       cbf/color-min       6.0
+                       cbf/abv-max         0.1
+                       cbf/color-max       25.0
+                       cbf/profile         "Aroma: Very strong maltiness. Darker versions will have significant Maillard products and often some toasty aromas. A light caramel aroma is acceptable. Lighter versions will have a strong malt presence with some Maillard products and toasty notes. Virtually no hop aroma, although a light noble hop aroma is acceptable in pale versions. A moderately low malt-derived dark fruit character may be present (but is optional) in dark versions. A very slight chocolate-like aroma may be present in darker versions, but no roasted or burned aromatics should ever be present. Moderate alcohol aroma may be present. Appearance: Deep gold to dark brown in color. Darker versions often have ruby highlights. Lagering should provide good clarity. Large, creamy, persistent head (color varies with base style: white for pale versions, off-white for dark varieties). Stronger versions might have impaired head retention, and can display noticeable legs. Flavor: Very rich and malty. Darker versions will have significant Maillard products and often some toasty flavors. Lighter versions will have a strong malt flavor with some Maillard products and toasty notes. A very slight chocolate flavor is optional in darker versions, but should never be perceived as roasty or burnt. Clean lager character. A moderately low malt-derived dark fruit character is optional in darker versions. Invariably there will be an impression of alcoholic strength, but this should be smooth and warming rather than harsh or burning. Little to no hop flavor (more is acceptable in pale versions). Hop bitterness varies from moderate to moderately low but always allows malt to dominate the flavor. Most versions are fairly malty-sweet, but should have an impression of attenuation. The sweetness comes from low hopping, not from incomplete fermentation. Paler versions generally have a drier finish. Mouthfeel: Medium-full to full body. Moderate to moderately-low carbonation. Very smooth without harshness, astringency. A light alcohol warmth may be noted, but it should never burn."
+                       cbf/ibu-min         16}))
 
 
 (def eisbock
@@ -36,27 +37,27 @@
    
    Even though flavors are concentrated, the alcohol should be smooth and warming, not burning."
   (styles/build-style :eisbock
-                      {:category        "Strong European Beer"
-                       :carb-min        1.5
-                       :fg-max          1.035
-                       :og-min          1.078
-                       :name            "Eisbock"
-                       :type            "Lager"
-                       :style-letter    "B"
-                       :abv-min         0.09
-                       :fg-min          1.02
-                       :category-number "9"
-                       :carb-max        3.0
-                       :ibu-max         35
-                       :ingredients     "Same as doppelbock. Commercial eisbocks are generally concentrated anywhere from 7% to 33% (by volume)."
-                       :examples        "Kulmbacher Eisbock"
-                       :notes           "A strong, full-bodied, rich, and malty dark German lager often with a viscous quality and strong flavors. Even though flavors are concentrated, the alcohol should be smooth and warming, not burning."
-                       :og-max          1.12
-                       :color-min       18.0
-                       :abv-max         0.14
-                       :color-max       30.0
-                       :profile         "Aroma: Dominated by a balance of rich, intense malt and a definite alcohol presence. No hop aroma. May have significant malt-derived dark fruit esters. Alcohol aromas should not be harsh or solventy. Appearance: Deep copper to dark brown in color, often with attractive ruby highlights. Lagering should provide good clarity. Head retention may be moderate to poor. Off-white to deep ivory colored head. Pronounced legs are often evident. Flavor: Rich, sweet malt balanced by a significant alcohol presence. The malt can have Maillard products, toasty qualities, some caramel, and occasionally a slight chocolate flavor. No hop flavor. Hop bitterness just offsets the malt sweetness enough to avoid a cloying character. May have significant malt-derived dark fruit esters. The alcohol should be smooth, not harsh or hot, and should help the hop bitterness balance the strong malt presence. The finish should be of malt and alcohol, and can have a certain dryness from the alcohol. It should not be sticky, syrupy or cloyingly sweet. Clean lager character. Mouthfeel: Full to very full-bodied. Low carbonation. Significant alcohol warmth without sharp hotness. Very smooth without harsh edges from alcohol, bitterness, fusels, or other concentrated flavors."
-                       :ibu-min         25}))
+                      {cbf/category        "Strong European Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.035
+                       cbf/og-min          1.078
+                       cbf/name            "Eisbock"
+                       cbf/type            "Lager"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.09
+                       cbf/fg-min          1.02
+                       cbf/category-number "9"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         35
+                       cbf/ingredients     "Same as doppelbock. Commercial eisbocks are generally concentrated anywhere from 7% to 33% (by volume)."
+                       cbf/examples        "Kulmbacher Eisbock"
+                       cbf/notes           "A strong, full-bodied, rich, and malty dark German lager often with a viscous quality and strong flavors. Even though flavors are concentrated, the alcohol should be smooth and warming, not burning."
+                       cbf/og-max          1.12
+                       cbf/color-min       18.0
+                       cbf/abv-max         0.14
+                       cbf/color-max       30.0
+                       cbf/profile         "Aroma: Dominated by a balance of rich, intense malt and a definite alcohol presence. No hop aroma. May have significant malt-derived dark fruit esters. Alcohol aromas should not be harsh or solventy. Appearance: Deep copper to dark brown in color, often with attractive ruby highlights. Lagering should provide good clarity. Head retention may be moderate to poor. Off-white to deep ivory colored head. Pronounced legs are often evident. Flavor: Rich, sweet malt balanced by a significant alcohol presence. The malt can have Maillard products, toasty qualities, some caramel, and occasionally a slight chocolate flavor. No hop flavor. Hop bitterness just offsets the malt sweetness enough to avoid a cloying character. May have significant malt-derived dark fruit esters. The alcohol should be smooth, not harsh or hot, and should help the hop bitterness balance the strong malt presence. The finish should be of malt and alcohol, and can have a certain dryness from the alcohol. It should not be sticky, syrupy or cloyingly sweet. Clean lager character. Mouthfeel: Full to very full-bodied. Low carbonation. Significant alcohol warmth without sharp hotness. Very smooth without harsh edges from alcohol, bitterness, fusels, or other concentrated flavors."
+                       cbf/ibu-min         25}))
 
 
 (def baltic-porter
@@ -64,27 +65,27 @@
    
    Very complex, with multi-layered malt and dark fruit flavors."
   (styles/build-style :baltic-porter
-                      {:category        "Strong European Beer"
-                       :carb-min        1.5
-                       :fg-max          1.024
-                       :og-min          1.06
-                       :name            "Baltic Porter"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.065
-                       :fg-min          1.016
-                       :category-number "9"
-                       :carb-max        3.0
-                       :ibu-max         40
-                       :ingredients     "Generally lager yeast (cold fermented if using ale yeast, as is required when brewed in Russia). Debittered chocolate or black malt. Munich or Vienna base malt. Continental hops (Saazer-type, typically). May contain crystal malts and/or adjuncts. Brown or amber malt common in historical recipes."
-                       :examples        "Aldaris Porteris, Baltika #6 Porter, Devils Backbone Danzig, Okocim Porter, Sinebrychoff Porter, Zywiec Porter"
-                       :notes           "A Baltic Porter often has the malt flavors reminiscent of an English porter and the restrained roast of a schwarzbier, but with a higher OG and alcohol content than either. Very complex, with multi-layered malt and dark fruit flavors."
-                       :og-max          1.09
-                       :color-min       17.0
-                       :abv-max         0.095
-                       :color-max       30.0
-                       :profile         "Aroma: Rich malty sweetness often containing caramel, toffee, nutty to deep toast, and/or licorice notes. Complex alcohol and ester profile of moderate strength, and reminiscent of plums, prunes, raisins, cherries or currants, occasionally with a vinous Port-like quality. Some darker malt character that is deep chocolate, coffee or molasses but never burnt. No hops. No sourness. Very smooth. Appearance: Dark reddish-copper to opaque dark brown (not black). Thick, persistent tan-colored head. Clear, although darker versions can be opaque. Flavor: As with aroma, has a rich malty sweetness with a complex blend of deep malt, dried fruit esters, and alcohol. Has a prominent yet smooth schwarzbier-like roasted flavor that stops short of burnt. Mouth-filling and very smooth. Clean lager character. Starts sweet but darker malt flavors quickly dominates and persists through finish. Just a touch dry with a hint of roast coffee or licorice in the finish. Malt can have a caramel, toffee, nutty, molasses and/or licorice complexity. Light hints of black currant and dark fruits. Medium-low to medium bitterness from malt and hops, just to provide balance. Hop flavor from slightly spicy hops ranges from none to medium-low. Mouthfeel: Generally quite full-bodied and smooth, with a well-aged alcohol warmth. Medium to medium-high carbonation, making it seem even more mouth-filling. Not heavy on the tongue due to carbonation level."
-                       :ibu-min         20}))
+                      {cbf/category        "Strong European Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.024
+                       cbf/og-min          1.06
+                       cbf/name            "Baltic Porter"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.065
+                       cbf/fg-min          1.016
+                       cbf/category-number "9"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         40
+                       cbf/ingredients     "Generally lager yeast (cold fermented if using ale yeast, as is required when brewed in Russia). Debittered chocolate or black malt. Munich or Vienna base malt. Continental hops (Saazer-type, typically). May contain crystal malts and/or adjuncts. Brown or amber malt common in historical recipes."
+                       cbf/examples        "Aldaris Porteris, Baltika #6 Porter, Devils Backbone Danzig, Okocim Porter, Sinebrychoff Porter, Zywiec Porter"
+                       cbf/notes           "A Baltic Porter often has the malt flavors reminiscent of an English porter and the restrained roast of a schwarzbier, but with a higher OG and alcohol content than either. Very complex, with multi-layered malt and dark fruit flavors."
+                       cbf/og-max          1.09
+                       cbf/color-min       17.0
+                       cbf/abv-max         0.095
+                       cbf/color-max       30.0
+                       cbf/profile         "Aroma: Rich malty sweetness often containing caramel, toffee, nutty to deep toast, and/or licorice notes. Complex alcohol and ester profile of moderate strength, and reminiscent of plums, prunes, raisins, cherries or currants, occasionally with a vinous Port-like quality. Some darker malt character that is deep chocolate, coffee or molasses but never burnt. No hops. No sourness. Very smooth. Appearance: Dark reddish-copper to opaque dark brown (not black). Thick, persistent tan-colored head. Clear, although darker versions can be opaque. Flavor: As with aroma, has a rich malty sweetness with a complex blend of deep malt, dried fruit esters, and alcohol. Has a prominent yet smooth schwarzbier-like roasted flavor that stops short of burnt. Mouth-filling and very smooth. Clean lager character. Starts sweet but darker malt flavors quickly dominates and persists through finish. Just a touch dry with a hint of roast coffee or licorice in the finish. Malt can have a caramel, toffee, nutty, molasses and/or licorice complexity. Light hints of black currant and dark fruits. Medium-low to medium bitterness from malt and hops, just to provide balance. Hop flavor from slightly spicy hops ranges from none to medium-low. Mouthfeel: Generally quite full-bodied and smooth, with a well-aged alcohol warmth. Medium to medium-high carbonation, making it seem even more mouth-filling. Not heavy on the tongue due to carbonation level."
+                       cbf/ibu-min         20}))
 
 
 (def strong-european-beer

--- a/src/common_beer_data/styles/bjcp_2015/styles.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/styles.cljc
@@ -1,39 +1,41 @@
 (ns ^:no-doc common-beer-data.styles.bjcp-2015.styles
-  "Function to help minimize repeated data in 2015 BJCP style guidelines")
+  "Function to help minimize repeated data in 2015 BJCP style guidelines"
+  {:added "1.0"}
+  (:require [common-beer-format.styles :as cbf]))
 
 
 (def ^:private style-defaults
-  {:version     1
-   :style-guide "BJCP 2015"})
+  {cbf/version     1
+   cbf/style-guide "BJCP 2015"})
 
 
 (defn build-style
   "Construct a style, including display/range values derived from core style data"
   [style-key style-data]
-  (let [carb-range        (str (:carb-min style-data) "-" (:carb-max style-data) " Vols")
-        og-range          (str (:og-min style-data) "-" (:og-max style-data) " SG")
-        fg-range          (str (:fg-min style-data) "-" (:fg-max style-data) " SG")
-        abv-range         (str (:abv-min style-data) "% - " (:abv-max style-data) "%")
-        ibu-range         (str (:ibu-min style-data) "-" (:ibu-max style-data) " IBUs")
-        color-range       (str (:color-min style-data) "-" (:color-max style-data) " SRM")
-        display-color-min (str (:color-min style-data) " SRM")
-        display-color-max (str (:color-max style-data) " SRM")
-        display-og-min    (str (:og-min style-data) " SG")
-        display-og-max    (str (:og-max style-data) " SG")
-        display-fg-min    (str (:fg-min style-data) " SG")
-        display-fg-max    (str (:fg-max style-data) " SG")
+  (let [carb-range        (str (cbf/carb-min style-data) "-" (cbf/carb-max style-data) " Vols")
+        og-range          (str (cbf/og-min style-data) "-" (cbf/og-max style-data) " SG")
+        fg-range          (str (cbf/fg-min style-data) "-" (cbf/fg-max style-data) " SG")
+        abv-range         (str (cbf/abv-min style-data) "% - " (cbf/abv-max style-data) "%")
+        ibu-range         (str (cbf/ibu-min style-data) "-" (cbf/ibu-max style-data) " IBUs")
+        color-range       (str (cbf/color-min style-data) "-" (cbf/color-max style-data) " SRM")
+        display-color-min (str (cbf/color-min style-data) " SRM")
+        display-color-max (str (cbf/color-max style-data) " SRM")
+        display-og-min    (str (cbf/og-min style-data) " SG")
+        display-og-max    (str (cbf/og-max style-data) " SG")
+        display-fg-min    (str (cbf/fg-min style-data) " SG")
+        display-fg-max    (str (cbf/fg-max style-data) " SG")
         base-style        (merge style-defaults style-data)
         style-def         (assoc base-style
-                                 :carb-range        carb-range
-                                 :og-range          og-range
-                                 :fg-range          fg-range
-                                 :abv-range         abv-range
-                                 :ibu-range         ibu-range
-                                 :color-range       color-range
-                                 :display-color-min display-color-min
-                                 :display-color-max display-color-max
-                                 :display-og-min    display-og-min
-                                 :display-og-max    display-og-max
-                                 :display-fg-min    display-fg-min
-                                 :display-fg-max    display-fg-max)]
+                                 cbf/carb-range        carb-range
+                                 cbf/og-range          og-range
+                                 cbf/fg-range          fg-range
+                                 cbf/abv-range         abv-range
+                                 cbf/ibu-range         ibu-range
+                                 cbf/color-range       color-range
+                                 cbf/display-color-min display-color-min
+                                 cbf/display-color-max display-color-max
+                                 cbf/display-og-min    display-og-min
+                                 cbf/display-og-max    display-og-max
+                                 cbf/display-fg-min    display-fg-min
+                                 cbf/display-fg-max    display-fg-max)]
     {style-key style-def}))

--- a/src/common_beer_data/styles/bjcp_2015/trappist_ale.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/trappist_ale.cljc
@@ -1,58 +1,59 @@
 (ns common-beer-data.styles.bjcp-2015.trappist-ale
   "2015 BJCP guidelines on Trappists."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def trappist-single
   "A pale, bitter, highly attenuated and well carbonated Trappist ale, showing a fruity-spicy Trappist yeast character, a spicy-floral hop profile, and a soft, supportive grainy-sweet malt palate."
   (styles/build-style :trappist-single
-                      {:category        "Trappist Ale"
-                       :carb-min        1.5
-                       :fg-max          1.01
-                       :og-min          1.044
-                       :name            "Trappist Single"
-                       :type            "Ale"
-                       :style-letter    "A"
-                       :abv-min         0.048
-                       :fg-min          1.004
-                       :category-number "26"
-                       :carb-max        3.0
-                       :ibu-max         45
-                       :ingredients     "Pilsner malt, Belgian Trappist yeast, Saazer-type hops."
-                       :examples        "Achel 5° Blond, St. Bernardus Extra 4, Westmalle Extra, Westvleteren Blond"
-                       :notes           "A pale, bitter, highly attenuated and well carbonated Trappist ale, showing a fruity-spicy Trappist yeast character, a spicy-floral hop profile, and a soft, supportive grainy-sweet malt palate."
-                       :og-max          1.054
-                       :color-min       3.0
-                       :abv-max         0.06
-                       :color-max       5.0
-                       :profile         "Aroma: Medium-low to medium-high Trappist yeast character, showing a fruity-spicy character along with medium-low to medium spicy or floral hops, occasionally enhanced by light herbal/citrusy spice additions. Low to medium-low grainy-sweet malt backdrop, which may have a light honey or sugar quality. Fruit expression can vary widely (citrus, pome fruit, stone fruit). Light spicy, yeast-driven phenolics found in the best examples. Bubblegum inappropriate. Appearance: Pale yellow to medium gold color. Generally good clarity, with a moderate-sized, persistent, billowy white head with characteristic lacing. Flavor: Fruity, hoppy, bitter, and dry. Initial malty-sweet impression, with a grainy-sweet soft malt palate, and a dry, hoppy finish. The malt may have a light honeyed biscuit or cracker impression. Moderate spicy or floral hop flavor. Esters can be citrus (orange, lemon, grapefruit), pome fruit (apple, pear), or stone fruit (apricot, peach). Light to moderate spicy, peppery, or clove phenolics. Bitterness rises towards the crisp, dry finish, with an aftertaste of light malt, moderate hops and yeast character. Mouthfeel: Medium-light to medium body. Smooth. Medium-high to high carbonation, can be somewhat prickly. Should not have noticeable alcohol warmth."
-                       :ibu-min         25}))
+                      {cbf/category        "Trappist Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.01
+                       cbf/og-min          1.044
+                       cbf/name            "Trappist Single"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.048
+                       cbf/fg-min          1.004
+                       cbf/category-number "26"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         45
+                       cbf/ingredients     "Pilsner malt, Belgian Trappist yeast, Saazer-type hops."
+                       cbf/examples        "Achel 5° Blond, St. Bernardus Extra 4, Westmalle Extra, Westvleteren Blond"
+                       cbf/notes           "A pale, bitter, highly attenuated and well carbonated Trappist ale, showing a fruity-spicy Trappist yeast character, a spicy-floral hop profile, and a soft, supportive grainy-sweet malt palate."
+                       cbf/og-max          1.054
+                       cbf/color-min       3.0
+                       cbf/abv-max         0.06
+                       cbf/color-max       5.0
+                       cbf/profile         "Aroma: Medium-low to medium-high Trappist yeast character, showing a fruity-spicy character along with medium-low to medium spicy or floral hops, occasionally enhanced by light herbal/citrusy spice additions. Low to medium-low grainy-sweet malt backdrop, which may have a light honey or sugar quality. Fruit expression can vary widely (citrus, pome fruit, stone fruit). Light spicy, yeast-driven phenolics found in the best examples. Bubblegum inappropriate. Appearance: Pale yellow to medium gold color. Generally good clarity, with a moderate-sized, persistent, billowy white head with characteristic lacing. Flavor: Fruity, hoppy, bitter, and dry. Initial malty-sweet impression, with a grainy-sweet soft malt palate, and a dry, hoppy finish. The malt may have a light honeyed biscuit or cracker impression. Moderate spicy or floral hop flavor. Esters can be citrus (orange, lemon, grapefruit), pome fruit (apple, pear), or stone fruit (apricot, peach). Light to moderate spicy, peppery, or clove phenolics. Bitterness rises towards the crisp, dry finish, with an aftertaste of light malt, moderate hops and yeast character. Mouthfeel: Medium-light to medium body. Smooth. Medium-high to high carbonation, can be somewhat prickly. Should not have noticeable alcohol warmth."
+                       cbf/ibu-min         25}))
 
 
 (def belgian-dubbel
   "A deep reddish-copper, moderately strong, malty, complex Trappist ale with rich malty flavors, dark or dried fruit esters, and light alcohol blended together in a malty presentation that still finishes fairly dry."
   (styles/build-style :belgian-dubbel
-                      {:category        "Trappist Ale"
-                       :carb-min        1.5
-                       :fg-max          1.018
-                       :og-min          1.062
-                       :name            "Belgian Dubbel"
-                       :type            "Ale"
-                       :style-letter    "B"
-                       :abv-min         0.06
-                       :fg-min          1.008
-                       :category-number "26"
-                       :carb-max        3.0
-                       :ibu-max         25
-                       :ingredients     "Belgian yeast strains prone to production of higher alcohols, esters, and phenolics are commonly used. Impression of complex grain bill, although traditional versions are typically Belgian Pils malt with caramelized sugar syrup or other unrefined sugars providing much of the character. Saazer-type, English-type or Styrian Goldings hops commonly used. No spices are traditionally used, although restrained use is allowable (background strength only)."
-                       :examples        "Affligem Dubbel, Chimay Première, Corsendonk Pater, Grimbergen Double, La Trappe Dubbel, St. Bernardus Pater 6, Trappistes Rochefort 6, Westmalle Dubbel"
-                       :notes           "A deep reddish-copper, moderately strong, malty, complex Trappist ale with rich malty flavors, dark or dried fruit esters, and light alcohol blended together in a malty presentation that still finishes fairly dry."
-                       :og-max          1.075
-                       :color-min       10.0
-                       :abv-max         0.076
-                       :color-max       17.0
-                       :profile         "Aroma: Complex, rich-sweet malty aroma, possibly with hints of chocolate, caramel and/or toast (but never roasted or burnt aromas). Moderate fruity esters (usually including raisins and plums, sometimes also dried cherries). Esters sometimes include banana or apple. Spicy phenols and higher alcohols are common (may include light clove and spice, peppery, rose-like and/or perfumy notes). Spicy qualities can be moderate to very low. Alcohol, if present, is soft and never hot or solventy. Low to no spicy, herbal, or floral hop aroma, typically absent. The malt is most prominent in the balance with esters and a touch of alcohol in support, blending together for a harmonious presentation. Appearance: Dark amber to copper in color, with an attractive reddish depth of color. Generally clear. Large, dense, and long-lasting creamy off-white head. Flavor: Similar qualities as aroma. Rich, complex medium to medium-full rich-sweet malt flavor on the palate yet finishes moderately dry. Complex malt, ester, alcohol and phenol interplay (raisiny flavors are common; dried fruit flavors are welcome; clove or pepper spiciness is optional). Balance is always toward the malt. Medium-low bitterness that doesn't persist into the aftertaste. Low spicy, floral, or herbal hop flavor is optional and not usually present. Mouthfeel: Medium-full body. Medium-high carbonation, which can influence the perception of body. Low alcohol warmth. Smooth, never hot or solventy."
-                       :ibu-min         15}))
+                      {cbf/category        "Trappist Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.018
+                       cbf/og-min          1.062
+                       cbf/name            "Belgian Dubbel"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.06
+                       cbf/fg-min          1.008
+                       cbf/category-number "26"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         25
+                       cbf/ingredients     "Belgian yeast strains prone to production of higher alcohols, esters, and phenolics are commonly used. Impression of complex grain bill, although traditional versions are typically Belgian Pils malt with caramelized sugar syrup or other unrefined sugars providing much of the character. Saazer-type, English-type or Styrian Goldings hops commonly used. No spices are traditionally used, although restrained use is allowable (background strength only)."
+                       cbf/examples        "Affligem Dubbel, Chimay Première, Corsendonk Pater, Grimbergen Double, La Trappe Dubbel, St. Bernardus Pater 6, Trappistes Rochefort 6, Westmalle Dubbel"
+                       cbf/notes           "A deep reddish-copper, moderately strong, malty, complex Trappist ale with rich malty flavors, dark or dried fruit esters, and light alcohol blended together in a malty presentation that still finishes fairly dry."
+                       cbf/og-max          1.075
+                       cbf/color-min       10.0
+                       cbf/abv-max         0.076
+                       cbf/color-max       17.0
+                       cbf/profile         "Aroma: Complex, rich-sweet malty aroma, possibly with hints of chocolate, caramel and/or toast (but never roasted or burnt aromas). Moderate fruity esters (usually including raisins and plums, sometimes also dried cherries). Esters sometimes include banana or apple. Spicy phenols and higher alcohols are common (may include light clove and spice, peppery, rose-like and/or perfumy notes). Spicy qualities can be moderate to very low. Alcohol, if present, is soft and never hot or solventy. Low to no spicy, herbal, or floral hop aroma, typically absent. The malt is most prominent in the balance with esters and a touch of alcohol in support, blending together for a harmonious presentation. Appearance: Dark amber to copper in color, with an attractive reddish depth of color. Generally clear. Large, dense, and long-lasting creamy off-white head. Flavor: Similar qualities as aroma. Rich, complex medium to medium-full rich-sweet malt flavor on the palate yet finishes moderately dry. Complex malt, ester, alcohol and phenol interplay (raisiny flavors are common; dried fruit flavors are welcome; clove or pepper spiciness is optional). Balance is always toward the malt. Medium-low bitterness that doesn't persist into the aftertaste. Low spicy, floral, or herbal hop flavor is optional and not usually present. Mouthfeel: Medium-full body. Medium-high carbonation, which can influence the perception of body. Low alcohol warmth. Smooth, never hot or solventy."
+                       cbf/ibu-min         15}))
 
 
 (def belgian-tripel
@@ -60,27 +61,27 @@
    
    Quite aromatic, with spicy, fruity, and light alcohol notes combining with the supportive clean malt character to produce a surprisingly drinkable beverage considering the high alcohol level."
   (styles/build-style :belgian-tripel
-                      {:category        "Trappist Ale"
-                       :carb-min        1.5
-                       :fg-max          1.014
-                       :og-min          1.075
-                       :name            "Belgian Tripel"
-                       :type            "Ale"
-                       :style-letter    "C"
-                       :abv-min         0.075
-                       :fg-min          1.008
-                       :category-number "26"
-                       :carb-max        3.0
-                       :ibu-max         40
-                       :ingredients     "Pilsner malt, typically with pale sugar adjuncts. Saazer-type hops or Styrian Goldings are commonly used. Belgian yeast strains are used - those that produce fruity esters, spicy phenolics and higher alcohols - often aided by slightly warmer fermentation temperatures. Spice additions are generally not traditional, and if used, should be a background character only. Fairly soft water."
-                       :examples        "Affligem Tripel, Chimay Cinq Cents, La Rulles Tripel, La Trappe Tripel, St. Bernardus Tripel, Unibroue La Fin Du Monde, Val-Dieu Triple, Watou Tripel, Westmalle Tripel"
-                       :notes           "A pale, somewhat spicy, dry, strong Trappist ale with a pleasant rounded malt flavor and firm bitterness. Quite aromatic, with spicy, fruity, and light alcohol notes combining with the supportive clean malt character to produce a surprisingly drinkable beverage considering the high alcohol level."
-                       :og-max          1.085
-                       :color-min       4.5
-                       :abv-max         0.095
-                       :color-max       7.0
-                       :profile         "Aroma: Complex bouquet with moderate to significant spiciness, moderate fruity esters and low alcohol and hop aromas. Generous spicy, peppery, sometimes clove-like phenols. Esters are often reminiscent of citrus fruits such as oranges, but may sometimes have a slight banana character. A low yet distinctive spicy, floral, sometimes perfumy hop character is usually found. Alcohols are soft, spicy and low in intensity. The malt character is light, with a soft, slightly grainy-sweet or slightly honey-like impression. The best examples have a seamless, harmonious interplay between the yeast character, hops, malt, and alcohol. Appearance: Deep yellow to deep gold in color. Good clarity. Effervescent. Long-lasting, creamy, rocky, white head resulting in characteristic Belgian lace on the glass as it fades. Flavor: Marriage of spicy, fruity and alcohol flavors supported by a soft, rounded grainy-sweet malt impression, occasionally with a very light honey note. Low to moderate phenols are peppery in character. Esters are reminiscent of citrus fruit such as orange or sometimes lemon, and are low to moderate. A low to moderate spicy hop character is usually found. Alcohols are soft, spicy, and low in intensity. Bitterness is typically medium to high from a combination of hop bitterness and yeast-produced phenolics. Substantial carbonation and bitterness lends a dry finish with a moderately bitter aftertaste with substantial spicy-fruity yeast character. The grainy-sweet malt flavor does not imply any residual sweetness. Mouthfeel: Medium-light to medium body, although lighter than the substantial gravity would suggest. Highly carbonated. The alcohol content is deceptive, and has little to no obvious warming sensation. Always effervescent."
-                       :ibu-min         20}))
+                      {cbf/category        "Trappist Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.014
+                       cbf/og-min          1.075
+                       cbf/name            "Belgian Tripel"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "C"
+                       cbf/abv-min         0.075
+                       cbf/fg-min          1.008
+                       cbf/category-number "26"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         40
+                       cbf/ingredients     "Pilsner malt, typically with pale sugar adjuncts. Saazer-type hops or Styrian Goldings are commonly used. Belgian yeast strains are used - those that produce fruity esters, spicy phenolics and higher alcohols - often aided by slightly warmer fermentation temperatures. Spice additions are generally not traditional, and if used, should be a background character only. Fairly soft water."
+                       cbf/examples        "Affligem Tripel, Chimay Cinq Cents, La Rulles Tripel, La Trappe Tripel, St. Bernardus Tripel, Unibroue La Fin Du Monde, Val-Dieu Triple, Watou Tripel, Westmalle Tripel"
+                       cbf/notes           "A pale, somewhat spicy, dry, strong Trappist ale with a pleasant rounded malt flavor and firm bitterness. Quite aromatic, with spicy, fruity, and light alcohol notes combining with the supportive clean malt character to produce a surprisingly drinkable beverage considering the high alcohol level."
+                       cbf/og-max          1.085
+                       cbf/color-min       4.5
+                       cbf/abv-max         0.095
+                       cbf/color-max       7.0
+                       cbf/profile         "Aroma: Complex bouquet with moderate to significant spiciness, moderate fruity esters and low alcohol and hop aromas. Generous spicy, peppery, sometimes clove-like phenols. Esters are often reminiscent of citrus fruits such as oranges, but may sometimes have a slight banana character. A low yet distinctive spicy, floral, sometimes perfumy hop character is usually found. Alcohols are soft, spicy and low in intensity. The malt character is light, with a soft, slightly grainy-sweet or slightly honey-like impression. The best examples have a seamless, harmonious interplay between the yeast character, hops, malt, and alcohol. Appearance: Deep yellow to deep gold in color. Good clarity. Effervescent. Long-lasting, creamy, rocky, white head resulting in characteristic Belgian lace on the glass as it fades. Flavor: Marriage of spicy, fruity and alcohol flavors supported by a soft, rounded grainy-sweet malt impression, occasionally with a very light honey note. Low to moderate phenols are peppery in character. Esters are reminiscent of citrus fruit such as orange or sometimes lemon, and are low to moderate. A low to moderate spicy hop character is usually found. Alcohols are soft, spicy, and low in intensity. Bitterness is typically medium to high from a combination of hop bitterness and yeast-produced phenolics. Substantial carbonation and bitterness lends a dry finish with a moderately bitter aftertaste with substantial spicy-fruity yeast character. The grainy-sweet malt flavor does not imply any residual sweetness. Mouthfeel: Medium-light to medium body, although lighter than the substantial gravity would suggest. Highly carbonated. The alcohol content is deceptive, and has little to no obvious warming sensation. Always effervescent."
+                       cbf/ibu-min         20}))
 
 
 (def belgian-dark-strong-ale
@@ -88,27 +89,27 @@
    
    Complex, rich, smooth and dangerous."
   (styles/build-style :belgian-dark-strong-ale
-                      {:category        "Trappist Ale"
-                       :carb-min        1.5
-                       :fg-max          1.024
-                       :og-min          1.075
-                       :name            "Belgian Dark Strong Ale"
-                       :type            "Ale"
-                       :style-letter    "D"
-                       :abv-min         0.08
-                       :fg-min          1.01
-                       :category-number "26"
-                       :carb-max        3.0
-                       :ibu-max         35
-                       :ingredients     "Belgian yeast strains prone to production of higher alcohols, esters, and sometimes phenolics are commonly used. Impression of a complex grain bill, although many traditional versions are quite simple, with caramelized sugar syrup or unrefined sugars and yeast providing much of the complexity. Saazer-type, English-type or Styrian Goldings hops commonly used. Spices generally not used; if used, keep subtle and in the background."
-                       :examples        "Achel Extra Brune, Boulevard The Sixth Glass, Chimay Grande Réserve, Gouden Carolus Grand Cru of the Emperor, Rochefort 8 and 10, St. Bernardus Abt 12, Westvleteren 12"
-                       :notes           "A dark, complex, very strong Belgian ale with a delicious blend of malt richness, dark fruit flavors, and spicy elements. Complex, rich, smooth and dangerous."
-                       :og-max          1.11
-                       :color-min       12.0
-                       :abv-max         0.12
-                       :color-max       22.0
-                       :profile         "Aroma: Complex, with a rich-sweet malty presence, significant esters and alcohol, and an optional light to moderate spiciness. The malt is rich and strong, and can have a deep bready-toasty quality often with a deep caramel complexity. The fruity esters are strong to moderately low, and can contain raisin, plum, dried cherry, fig or prune notes. Spicy phenols may be present, but usually have a peppery quality not clove-like; light vanilla is possible. Alcohols are soft, spicy, perfumy and/or rose-like, and are low to moderate in intensity. Hops are not usually present (but a very low spicy, floral, or herbal hop aroma is acceptable). No dark/roast malt aroma. No hot alcohols or solventy aromas. Appearance: Deep amber to deep coppery-brown in color (dark in this context implies more deeply colored than golden). Huge, dense, moussy, persistent cream- to light tan-colored head. Can be clear to somewhat hazy. Flavor: Similar to aroma (same malt, ester, phenol, alcohol, and hop comments apply to flavor as well). Moderately malty-rich on the palate, which can have a sweet impression if bitterness is low. Usually moderately dry to dry finish, although may be up to moderately sweet. Medium-low to moderate bitterness; alcohol provides some of the balance to the malt. Generally malty-rich balance, but can be fairly even with bitterness. The complex and varied flavors should blend smoothly and harmoniously. The finish should not be heavy or syrupy. Mouthfeel: High carbonation but not sharp. Smooth but noticeable alcohol warmth. Body can range from medium-light to medium-full and creamy. Most are medium-bodied."
-                       :ibu-min         20}))
+                      {cbf/category        "Trappist Ale"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.024
+                       cbf/og-min          1.075
+                       cbf/name            "Belgian Dark Strong Ale"
+                       cbf/type            "Ale"
+                       cbf/style-letter    "D"
+                       cbf/abv-min         0.08
+                       cbf/fg-min          1.01
+                       cbf/category-number "26"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         35
+                       cbf/ingredients     "Belgian yeast strains prone to production of higher alcohols, esters, and sometimes phenolics are commonly used. Impression of a complex grain bill, although many traditional versions are quite simple, with caramelized sugar syrup or unrefined sugars and yeast providing much of the complexity. Saazer-type, English-type or Styrian Goldings hops commonly used. Spices generally not used; if used, keep subtle and in the background."
+                       cbf/examples        "Achel Extra Brune, Boulevard The Sixth Glass, Chimay Grande Réserve, Gouden Carolus Grand Cru of the Emperor, Rochefort 8 and 10, St. Bernardus Abt 12, Westvleteren 12"
+                       cbf/notes           "A dark, complex, very strong Belgian ale with a delicious blend of malt richness, dark fruit flavors, and spicy elements. Complex, rich, smooth and dangerous."
+                       cbf/og-max          1.11
+                       cbf/color-min       12.0
+                       cbf/abv-max         0.12
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Complex, with a rich-sweet malty presence, significant esters and alcohol, and an optional light to moderate spiciness. The malt is rich and strong, and can have a deep bready-toasty quality often with a deep caramel complexity. The fruity esters are strong to moderately low, and can contain raisin, plum, dried cherry, fig or prune notes. Spicy phenols may be present, but usually have a peppery quality not clove-like; light vanilla is possible. Alcohols are soft, spicy, perfumy and/or rose-like, and are low to moderate in intensity. Hops are not usually present (but a very low spicy, floral, or herbal hop aroma is acceptable). No dark/roast malt aroma. No hot alcohols or solventy aromas. Appearance: Deep amber to deep coppery-brown in color (dark in this context implies more deeply colored than golden). Huge, dense, moussy, persistent cream- to light tan-colored head. Can be clear to somewhat hazy. Flavor: Similar to aroma (same malt, ester, phenol, alcohol, and hop comments apply to flavor as well). Moderately malty-rich on the palate, which can have a sweet impression if bitterness is low. Usually moderately dry to dry finish, although may be up to moderately sweet. Medium-low to moderate bitterness; alcohol provides some of the balance to the malt. Generally malty-rich balance, but can be fairly even with bitterness. The complex and varied flavors should blend smoothly and harmoniously. The finish should not be heavy or syrupy. Mouthfeel: High carbonation but not sharp. Smooth but noticeable alcohol warmth. Body can range from medium-light to medium-full and creamy. Most are medium-bodied."
+                       cbf/ibu-min         20}))
 
 
 (def trappist-ale

--- a/src/common_beer_data/styles/bjcp_2015/wood_beer.cljc
+++ b/src/common_beer_data/styles/bjcp_2015/wood_beer.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-data.styles.bjcp-2015.wood-beer
   "2015 BJCP guidelines on Wood Beers."
-  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]))
+  (:require [common-beer-data.styles.bjcp-2015.styles :as styles]
+            [common-beer-format.styles :as cbf]))
 
 
 (def wood-aged-beer
@@ -8,27 +9,27 @@
    
    The best examples will be smooth, flavorful, well-balanced and well-aged."
   (styles/build-style :wood-aged-beer
-                      {:category        "Wood Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Wood-Aged Beer"
-                       :type            "Mixed"
-                       :style-letter    "A"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "33"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Varies with base style. Aged in wooden casks or barrels, or using wood-based additives (wood chips, wood staves, oak essence). Fuller-bodied, higher-gravity base styles often are used since they can best stand up to the additional flavors, although experimentation is encouraged."
-                       :examples        "Bush Prestige, Cigar City Humidor India Pale Ale, Faust Holzfassgereifter Eisbock, Firestone Walker Double Barrel Ale, Great Divide Oak Aged Yeti Imperial Stout, Petrus Aged Pale, Samuel Smith Yorkshire Stingo"
-                       :notes           "A harmonious blend of the base beer style with characteristics from aging in contact with wood. The best examples will be smooth, flavorful, well-balanced and well-aged."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: Varies with base style. A low to moderate wood- or oak-based aroma is usually present. Fresh wood can occasionally impart raw \"green\" aromatics, although this character should never be too strong. Other optional aromatics include a low to moderate vanilla, caramel, toffee, toast, or cocoa character from any char on the wood. Any alcohol character should be smooth and balanced, not hot. Some background oxidation character is optional, and can take on a pleasant, sherry-like character and not be papery or cardboard-like. Should not have added alcohol character. Appearance: Varies with base style. Often darker than the unadulterated base beer style, particularly if toasted/charred barrels are used. Flavor: Varies with base style. Wood usually contributes a woody or oaky flavor, which can occasionally take on a raw \"green\" flavor if new wood is used. Other flavors that may optionally be present include vanilla (from vanillin in the wood); caramel, butterscotch, toasted bread or almonds (from toasted wood); and coffee, chocolate, cocoa (from charred wood). The wood and/or other cask-derived flavors should be balanced, supportive and noticeable, but should not overpower the base beer style. Some background oxidation character is optional, although this should take on a pleasant, sherry-like character and not be papery or cardboard-like. Mouthfeel: Varies with base style. Wood can add tannins to the beer, depending on age of the cask. The tannins can lead to additional astringency (which should never be high), or simply a fuller mouthfeel. Tart or acidic characteristics should be low to none, and never distracting."
-                       :ibu-min         7}))
+                      {cbf/category        "Wood Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Wood-Aged Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "A"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "33"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Varies with base style. Aged in wooden casks or barrels, or using wood-based additives (wood chips, wood staves, oak essence). Fuller-bodied, higher-gravity base styles often are used since they can best stand up to the additional flavors, although experimentation is encouraged."
+                       cbf/examples        "Bush Prestige, Cigar City Humidor India Pale Ale, Faust Holzfassgereifter Eisbock, Firestone Walker Double Barrel Ale, Great Divide Oak Aged Yeti Imperial Stout, Petrus Aged Pale, Samuel Smith Yorkshire Stingo"
+                       cbf/notes           "A harmonious blend of the base beer style with characteristics from aging in contact with wood. The best examples will be smooth, flavorful, well-balanced and well-aged."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Varies with base style. A low to moderate wood- or oak-based aroma is usually present. Fresh wood can occasionally impart raw \"green\" aromatics, although this character should never be too strong. Other optional aromatics include a low to moderate vanilla, caramel, toffee, toast, or cocoa character from any char on the wood. Any alcohol character should be smooth and balanced, not hot. Some background oxidation character is optional, and can take on a pleasant, sherry-like character and not be papery or cardboard-like. Should not have added alcohol character. Appearance: Varies with base style. Often darker than the unadulterated base beer style, particularly if toasted/charred barrels are used. Flavor: Varies with base style. Wood usually contributes a woody or oaky flavor, which can occasionally take on a raw \"green\" flavor if new wood is used. Other flavors that may optionally be present include vanilla (from vanillin in the wood); caramel, butterscotch, toasted bread or almonds (from toasted wood); and coffee, chocolate, cocoa (from charred wood). The wood and/or other cask-derived flavors should be balanced, supportive and noticeable, but should not overpower the base beer style. Some background oxidation character is optional, although this should take on a pleasant, sherry-like character and not be papery or cardboard-like. Mouthfeel: Varies with base style. Wood can add tannins to the beer, depending on age of the cask. The tannins can lead to additional astringency (which should never be high), or simply a fuller mouthfeel. Tart or acidic characteristics should be low to none, and never distracting."
+                       cbf/ibu-min         7}))
 
 
 (def specialty-wood-aged-beer
@@ -36,27 +37,27 @@
    
    The best examples will be smooth, flavorful, well-balanced and well-aged."
   (styles/build-style :specialty-wood-aged-beer
-                      {:category        "Wood Beer"
-                       :carb-min        1.5
-                       :fg-max          1.02
-                       :og-min          1.076
-                       :name            "Specialty Wood-Aged Beer"
-                       :type            "Mixed"
-                       :style-letter    "B"
-                       :abv-min         0.07
-                       :fg-min          1.016
-                       :category-number "33"
-                       :carb-max        3.0
-                       :ibu-max         15
-                       :ingredients     "Varies with base style. Aged in wooden casks or barrels previously used to store alcohol (e.g., whiskey, bourbon, port, sherry, Madeira, wine, etc). Fuller-bodied, higher-gravity base styles often are used since they can best stand up to the additional flavors, although experimentation is encouraged."
-                       :examples        "Founders Kentucky Breakfast Stout, Goose Island Bourbon County Stout, J.W. Lees Harvest Ale in Port, Sherry, Lagavulin Whisky or Calvados Casks, The Lost Abbey Angel's Share Ale; many microbreweries have specialty beers served only on premises often directly from the cask."
-                       :notes           "A harmonious blend of the base beer style with characteristics from aging in contact with wood (including alcoholic products previously in contact with the wood). The best examples will be smooth, flavorful, well-balanced and well-aged."
-                       :og-max          1.12
-                       :color-min       4.0
-                       :abv-max         0.11
-                       :color-max       22.0
-                       :profile         "Aroma: Varies with base style. A low to moderate wood- or oak-based aroma is usually present. Other aromatics often include a low to moderate vanilla, caramel, toffee, toast, or cocoa character, as well as any aromatics associated with alcohol (distilled spirits, wine, etc.) previously stored in the wood. The added alcohol character should be smooth and balanced, not hot. Some background oxidation character is optional, and can take on a pleasant, sherry-like character and not be papery or cardboard-like. Appearance: Varies with base style. Often darker than the unadulterated base beer style, particularly if whiskey/bourbon barrels are used. Beers aged in wine barrels or other products with distinctive colors may also impart a color to the finished beer. Flavor: Varies with base style. Wood usually contributes a woody or oaky flavor. Other flavors that are typically present include vanilla (from vanillin in the wood); caramel, butterscotch, toasted bread or almonds (from toasted wood); coffee, chocolate, cocoa (from charred wood or bourbon casks); and alcohol flavors from other products previously stored in the wood. The wood and/or other cask-derived flavors should be balanced, supportive and noticeable, but should not overpower the base beer style. Some background oxidation character is optional, although this should take on a pleasant, sherry-like character and not be papery or cardboard-like. Mouthfeel: Varies with base style. Wood can add tannins to the beer, depending on age of the cask. The tannins can lead to additional astringency (which should never be high), or simply a fuller mouthfeel. Usually exhibits additional alcohol warming. Higher alcohol levels should not result in \"hot\" beers; aged, smooth flavors are most desirable. Tart or acidic characteristics should be low to none."
-                       :ibu-min         7}))
+                      {cbf/category        "Wood Beer"
+                       cbf/carb-min        1.5
+                       cbf/fg-max          1.02
+                       cbf/og-min          1.076
+                       cbf/name            "Specialty Wood-Aged Beer"
+                       cbf/type            "Mixed"
+                       cbf/style-letter    "B"
+                       cbf/abv-min         0.07
+                       cbf/fg-min          1.016
+                       cbf/category-number "33"
+                       cbf/carb-max        3.0
+                       cbf/ibu-max         15
+                       cbf/ingredients     "Varies with base style. Aged in wooden casks or barrels previously used to store alcohol (e.g., whiskey, bourbon, port, sherry, Madeira, wine, etc). Fuller-bodied, higher-gravity base styles often are used since they can best stand up to the additional flavors, although experimentation is encouraged."
+                       cbf/examples        "Founders Kentucky Breakfast Stout, Goose Island Bourbon County Stout, J.W. Lees Harvest Ale in Port, Sherry, Lagavulin Whisky or Calvados Casks, The Lost Abbey Angel's Share Ale; many microbreweries have specialty beers served only on premises often directly from the cask."
+                       cbf/notes           "A harmonious blend of the base beer style with characteristics from aging in contact with wood (including alcoholic products previously in contact with the wood). The best examples will be smooth, flavorful, well-balanced and well-aged."
+                       cbf/og-max          1.12
+                       cbf/color-min       4.0
+                       cbf/abv-max         0.11
+                       cbf/color-max       22.0
+                       cbf/profile         "Aroma: Varies with base style. A low to moderate wood- or oak-based aroma is usually present. Other aromatics often include a low to moderate vanilla, caramel, toffee, toast, or cocoa character, as well as any aromatics associated with alcohol (distilled spirits, wine, etc.) previously stored in the wood. The added alcohol character should be smooth and balanced, not hot. Some background oxidation character is optional, and can take on a pleasant, sherry-like character and not be papery or cardboard-like. Appearance: Varies with base style. Often darker than the unadulterated base beer style, particularly if whiskey/bourbon barrels are used. Beers aged in wine barrels or other products with distinctive colors may also impart a color to the finished beer. Flavor: Varies with base style. Wood usually contributes a woody or oaky flavor. Other flavors that are typically present include vanilla (from vanillin in the wood); caramel, butterscotch, toasted bread or almonds (from toasted wood); coffee, chocolate, cocoa (from charred wood or bourbon casks); and alcohol flavors from other products previously stored in the wood. The wood and/or other cask-derived flavors should be balanced, supportive and noticeable, but should not overpower the base beer style. Some background oxidation character is optional, although this should take on a pleasant, sherry-like character and not be papery or cardboard-like. Mouthfeel: Varies with base style. Wood can add tannins to the beer, depending on age of the cask. The tannins can lead to additional astringency (which should never be high), or simply a fuller mouthfeel. Usually exhibits additional alcohol warming. Higher alcohol levels should not result in \"hot\" beers; aged, smooth flavors are most desirable. Tart or acidic characteristics should be low to none."
+                       cbf/ibu-min         7}))
 
 
 (def wood-beer

--- a/src/common_beer_data/yeasts/brewtek.cljc
+++ b/src/common_beer_data/yeasts/brewtek.cljc
@@ -1,7 +1,9 @@
 (ns common-beer-data.yeasts.brewtek
   "Data for yeasts cultivated by Brewtek.
    https://brewtek.se/sv/"
-  (:require [common-beer-data.yeasts.yeasts :as yeasts]))
+  {:added "1.0"}
+  (:require [common-beer-data.yeasts.yeasts :as yeasts]
+            [common-beer-format.yeasts :as cbf]))
 
 
 (def cl-0010-american-microbrewery-ale-1
@@ -9,17 +11,17 @@
    
    Clean malt flavor is ideal for cream ales."
   (yeasts/build-yeasts :cl-0010-american-microbrewery-ale-1
-                       {:min-temperature 13.33
-                        :name            "CL-0010 American Microbrewery Ale #1"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "American Ales, Cream Ales"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Smooth, clean, strong fermenting ale yeast that works well at cold temperature. Clean malt flavor is ideal for cream ales."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0010"}))
+                       {cbf/min-temperature 13.33
+                        cbf/name            "CL-0010 American Microbrewery Ale #1"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "American Ales, Cream Ales"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Smooth, clean, strong fermenting ale yeast that works well at cold temperature. Clean malt flavor is ideal for cream ales."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0010"}))
 
 
 (def cl-0020-american-microbrewery-ale-2
@@ -28,17 +30,17 @@
    Generous amounts of diacytl. 
    Use for low gravity beers where malt character is needed or stronger beers for a robust character."
   (yeasts/build-yeasts :cl-0020-american-microbrewery-ale-2
-                       {:min-temperature 13.33
-                        :name            "CL-0020 American Microbrewery Ale #2"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "American ales"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Accentuated, rich, creamy malt profile. Generous amounts of diacytl. Use for low gravity beers where malt character is needed or stronger beers for a robust character."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0020"}))
+                       {cbf/min-temperature 13.33
+                        cbf/name            "CL-0020 American Microbrewery Ale #2"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "American ales"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Accentuated, rich, creamy malt profile. Generous amounts of diacytl. Use for low gravity beers where malt character is needed or stronger beers for a robust character."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0020"}))
 
 
 (def cl-0050-california-pub-ale
@@ -47,17 +49,17 @@
    CL-50 produces terrific American red & pale ale styles. 
    While attenuation is normal, this yeast produces a big, soft, well rounded malt flavor that really lets caramel malt flavors shine."
   (yeasts/build-yeasts :cl-0050-california-pub-ale
-                       {:min-temperature 15.56
-                        :name            "CL-0050 California Pub Ale"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "California and other American ales"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "For that classic U.S. small brewery flavor. CL-50 produces terrific American red & pale ale styles. While attenuation is normal, this yeast produces a big, soft, well rounded malt flavor that really lets caramel malt flavors shine."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0050"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "CL-0050 California Pub Ale"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "California and other American ales"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "For that classic U.S. small brewery flavor. CL-50 produces terrific American red & pale ale styles. While attenuation is normal, this yeast produces a big, soft, well rounded malt flavor that really lets caramel malt flavors shine."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0050"}))
 
 
 (def cl-0060-north-eastern-micro-ale
@@ -66,17 +68,17 @@
    Leaves hops flavor and aroma intact. 
    Versitile yeast for many American styles."
   (yeasts/build-yeasts :cl-0060-north-eastern-micro-ale
-                       {:min-temperature 13.33
-                        :name            "CL-0060 North-Eastern Micro Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "American Ales, Reds, Ambers"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Malty, bready, yet clean malt character. Leaves hops flavor and aroma intact. Versitile yeast for many American styles."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0060"}))
+                       {cbf/min-temperature 13.33
+                        cbf/name            "CL-0060 North-Eastern Micro Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "American Ales, Reds, Ambers"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Malty, bready, yet clean malt character. Leaves hops flavor and aroma intact. Versitile yeast for many American styles."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0060"}))
 
 
 (def cl-0110-british-microbrewery-ale
@@ -85,17 +87,17 @@
    Slightly under-attenuated finish leaves some residual malt flavor. 
    Suitable for low to medium gravity bitters and ales."
   (yeasts/build-yeasts :cl-0110-british-microbrewery-ale
-                       {:min-temperature 16.67
-                        :name            "CL-0110 British Microbrewery Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "English Bitters and Milds"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Complex oakey, and fruity ester profile. Slightly under-attenuated finish leaves some residual malt flavor. Suitable for low to medium gravity bitters and ales."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0110"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0110 British Microbrewery Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "English Bitters and Milds"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Complex oakey, and fruity ester profile. Slightly under-attenuated finish leaves some residual malt flavor. Suitable for low to medium gravity bitters and ales."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0110"}))
 
 
 (def cl-0120-british-pale-ale-1
@@ -103,17 +105,17 @@
    
    Distinct character of a classic Pale Ale."
   (yeasts/build-yeasts :cl-0120-british-pale-ale-1
-                       {:min-temperature 16.67
-                        :name            "CL-0120 British Pale Ale #1"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "British Pale Ales and Bitters."
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Bold, citrusy character which accentuates mineral and hop flavors. Distinct character of a classic Pale Ale."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0120"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0120 British Pale Ale #1"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "British Pale Ales and Bitters."
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Bold, citrusy character which accentuates mineral and hop flavors. Distinct character of a classic Pale Ale."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0120"}))
 
 
 (def cl-0130-british-pale-ale-2
@@ -123,17 +125,17 @@
    Strong ferementer suitable for strong or spiced ales. 
    Accentuates caramel and malt flavors."
   (yeasts/build-yeasts :cl-0130-british-pale-ale-2
-                       {:min-temperature 16.67
-                        :name            "CL-0130 British Pale Ale #2"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "British Pale Ale, other British Ales"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Smooth, full bodied, well roundd ale yeast. Mild esters. Strong ferementer suitable for strong or spiced ales. Accentuates caramel and malt flavors."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0130"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0130 British Pale Ale #2"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "British Pale Ale, other British Ales"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Smooth, full bodied, well roundd ale yeast. Mild esters. Strong ferementer suitable for strong or spiced ales. Accentuates caramel and malt flavors."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0130"}))
 
 
 (def cl-0150-british-real-ale
@@ -142,17 +144,17 @@
    Has a complex, woody flavor and musty ester profile that characterizes real ale. 
    Underattenuating to leave mild sweetness to the finish."
   (yeasts/build-yeasts :cl-0150-british-real-ale
-                       {:min-temperature 16.67
-                        :name            "CL-0150 British Real Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Bitters and other English Ales"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Great for real pub bitters. Has a complex, woody flavor and musty ester profile that characterizes real ale. Underattenuating to leave mild sweetness to the finish."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0150"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0150 British Real Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Bitters and other English Ales"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Great for real pub bitters. Has a complex, woody flavor and musty ester profile that characterizes real ale. Underattenuating to leave mild sweetness to the finish."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0150"}))
 
 
 (def cl-0160-british-draft-ale
@@ -161,17 +163,17 @@
    Emphasizes malt character. 
    Great for porters and bitters."
   (yeasts/build-yeasts :cl-0160-british-draft-ale
-                       {:min-temperature 16.67
-                        :name            "CL-0160 British Draft Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Porters and Bitters."
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Full bodied, well rounded ale yeast with a touch of diacytl. Emphasizes malt character. Great for porters and bitters."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0160"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0160 British Draft Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Porters and Bitters."
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Full bodied, well rounded ale yeast with a touch of diacytl. Emphasizes malt character. Great for porters and bitters."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0160"}))
 
 
 (def cl-0170-classic-british-ale
@@ -179,17 +181,17 @@
    
    Works well in high gravity ales such as scottish heavy as well."
   (yeasts/build-yeasts :cl-0170-classic-british-ale
-                       {:min-temperature 16.67
-                        :name            "CL-0170 Classic British Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Bitters, Porters, Scottish Heavy Ales."
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Complex ale with British tones and fruit like esters. Works well in high gravity ales such as scottish heavy as well."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0170"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0170 Classic British Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Bitters, Porters, Scottish Heavy Ales."
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Complex ale with British tones and fruit like esters. Works well in high gravity ales such as scottish heavy as well."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0170"}))
 
 
 (def cl-0200-scottish-ale
@@ -198,17 +200,17 @@
    This yeast produces a soft, fruity malt profile with a subtle woody, oakey ester profile. 
    A mild, mineral like dryness in the finish makes this a very complex strain."
   (yeasts/build-yeasts :cl-0200-scottish-ale
-                       {:min-temperature 15.56
-                        :name            "CL-0200 Scottish Ale"
-                        :max-temperature 20.0
-                        :type            "Ale"
-                        :best-for        "Scottish ales"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Use for classic Scottish heavys, 90's- or strong ales. This yeast produces a soft, fruity malt profile with a subtle woody, oakey ester profile. A mild, mineral like dryness in the finish makes this a very complex strain."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "CL-0200"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "CL-0200 Scottish Ale"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "Scottish ales"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Use for classic Scottish heavys, 90's- or strong ales. This yeast produces a soft, fruity malt profile with a subtle woody, oakey ester profile. A mild, mineral like dryness in the finish makes this a very complex strain."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0200"}))
 
 
 (def cl-0240-irish-dry-stout
@@ -217,33 +219,33 @@
    Vinous almost lactic character that blends well with roast malts. 
    High attenuation."
   (yeasts/build-yeasts :cl-0240-irish-dry-stout
-                       {:min-temperature 16.67
-                        :name            "CL-0240 Irish Dry Stout"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Dry Stouts"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Top fermenting yeast which leaves a recognizable slightly woody character to Dry Stouts. Vinous almost lactic character that blends well with roast malts. High attenuation."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0240"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0240 Irish Dry Stout"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Dry Stouts"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Top fermenting yeast which leaves a recognizable slightly woody character to Dry Stouts. Vinous almost lactic character that blends well with roast malts. High attenuation."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0240"}))
 
 
 (def cl-0260-canadian-ale
   "Clean, strong fermenting, well attenuated ale yeast that leaves a pleasant, fruity, complex finish."
   (yeasts/build-yeasts :cl-0260-canadian-ale
-                       {:min-temperature 16.67
-                        :name            "CL-0260 Canadian Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Light Canadian Ales, Bitish Bitter, Pale Ale, Porters"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Clean, strong fermenting, well attenuated ale yeast that leaves a pleasant, fruity, complex finish."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0260"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0260 Canadian Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Light Canadian Ales, Bitish Bitter, Pale Ale, Porters"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Clean, strong fermenting, well attenuated ale yeast that leaves a pleasant, fruity, complex finish."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0260"}))
 
 
 (def cl-0270-australian-ale
@@ -251,17 +253,17 @@
    
    This yeast emphasizes malt nuances and is very forgiving in warmer fermentations for those who cannot ferment under controlled conditions."
   (yeasts/build-yeasts :cl-0270-australian-ale
-                       {:min-temperature 18.89
-                        :name            "CL-0270 Australian Ale"
-                        :max-temperature 24.44
-                        :type            "Ale"
-                        :best-for        "Australian styles"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Produces a malty, bready, nutty character with a pleasant honey like finish. This yeast emphasizes malt nuances and is very forgiving in warmer fermentations for those who cannot ferment under controlled conditions."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0270"}))
+                       {cbf/min-temperature 18.89
+                        cbf/name            "CL-0270 Australian Ale"
+                        cbf/max-temperature 24.44
+                        cbf/type            "Ale"
+                        cbf/best-for        "Australian styles"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Produces a malty, bready, nutty character with a pleasant honey like finish. This yeast emphasizes malt nuances and is very forgiving in warmer fermentations for those who cannot ferment under controlled conditions."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0270"}))
 
 
 (def cl-0300-belgian-ale-1
@@ -270,17 +272,17 @@
    Robust, estery with notes of clove and fruit. 
    Ferments well in high gravity worts."
   (yeasts/build-yeasts :cl-0300-belgian-ale-1
-                       {:min-temperature 16.67
-                        :name            "CL-0300 Belgian Ale #1"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Belgian Ales, High gravity ales."
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Produces classic Belgian ale flavor. Robust, estery with notes of clove and fruit. Ferments well in high gravity worts."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0300"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0300 Belgian Ale #1"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Ales, High gravity ales."
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Produces classic Belgian ale flavor. Robust, estery with notes of clove and fruit. Ferments well in high gravity worts."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0300"}))
 
 
 (def cl-0320-belgian-ale-2
@@ -289,17 +291,17 @@
    Strong fermenting yeast attenuates well and produces fruity, malty, estery malt profile. 
    Slow to flocculate."
   (yeasts/build-yeasts :cl-0320-belgian-ale-2
-                       {:min-temperature 16.67
-                        :name            "CL-0320 Belgian Ale #2"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Flanders style Belgian Ales, Belgian Brown, Fruit beers"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Flanders style yeast. Strong fermenting yeast attenuates well and produces fruity, malty, estery malt profile. Slow to flocculate."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "CL-0320"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0320 Belgian Ale #2"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Flanders style Belgian Ales, Belgian Brown, Fruit beers"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Flanders style yeast. Strong fermenting yeast attenuates well and produces fruity, malty, estery malt profile. Slow to flocculate."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0320"}))
 
 
 (def cl-0340-belgian-ale-3
@@ -309,17 +311,17 @@
    Mildly phenolic. 
    Strong fermenting yeast."
   (yeasts/build-yeasts :cl-0340-belgian-ale-3
-                       {:min-temperature 16.67
-                        :name            "CL-0340 Belgian Ale #3"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Belgian ales, Trappist Ales"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Slightly more refined than CL-300. Produces the classic Trappist ale character with esters of spice and fruit. Mildly phenolic. Strong fermenting yeast."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0340"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0340 Belgian Ale #3"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian ales, Trappist Ales"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Slightly more refined than CL-300. Produces the classic Trappist ale character with esters of spice and fruit. Mildly phenolic. Strong fermenting yeast."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0340"}))
 
 
 (def cl-0380-saison
@@ -327,17 +329,17 @@
    
    Leaves a smooth full character to the malt with mild, but pleasant esters and some apple pie spices."
   (yeasts/build-yeasts :cl-0380-saison
-                       {:min-temperature 16.67
-                        :name            "CL-0380 Saison"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "French or Belgian Ales and Grand Cru styles."
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Pleasant yeast blend. Leaves a smooth full character to the malt with mild, but pleasant esters and some apple pie spices."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0380"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0380 Saison"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "French or Belgian Ales and Grand Cru styles."
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Pleasant yeast blend. Leaves a smooth full character to the malt with mild, but pleasant esters and some apple pie spices."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0380"}))
 
 
 (def cl-0400-old-german-ale
@@ -346,17 +348,17 @@
    Strong fermenter with a smooth, attenuated, mild flavor. 
    Slightly dry, clean, quenching finish."
   (yeasts/build-yeasts :cl-0400-old-german-ale
-                       {:min-temperature 16.67
-                        :name            "CL-0400 Old German Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Altbier, German ales, some Wheat beers."
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Traditional Alt Bier flavor. Strong fermenter with a smooth, attenuated, mild flavor. Slightly dry, clean, quenching finish."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0400"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0400 Old German Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Altbier, German ales, some Wheat beers."
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Traditional Alt Bier flavor. Strong fermenter with a smooth, attenuated, mild flavor. Slightly dry, clean, quenching finish."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0400"}))
 
 
 (def cl-0450-kolsch
@@ -365,17 +367,17 @@
    Mineral and malt characters come through well. 
    Clean, lightly yeasty flavor and aroma in the finish."
   (yeasts/build-yeasts :cl-0450-kolsch
-                       {:min-temperature 16.67
-                        :name            "CL-0450 Kolsch"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "German Kolsch"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Produces mild sulfer flavor which smooths with time to a clean attenuated flavor. Mineral and malt characters come through well. Clean, lightly yeasty flavor and aroma in the finish."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0450"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "CL-0450 Kolsch"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "German Kolsch"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Produces mild sulfer flavor which smooths with time to a clean attenuated flavor. Mineral and malt characters come through well. Clean, lightly yeasty flavor and aroma in the finish."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0450"}))
 
 
 (def cl-0600-original-pilsner
@@ -385,17 +387,17 @@
    Big malty palatte. 
    Classic Pilsner finish and style."
   (yeasts/build-yeasts :cl-0600-original-pilsner
-                       {:min-temperature 8.89
-                        :name            "CL-0600 Original Pilsner"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "Classic Czech Pilsners"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Full bodied lager yeast with sweet, underattenuated finish. Subdued diacetyl character. Big malty palatte. Classic Pilsner finish and style."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0600"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "CL-0600 Original Pilsner"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "Classic Czech Pilsners"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Full bodied lager yeast with sweet, underattenuated finish. Subdued diacetyl character. Big malty palatte. Classic Pilsner finish and style."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0600"}))
 
 
 (def cl-0620-american-megabrewery
@@ -404,17 +406,17 @@
    Lagers into a smooth, clean tasting beer. 
    Use for light, clean lager styles with unobtrusive yeast character."
   (yeasts/build-yeasts :cl-0620-american-megabrewery
-                       {:min-temperature 8.89
-                        :name            "CL-0620 American Megabrewery"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "Light, Clean American style lagers."
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Smooth yeast with a slight fruity flavor. Lagers into a smooth, clean tasting beer. Use for light, clean lager styles with unobtrusive yeast character."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0620"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "CL-0620 American Megabrewery"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "Light, Clean American style lagers."
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Smooth yeast with a slight fruity flavor. Lagers into a smooth, clean tasting beer. Use for light, clean lager styles with unobtrusive yeast character."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0620"}))
 
 
 (def cl-0630-american-microbrewery-lager
@@ -424,17 +426,17 @@
    Slightly attenuative.
    Versatile for most lager styles with a clean full flavor."
   (yeasts/build-yeasts :cl-0630-american-microbrewery-lager
-                       {:min-temperature 8.89
-                        :name            "CL-0630 American Microbrewery Lager"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "All lager styles"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Strong fermenter. Leaves a clean, full flavored, malty finish. Slightly attenuative. Versatile for most lager styles with a clean full flavor."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0630"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "CL-0630 American Microbrewery Lager"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "All lager styles"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Strong fermenter. Leaves a clean, full flavored, malty finish. Slightly attenuative. Versatile for most lager styles with a clean full flavor."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0630"}))
 
 
 (def cl-0650-old-bavarian-lager
@@ -442,17 +444,17 @@
    
    Distinct, flavorful yeast is great for Southern German lager styles."
   (yeasts/build-yeasts :cl-0650-old-bavarian-lager
-                       {:min-temperature 8.89
-                        :name            "CL-0650 Old Bavarian Lager"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "German lagers, Bock, Dunkel, Helles"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Well rounded, malty with a subtle ester complex and citrus flavors. Distinct, flavorful yeast is great for Southern German lager styles."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0650"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "CL-0650 Old Bavarian Lager"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "German lagers, Bock, Dunkel, Helles"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Well rounded, malty with a subtle ester complex and citrus flavors. Distinct, flavorful yeast is great for Southern German lager styles."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0650"}))
 
 
 (def cl-0660-northern-german-lager
@@ -461,17 +463,17 @@
    Strong fermenting and forgiving yeast. 
    Excellent general purpose lager yeast."
   (yeasts/build-yeasts :cl-0660-northern-german-lager
-                       {:min-temperature 8.89
-                        :name            "CL-0660 Northern German Lager"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "German pilsners, Mexican and Canadian Lagers"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Clean, crisp, traditional lager character. Strong fermenting and forgiving yeast. Excellent general purpose lager yeast."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0660"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "CL-0660 Northern German Lager"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "German pilsners, Mexican and Canadian Lagers"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Clean, crisp, traditional lager character. Strong fermenting and forgiving yeast. Excellent general purpose lager yeast."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0660"}))
 
 
 (def cl-0670-swiss-lager
@@ -480,17 +482,17 @@
    Perfect for European Pilsners. 
    Like our CL-660 strain, this is an excellent all purpose Lager yeast for those wanting a fuller, rounder palate."
   (yeasts/build-yeasts :cl-0670-swiss-lager
-                       {:min-temperature 8.89
-                        :name            "CL-0670 Swiss Lager"
-                        :max-temperature 12.22
-                        :type            "Lager"
-                        :best-for        "European pilsners and lagers"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "A unique strain that has both a clean, crisp lager flavor and a soft, smooth maltiness. Perfect for European Pilsners. Like our CL-660 strain, this is an excellent all purpose Lager yeast for those wanting a fuller, rounder palate."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0670"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "CL-0670 Swiss Lager"
+                        cbf/max-temperature 12.22
+                        cbf/type            "Lager"
+                        cbf/best-for        "European pilsners and lagers"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "A unique strain that has both a clean, crisp lager flavor and a soft, smooth maltiness. Perfect for European Pilsners. Like our CL-660 strain, this is an excellent all purpose Lager yeast for those wanting a fuller, rounder palate."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0670"}))
 
 
 (def cl-0680-east-european-lager
@@ -499,17 +501,17 @@
    Emphasizes big malt flavor and clean finish. 
    Full but smooth malt character."
   (yeasts/build-yeasts :cl-0680-east-european-lager
-                       {:min-temperature 8.89
-                        :name            "CL-0680 East European Lager"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "Marzens, Oktoberfest"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Smooth, rich, creamy character. Emphasizes big malt flavor and clean finish. Full but smooth malt character."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0680"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "CL-0680 East European Lager"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "Marzens, Oktoberfest"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Smooth, rich, creamy character. Emphasizes big malt flavor and clean finish. Full but smooth malt character."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0680"}))
 
 
 (def cl-0690-california-esteem-gold
@@ -519,17 +521,17 @@
    Quite distinct in flavor. 
    Can also be used for complex porters."
   (yeasts/build-yeasts :cl-0690-california-esteem-gold
-                       {:min-temperature 8.89
-                        :name            "CL-0690 California Esteem (Gold)"
-                        :max-temperature 18.33
-                        :type            "Lager"
-                        :best-for        "California Common Beer, American or Robust porters"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Use for California Common Beers (aka Steam Beer). Leaves a slightly estery, well attenuated finish. Quite distinct in flavor. Can also be used for complex porters."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0690"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "CL-0690 California Esteem (Gold)"
+                        cbf/max-temperature 18.33
+                        cbf/type            "Lager"
+                        cbf/best-for        "California Common Beer, American or Robust porters"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Use for California Common Beers (aka Steam Beer). Leaves a slightly estery, well attenuated finish. Quite distinct in flavor. Can also be used for complex porters."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0690"}))
 
 
 (def cl-0900-belgian-wheat
@@ -539,17 +541,17 @@
    Delicious Belgian character to any beer. 
    Great in Wit style with coriander and bitter orange peel."
   (yeasts/build-yeasts :cl-0900-belgian-wheat
-                       {:min-temperature 12.78
-                        :name            "CL-0900 Belgian Wheat"
-                        :max-temperature 20.0
-                        :type            "Wheat"
-                        :best-for        "Belgian Pils, Belgian Wit"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Top fermenting yeast with a soft bread-like character. Leaves a sweet, mildly estery finish. Delicious Belgian character to any beer. Great in Wit style with coriander and bitter orange peel."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0900"}))
+                       {cbf/min-temperature 12.78
+                        cbf/name            "CL-0900 Belgian Wheat"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Belgian Pils, Belgian Wit"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Top fermenting yeast with a soft bread-like character. Leaves a sweet, mildly estery finish. Delicious Belgian character to any beer. Great in Wit style with coriander and bitter orange peel."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0900"}))
 
 
 (def cl-0920-german-wheat-bt
@@ -558,17 +560,17 @@
    Intensely spicy, clovey and phenolic. 
    High attenuation."
   (yeasts/build-yeasts :cl-0920-german-wheat-bt
-                       {:min-temperature 12.78
-                        :name            "CL-0920 German Wheat BT"
-                        :max-temperature 20.0
-                        :type            "Wheat"
-                        :best-for        "Weizen, Weizenbocks"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Top fermenting Weizenbier yeast. Intensely spicy, clovey and phenolic. High attenuation."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0920"}))
+                       {cbf/min-temperature 12.78
+                        cbf/name            "CL-0920 German Wheat BT"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Weizen, Weizenbocks"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Top fermenting Weizenbier yeast. Intensely spicy, clovey and phenolic. High attenuation."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0920"}))
 
 
 (def cl-0930-german-weiss
@@ -576,17 +578,17 @@
    
    Full, earthy character."
   (yeasts/build-yeasts :cl-0930-german-weiss
-                       {:min-temperature 12.78
-                        :name            "CL-0930 German Weiss"
-                        :max-temperature 20.0
-                        :type            "Wheat"
-                        :best-for        "Weiss, Weizen, other Southern German Wheat styles"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Milder than German Wheat #1, this strain still produces the desired clove and phenol character, but to a lesser degree. Full, earthy character."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-0930"}))
+                       {cbf/min-temperature 12.78
+                        cbf/name            "CL-0930 German Weiss"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Weiss, Weizen, other Southern German Wheat styles"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Milder than German Wheat #1, this strain still produces the desired clove and phenol character, but to a lesser degree. Full, earthy character."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0930"}))
 
 
 (def cl-0980-american-white-ale
@@ -595,17 +597,17 @@
    Low flocculation leaves cloudy Hefe-Weizen finish. 
    Smooth flavor makes a great unfiltered wheat beer."
   (yeasts/build-yeasts :cl-0980-american-white-ale
-                       {:min-temperature 12.78
-                        :name            "CL-0980 American White Ale"
-                        :max-temperature 20.0
-                        :type            "Wheat"
-                        :best-for        "Hefe-Weizen, American Wheat"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Smooth wheat yeast with a round, clean, malt flavor. Low flocculation leaves cloudy Hefe-Weizen finish. Smooth flavor makes a great unfiltered wheat beer."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "CL-0980"}))
+                       {cbf/min-temperature 12.78
+                        cbf/name            "CL-0980 American White Ale"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Hefe-Weizen, American Wheat"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Smooth wheat yeast with a round, clean, malt flavor. Low flocculation leaves cloudy Hefe-Weizen finish. Smooth flavor makes a great unfiltered wheat beer."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-0980"}))
 
 
 (def cl-5200-brettanomyces-lambicus
@@ -614,17 +616,17 @@
    Contributes horsey, old leather flavor complex to Belgian lambics. 
    Slow growing yeast that takes weeks to ferment and months to develop fully."
   (yeasts/build-yeasts :cl-5200-brettanomyces-lambicus
-                       {:min-temperature 8.89
-                        :name            "CL-5200 Brettanomyces Lambicus"
-                        :max-temperature 20.0
-                        :type            "Ale"
-                        :best-for        "Belgian Lambic beers"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Wild yeast strain associated with Belgian breweries. Contributes horsey, old leather flavor complex to Belgian lambics. Slow growing yeast that takes weeks to ferment and months to develop fully."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-5200"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "CL-5200 Brettanomyces Lambicus"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Lambic beers"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Wild yeast strain associated with Belgian breweries. Contributes horsey, old leather flavor complex to Belgian lambics. Slow growing yeast that takes weeks to ferment and months to develop fully."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-5200"}))
 
 
 (def cl-5600-pediococcus-damnosus
@@ -633,17 +635,17 @@
    Produces large amounts of lactic acid and diacytl. 
    Prefers anaerobic conditions."
   (yeasts/build-yeasts :cl-5600-pediococcus-damnosus
-                       {:min-temperature 8.89
-                        :name            "CL-5600 Pediococcus Damnosus"
-                        :max-temperature 20.0
-                        :type            "Ale"
-                        :best-for        "Belgian Lambic beers"
-                        :laboratory      "Brewtek"
-                        :attenuation     0.765
-                        :notes           "Slow growing bacteria used in secondary to create lactic acid flavor in Belgian lambics. Produces large amounts of lactic acid and diacytl. Prefers anaerobic conditions."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "CL-5600"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "CL-5600 Pediococcus Damnosus"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Lambic beers"
+                        cbf/laboratory      "Brewtek"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Slow growing bacteria used in secondary to create lactic acid flavor in Belgian lambics. Produces large amounts of lactic acid and diacytl. Prefers anaerobic conditions."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "CL-5600"}))
 
 
 (def brewtek

--- a/src/common_beer_data/yeasts/dcl_fermentis.cljc
+++ b/src/common_beer_data/yeasts/dcl_fermentis.cljc
@@ -2,7 +2,9 @@
   "Data for yeasts cultivated by DCL/Fermentis.
    
    https://fermentis.com/en/fermentation-solutions/beer/"
-  (:require [common-beer-data.yeasts.yeasts :as yeasts]))
+  {:added "1.0"}
+  (:require [common-beer-data.yeasts.yeasts :as yeasts]
+            [common-beer-format.yeasts :as cbf]))
 
 
 (def k-97-safale-german-ale
@@ -10,17 +12,17 @@
    
    Good for wheat beers, weizens and light ales."
   (yeasts/build-yeasts :k-97-safale-german-ale
-                       {:min-temperature 15.0
-                        :name            "K-97 SafAle German Ale"
-                        :max-temperature 24.0
-                        :type            "Ale"
-                        :best-for        "High attenuation ales, wheat beers and weizens."
-                        :laboratory      "DCL/Fermentis"
-                        :attenuation     0.765
-                        :notes           "Low sedimentation yeast, sometimes used in open fermentation. Good for wheat beers, weizens and light ales."
-                        :flocculation    "Medium"
-                        :form            "Dry"
-                        :product-id      "K-97"}))
+                       {cbf/min-temperature 15.0
+                        cbf/name            "K-97 SafAle German Ale"
+                        cbf/max-temperature 24.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "High attenuation ales, wheat beers and weizens."
+                        cbf/laboratory      "DCL/Fermentis"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Low sedimentation yeast, sometimes used in open fermentation. Good for wheat beers, weizens and light ales."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Dry"
+                        cbf/product-id      "K-97"}))
 
 
 (def s-04-safale-english-ale
@@ -29,17 +31,17 @@
    Quick attenuation helps to produce a clean, crisp, clear ale. 
    Can be used in a wide range of ales."
   (yeasts/build-yeasts :s-04-safale-english-ale
-                       {:min-temperature 15.0
-                        :name            "S-04 SafAle English Ale"
-                        :max-temperature 24.0
-                        :type            "Ale"
-                        :best-for        "Great general purpose ale yeast."
-                        :laboratory      "DCL/Fermentis"
-                        :attenuation     0.765
-                        :notes           "Fast starting, fast fermenting yeast. Quick attenuation helps to produce a clean, crisp, clear ale. Can be used in a wide range of ales."
-                        :flocculation    "Medium"
-                        :form            "Dry"
-                        :product-id      "S-04"}))
+                       {cbf/min-temperature 15.0
+                        cbf/name            "S-04 SafAle English Ale"
+                        cbf/max-temperature 24.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "Great general purpose ale yeast."
+                        cbf/laboratory      "DCL/Fermentis"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Fast starting, fast fermenting yeast. Quick attenuation helps to produce a clean, crisp, clear ale. Can be used in a wide range of ales."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Dry"
+                        cbf/product-id      "S-04"}))
 
 
 (def s-189-saflager-german-lager
@@ -48,17 +50,17 @@
    Produces wide range of continental lagers and pilsners. 
    Clean finish."
   (yeasts/build-yeasts :s-189-saflager-german-lager
-                       {:min-temperature 8.89
-                        :name            "S-189 SafLager German Lager"
-                        :max-temperature 13.33
-                        :type            "Lager"
-                        :best-for        "Wide range of lagers and pilsners."
-                        :laboratory      "DCL/Fermentis"
-                        :attenuation     0.765
-                        :notes           "Popular lager yeast strain. Produces wide range of continental lagers and pilsners. Clean finish."
-                        :flocculation    "High"
-                        :form            "Dry"
-                        :product-id      "S-189"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "S-189 SafLager German Lager"
+                        cbf/max-temperature 13.33
+                        cbf/type            "Lager"
+                        cbf/best-for        "Wide range of lagers and pilsners."
+                        cbf/laboratory      "DCL/Fermentis"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Popular lager yeast strain. Produces wide range of continental lagers and pilsners. Clean finish."
+                        cbf/flocculation    "High"
+                        cbf/form            "Dry"
+                        cbf/product-id      "S-189"}))
 
 
 (def s-23-saflager-west-european-lager
@@ -67,17 +69,17 @@
    Performs well at low temperature. 
    High flocculation and attenuation for a clean German finish."
   (yeasts/build-yeasts :s-23-saflager-west-european-lager
-                       {:min-temperature 7.78
-                        :name            "S-23 SafLager West European Lager"
-                        :max-temperature 10.0
-                        :type            "Lager"
-                        :best-for        "German style Lagers and Pilsners."
-                        :laboratory      "DCL/Fermentis"
-                        :attenuation     0.765
-                        :notes           "German lager yeast strain. Performs well at low temperature. High flocculation and attenuation for a clean German finish."
-                        :flocculation    "High"
-                        :form            "Dry"
-                        :product-id      "S-23"}))
+                       {cbf/min-temperature 7.78
+                        cbf/name            "S-23 SafLager West European Lager"
+                        cbf/max-temperature 10.0
+                        cbf/type            "Lager"
+                        cbf/best-for        "German style Lagers and Pilsners."
+                        cbf/laboratory      "DCL/Fermentis"
+                        cbf/attenuation     0.765
+                        cbf/notes           "German lager yeast strain. Performs well at low temperature. High flocculation and attenuation for a clean German finish."
+                        cbf/flocculation    "High"
+                        cbf/form            "Dry"
+                        cbf/product-id      "S-23"}))
 
 
 (def s-33-safbrew-ale
@@ -86,17 +88,17 @@
    Very consistent, clean finish. 
    High attenuation and good flavor profile."
   (yeasts/build-yeasts :s-33-safbrew-ale
-                       {:min-temperature 18.33
-                        :name            "S-33 SafBrew Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Most ales."
-                        :laboratory      "DCL/Fermentis"
-                        :attenuation     0.765
-                        :notes           "General purpose ale yeast, widely used. Very consistent, clean finish. High attenuation and good flavor profile."
-                        :flocculation    "Medium"
-                        :form            "Dry"
-                        :product-id      "S-33"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "S-33 SafBrew Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Most ales."
+                        cbf/laboratory      "DCL/Fermentis"
+                        cbf/attenuation     0.765
+                        cbf/notes           "General purpose ale yeast, widely used. Very consistent, clean finish. High attenuation and good flavor profile."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Dry"
+                        cbf/product-id      "S-33"}))
 
 
 (def t-58-safbrew-specialty-ale
@@ -105,33 +107,33 @@
    Solid yeast formation at end of fermentation. 
    Widely used for bottle and cask conditioning."
   (yeasts/build-yeasts :t-58-safbrew-specialty-ale
-                       {:min-temperature 15.56
-                        :name            "T-58 SafBrew Specialty Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Complex ales."
-                        :laboratory      "DCL/Fermentis"
-                        :attenuation     0.765
-                        :notes           "Estery, somewhat spicy ale yeast. Solid yeast formation at end of fermentation. Widely used for bottle and cask conditioning."
-                        :flocculation    "Medium"
-                        :form            "Dry"
-                        :product-id      "T-58"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "T-58 SafBrew Specialty Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Complex ales."
+                        cbf/laboratory      "DCL/Fermentis"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Estery, somewhat spicy ale yeast. Solid yeast formation at end of fermentation. Widely used for bottle and cask conditioning."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Dry"
+                        cbf/product-id      "T-58"}))
 
 
 (def us-05-safale-american
   "American ale yeast that produces well balanced beers with low diacetyl and a very clean, crisp end palate."
   (yeasts/build-yeasts :us-05-safale-american
-                       {:min-temperature 15.0
-                        :name            "US-05 Safale American"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "American ale, other clean finish ales"
-                        :laboratory      "DCL/Fermentis"
-                        :attenuation     0.765
-                        :notes           "American ale yeast that produces well balanced beers with low diacetyl and a very clean, crisp end palate."
-                        :flocculation    "Medium"
-                        :form            "Dry"
-                        :product-id      "US-05"}))
+                       {cbf/min-temperature 15.0
+                        cbf/name            "US-05 Safale American"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "American ale, other clean finish ales"
+                        cbf/laboratory      "DCL/Fermentis"
+                        cbf/attenuation     0.765
+                        cbf/notes           "American ale yeast that produces well balanced beers with low diacetyl and a very clean, crisp end palate."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Dry"
+                        cbf/product-id      "US-05"}))
 
 
 (def w-34-70-saflager-lager
@@ -139,17 +141,17 @@
    
    Their most popular strain for lagers."
   (yeasts/build-yeasts :w-34-70-saflager-lager
-                       {:min-temperature 8.89
-                        :name            "W-34/70 Saflager Lager"
-                        :max-temperature 15.0
-                        :type            "Lager"
-                        :best-for        "European lagers"
-                        :laboratory      "DCL/Fermentis"
-                        :attenuation     0.765
-                        :notes           "A famous yeast strain from Weihenstephan Germany used worldwide in brewing. Their most popular strain for lagers."
-                        :flocculation    "High"
-                        :form            "Dry"
-                        :product-id      "W-34/70"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "W-34/70 Saflager Lager"
+                        cbf/max-temperature 15.0
+                        cbf/type            "Lager"
+                        cbf/best-for        "European lagers"
+                        cbf/laboratory      "DCL/Fermentis"
+                        cbf/attenuation     0.765
+                        cbf/notes           "A famous yeast strain from Weihenstephan Germany used worldwide in brewing. Their most popular strain for lagers."
+                        cbf/flocculation    "High"
+                        cbf/form            "Dry"
+                        cbf/product-id      "W-34/70"}))
 
 
 (def wb-06-safbrew-wheat
@@ -157,17 +159,17 @@
    
    The yeast produces a subtle estery and phenlol flavor typical of wheat beers."
   (yeasts/build-yeasts :wb-06-safbrew-wheat
-                       {:min-temperature 15.0
-                        :name            "WB-06 Safbrew Wheat"
-                        :max-temperature 23.89
-                        :type            "Wheat"
-                        :best-for        "Wheat beers"
-                        :laboratory      "DCL/Fermentis"
-                        :attenuation     0.765
-                        :notes           "A specialty yeast for wheat beer fermentation. The yeast produces a subtle estery and phenlol flavor typical of wheat beers."
-                        :flocculation    "Medium"
-                        :form            "Dry"
-                        :product-id      "WB-06"}))
+                       {cbf/min-temperature 15.0
+                        cbf/name            "WB-06 Safbrew Wheat"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Wheat beers"
+                        cbf/laboratory      "DCL/Fermentis"
+                        cbf/attenuation     0.765
+                        cbf/notes           "A specialty yeast for wheat beer fermentation. The yeast produces a subtle estery and phenlol flavor typical of wheat beers."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Dry"
+                        cbf/product-id      "WB-06"}))
 
 
 (def dcl-fermentis

--- a/src/common_beer_data/yeasts/lallemand.cljc
+++ b/src/common_beer_data/yeasts/lallemand.cljc
@@ -1,7 +1,9 @@
 (ns common-beer-data.yeasts.lallemand
   "Data for yeasts cultivated by Lallemand.
    https://www.lallemandbrewing.com/en/canada/products/brewing-yeast/"
-  (:require [common-beer-data.yeasts.yeasts :as yeasts]))
+  {:added "1.0"}
+  (:require [common-beer-data.yeasts.yeasts :as yeasts]
+            [common-beer-format.yeasts :as cbf]))
 
 
 (def lalvin-71b-1122
@@ -11,17 +13,17 @@
    Partial metabolism of malic acid helps soften the wine. 
    May produce significant esters, making it a good choice for concentrates."
   (yeasts/build-yeasts :lalvin-71b-1122
-                       {:min-temperature 15.0
-                        :name            "71B-1122 Lalvin"
-                        :max-temperature 30.0
-                        :type            "Wine"
-                        :best-for        "Young wines such as nouveau, blush and sugar white."
-                        :laboratory      "Lallemand"
-                        :attenuation     0.765
-                        :notes           "Rapid starter with constant and complete fermentation. Ability to metabolize high amounts (20-40%) of malic acid. Partial metabolism of malic acid helps soften the wine. May produce significant esters, making it a good choice for concentrates."
-                        :flocculation    "High"
-                        :form            "Dry"
-                        :product-id      "71B-1122"}))
+                       {cbf/min-temperature 15.0
+                        cbf/name            "71B-1122 Lalvin"
+                        cbf/max-temperature 30.0
+                        cbf/type            "Wine"
+                        cbf/best-for        "Young wines such as nouveau, blush and sugar white."
+                        cbf/laboratory      "Lallemand"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Rapid starter with constant and complete fermentation. Ability to metabolize high amounts (20-40%) of malic acid. Partial metabolism of malic acid helps soften the wine. May produce significant esters, making it a good choice for concentrates."
+                        cbf/flocculation    "High"
+                        cbf/form            "Dry"
+                        cbf/product-id      "71B-1122"}))
 
 
 (def lalvin-d-47
@@ -31,17 +33,17 @@
    Use yeast nutrients if making mead. 
    Saccharomyces Cerevisiae."
   (yeasts/build-yeasts :lalvin-d-47
-                       {:min-temperature 10.0
-                        :name            "D-47 Lalvin"
-                        :max-temperature 30.0
-                        :type            "Wine"
-                        :best-for        "White wines such as Chardonnay and Rose. Also good for mead."
-                        :laboratory      "Lallemand"
-                        :attenuation     0.765
-                        :notes           "Recommended for white variety wines such as Chardonnay and Rose as well as Mead. Low foaming, quick fermenting, forming a compact lees at the end of fermentation. Use yeast nutrients if making mead. Saccharomyces Cerevisiae."
-                        :flocculation    "High"
-                        :form            "Dry"
-                        :product-id      "D-47"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "D-47 Lalvin"
+                        cbf/max-temperature 30.0
+                        cbf/type            "Wine"
+                        cbf/best-for        "White wines such as Chardonnay and Rose. Also good for mead."
+                        cbf/laboratory      "Lallemand"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Recommended for white variety wines such as Chardonnay and Rose as well as Mead. Low foaming, quick fermenting, forming a compact lees at the end of fermentation. Use yeast nutrients if making mead. Saccharomyces Cerevisiae."
+                        cbf/flocculation    "High"
+                        cbf/form            "Dry"
+                        cbf/product-id      "D-47"}))
 
 
 (def lalvin-ec-1118
@@ -51,17 +53,17 @@
    High alcohol tolerance, compact lees and good flocculation.
    Relatively neutral flavor and aroma."
   (yeasts/build-yeasts :lalvin-ec-1118
-                       {:min-temperature 7.22
-                        :name            "EC-1118 Lalvin"
-                        :max-temperature 35.0
-                        :type            "Wine"
-                        :best-for        "All types of wine and also cider."
-                        :laboratory      "Lallemand"
-                        :attenuation     0.765
-                        :notes           "Low production of foam, volatile acid and H2S. Ferments over a wide temperature range. High alcohol tolerance, compact lees and good flocculation. Relatively neutral flavor and aroma."
-                        :flocculation    "High"
-                        :form            "Dry"
-                        :product-id      "EC-1118"}))
+                       {cbf/min-temperature 7.22
+                        cbf/name            "EC-1118 Lalvin"
+                        cbf/max-temperature 35.0
+                        cbf/type            "Wine"
+                        cbf/best-for        "All types of wine and also cider."
+                        cbf/laboratory      "Lallemand"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Low production of foam, volatile acid and H2S. Ferments over a wide temperature range. High alcohol tolerance, compact lees and good flocculation. Relatively neutral flavor and aroma."
+                        cbf/flocculation    "High"
+                        cbf/form            "Dry"
+                        cbf/product-id      "EC-1118"}))
 
 
 (def lalvin-k1v-1116
@@ -71,17 +73,17 @@
    Capable of surviving difficult conditions such as low nutrient or high SO2 levels. 
    Has low volatile action."
   (yeasts/build-yeasts :lalvin-k1v-1116
-                       {:min-temperature 15.0
-                        :name            "K1V-1116 Lalvin"
-                        :max-temperature 30.0
-                        :type            "Wine"
-                        :best-for        "Souvingnon Blanc, Chenin Blanc and Seyval."
-                        :laboratory      "Lallemand"
-                        :attenuation     0.765
-                        :notes           "Used for white grape varieties. Rapid starter with constant and complete fermentation. Capable of surviving difficult conditions such as low nutrient or high SO2 levels. Has low volatile action."
-                        :flocculation    "Medium"
-                        :form            "Dry"
-                        :product-id      "K1V-1116"}))
+                       {cbf/min-temperature 15.0
+                        cbf/name            "K1V-1116 Lalvin"
+                        cbf/max-temperature 30.0
+                        cbf/type            "Wine"
+                        cbf/best-for        "Souvingnon Blanc, Chenin Blanc and Seyval."
+                        cbf/laboratory      "Lallemand"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Used for white grape varieties. Rapid starter with constant and complete fermentation. Capable of surviving difficult conditions such as low nutrient or high SO2 levels. Has low volatile action."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Dry"
+                        cbf/product-id      "K1V-1116"}))
 
 
 (def lalvin-rc-212
@@ -91,17 +93,17 @@
    Low foaming and moderate speed fermenting. 
    Saccharomyces Cerevisiae."
   (yeasts/build-yeasts :lalvin-rc-212
-                       {:min-temperature 15.0
-                        :name            "RC-212 Lalvin"
-                        :max-temperature 30.0
-                        :type            "Wine"
-                        :best-for        "Red wines."
-                        :laboratory      "Lallemand"
-                        :attenuation     0.765
-                        :notes           "RC212 recommended for red variety wines and high gravity beers. Alcohol tolerance in the 12-14% range. Low foaming and moderate speed fermenting. Saccharomyces Cerevisiae."
-                        :flocculation    "Medium"
-                        :form            "Dry"
-                        :product-id      "RC-212"}))
+                       {cbf/min-temperature 15.0
+                        cbf/name            "RC-212 Lalvin"
+                        cbf/max-temperature 30.0
+                        cbf/type            "Wine"
+                        cbf/best-for        "Red wines."
+                        cbf/laboratory      "Lallemand"
+                        cbf/attenuation     0.765
+                        cbf/notes           "RC212 recommended for red variety wines and high gravity beers. Alcohol tolerance in the 12-14% range. Low foaming and moderate speed fermenting. Saccharomyces Cerevisiae."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Dry"
+                        cbf/product-id      "RC-212"}))
 
 
 (def lallemand

--- a/src/common_beer_data/yeasts/white_labs.cljc
+++ b/src/common_beer_data/yeasts/white_labs.cljc
@@ -2,7 +2,9 @@
   "Data for yeasts cultivated by White Labs.
    
    https://www.whitelabs.com/product-landing?id=1"
-  (:require [common-beer-data.yeasts.yeasts :as yeasts]))
+  {:added "1.0"}
+  (:require [common-beer-data.yeasts.yeasts :as yeasts]
+            [common-beer-format.yeasts :as cbf]))
 
 
 (def wlp001-california-ale
@@ -10,17 +12,17 @@
    
    Accentuates hop flavor Versitile - can be used to make any style ale."
   (yeasts/build-yeasts :wlp001-california-ale
-                       {:min-temperature 20.0
-                        :name            "WLP001 California Ale"
-                        :max-temperature 22.78
-                        :type            "Ale"
-                        :best-for        "American Style Ales, Ambers, Pale Ales, Brown Ale, Strong Ale"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Very clean flavor, balance and stability. Accentuates hop flavor Versitile - can be used to make any style ale."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "WLP001"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP001 California Ale"
+                        cbf/max-temperature 22.78
+                        cbf/type            "Ale"
+                        cbf/best-for        "American Style Ales, Ambers, Pale Ales, Brown Ale, Strong Ale"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Very clean flavor, balance and stability. Accentuates hop flavor Versitile - can be used to make any style ale."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP001"}))
 
 
 (def wlp002-english-ale
@@ -28,17 +30,17 @@
    
    Leaves a clear beer with some residual sweetness."
   (yeasts/build-yeasts :wlp002-english-ale
-                       {:min-temperature 18.33
-                        :name            "WLP002 English Ale"
-                        :max-temperature 20.0
-                        :type            "Ale"
-                        :best-for        "English Pale Ale, ESB, India Pale Ale, Brown Ale, Porter, Sweet Stouts and Strong Ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Classic ESB strain best for English style milds, bitters, porters and English style stouts. Leaves a clear beer with some residual sweetness."
-                        :flocculation    "Very High"
-                        :form            "Liquid"
-                        :product-id      "WLP002"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP002 English Ale"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "English Pale Ale, ESB, India Pale Ale, Brown Ale, Porter, Sweet Stouts and Strong Ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Classic ESB strain best for English style milds, bitters, porters and English style stouts. Leaves a clear beer with some residual sweetness."
+                        cbf/flocculation    "Very High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP002"}))
 
 
 (def wlp003-german-ale-ii
@@ -46,17 +48,17 @@
    
    Clean flavor, but with more ester production than regular German Ale Yeast."
   (yeasts/build-yeasts :wlp003-german-ale-ii
-                       {:min-temperature 18.33
-                        :name            "WLP003 German Ale II"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "Kolsch, Alt and German Pale Ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Strong sulfer component will reduce with aging. Clean flavor, but with more ester production than regular German Ale Yeast."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP003"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP003 German Ale II"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "Kolsch, Alt and German Pale Ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Strong sulfer component will reduce with aging. Clean flavor, but with more ester production than regular German Ale Yeast."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP003"}))
 
 
 (def wlp004-irish-ale-yeast
@@ -64,17 +66,17 @@
    
    Produces slight hint of diacetyl balanced by a light fruitiness and a slightly dry crispness."
   (yeasts/build-yeasts :wlp004-irish-ale-yeast
-                       {:min-temperature 18.33
-                        :name            "WLP004 Irish Ale Yeast"
-                        :max-temperature 20.0
-                        :type            "Ale"
-                        :best-for        "Irish Ales, Stouts, Porters, Browns, Reds and Pale Ale"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Excellent for Irish Stouts. Produces slight hint of diacetyl balanced by a light fruitiness and a slightly dry crispness."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP004"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP004 Irish Ale Yeast"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "Irish Ales, Stouts, Porters, Browns, Reds and Pale Ale"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Excellent for Irish Stouts. Produces slight hint of diacetyl balanced by a light fruitiness and a slightly dry crispness."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP004"}))
 
 
 (def wlp005-british-ale
@@ -82,17 +84,17 @@
    
    Produces a malty flavored beer."
   (yeasts/build-yeasts :wlp005-british-ale
-                       {:min-temperature 19.44
-                        :name            "WLP005 British Ale"
-                        :max-temperature 23.33
-                        :type            "Ale"
-                        :best-for        "Excellent for all English style ales including bitters, pale ale, porters and brown ale."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "This yeast has higher attenuation than the White Labs English Ale yeast strains. Produces a malty flavored beer."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "WLP005"}))
+                       {cbf/min-temperature 19.44
+                        cbf/name            "WLP005 British Ale"
+                        cbf/max-temperature 23.33
+                        cbf/type            "Ale"
+                        cbf/best-for        "Excellent for all English style ales including bitters, pale ale, porters and brown ale."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "This yeast has higher attenuation than the White Labs English Ale yeast strains. Produces a malty flavored beer."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP005"}))
 
 
 (def wlp006-bedford-british-ale
@@ -102,17 +104,17 @@
    Distinctive ester profile. 
    Good for most English ale styles."
   (yeasts/build-yeasts :wlp006-bedford-british-ale
-                       {:min-temperature 18.33
-                        :name            "WLP006 Bedford British Ale"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "English style ales - bitter, pale, porter and brown ale"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "High attenuation. Ferments dry with high flocculation. Distinctive ester profile. Good for most English ale styles."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "WLP006"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP006 Bedford British Ale"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "English style ales - bitter, pale, porter and brown ale"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "High attenuation. Ferments dry with high flocculation. Distinctive ester profile. Good for most English ale styles."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP006"}))
 
 
 (def wlp007-dry-english-ale
@@ -121,17 +123,17 @@
    Similar to White labs English Ale yeast, but more attentive. 
    Suitable for high gravity ales."
   (yeasts/build-yeasts :wlp007-dry-english-ale
-                       {:min-temperature 18.33
-                        :name            "WLP007 Dry English Ale"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "Pale Ales, Amber, ESB, Brown Ales, Strong Ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Clean, Highly flocculant, and highly attentive yeast. Similar to White labs English Ale yeast, but more attentive. Suitable for high gravity ales."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "WLP007"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP007 Dry English Ale"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "Pale Ales, Amber, ESB, Brown Ales, Strong Ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Clean, Highly flocculant, and highly attentive yeast. Similar to White labs English Ale yeast, but more attentive. Suitable for high gravity ales."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP007"}))
 
 
 (def wlp008-east-coast-ale
@@ -139,17 +141,17 @@
    
    Very clean with low esters."
   (yeasts/build-yeasts :wlp008-east-coast-ale
-                       {:min-temperature 20.0
-                        :name            "WLP008 East Coast Ale"
-                        :max-temperature 22.78
-                        :type            "Ale"
-                        :best-for        "American Ales, Golden ales, Blonde Ale, Pale Ale and German Alt styles"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "White labs \"Brewer Patriot\" strain can be used to reproduce many of the American versions of classic beer styles. Very clean with low esters."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP008"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP008 East Coast Ale"
+                        cbf/max-temperature 22.78
+                        cbf/type            "Ale"
+                        cbf/best-for        "American Ales, Golden ales, Blonde Ale, Pale Ale and German Alt styles"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "White labs \"Brewer Patriot\" strain can be used to reproduce many of the American versions of classic beer styles. Very clean with low esters."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP008"}))
 
 
 (def wlp009-australian-ale-yeast
@@ -159,17 +161,17 @@
    Bready character. 
    Can ferment clean at high temperatures."
   (yeasts/build-yeasts :wlp009-australian-ale-yeast
-                       {:min-temperature 18.33
-                        :name            "WLP009 Australian Ale Yeast"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "Australian Ales, English Ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "White Labs entry for Australian Ales. Produces a clean, malty finish with pleasant ester character. Bready character. Can ferment clean at high temperatures."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "WLP009"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP009 Australian Ale Yeast"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "Australian Ales, English Ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "White Labs entry for Australian Ales. Produces a clean, malty finish with pleasant ester character. Bready character. Can ferment clean at high temperatures."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP009"}))
 
 
 (def wlp011-european-ale
@@ -178,17 +180,17 @@
    Low ester production, low sulfer, gives a clean profile. 
    Low attenuation contributes to malty taste."
   (yeasts/build-yeasts :wlp011-european-ale
-                       {:min-temperature 18.33
-                        :name            "WLP011 European Ale"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "Alt, Kolsch, malty English Ales, Fruit beers"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Malty, Northern European ale yeast. Low ester production, low sulfer, gives a clean profile. Low attenuation contributes to malty taste."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP011"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP011 European Ale"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "Alt, Kolsch, malty English Ales, Fruit beers"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Malty, Northern European ale yeast. Low ester production, low sulfer, gives a clean profile. Low attenuation contributes to malty taste."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP011"}))
 
 
 (def wlp013-london-ale
@@ -197,17 +199,17 @@
    Produces a complex, oak flavored ester character. 
    Hop bitterness comes through well."
   (yeasts/build-yeasts :wlp013-london-ale
-                       {:min-temperature 18.89
-                        :name            "WLP013 London Ale"
-                        :max-temperature 21.67
-                        :type            "Ale"
-                        :best-for        "Classic British Pale Ales, Bitters and Stouts"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Dry, malty ale yeast. Produces a complex, oak flavored ester character. Hop bitterness comes through well."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP013"}))
+                       {cbf/min-temperature 18.89
+                        cbf/name            "WLP013 London Ale"
+                        cbf/max-temperature 21.67
+                        cbf/type            "Ale"
+                        cbf/best-for        "Classic British Pale Ales, Bitters and Stouts"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Dry, malty ale yeast. Produces a complex, oak flavored ester character. Hop bitterness comes through well."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP013"}))
 
 
 (def wlp022-essex-ale-yeast
@@ -217,17 +219,17 @@
    Well suited for top cropping (collecting). 
    Does not flocculate as much as WLP005 or WLP002."
   (yeasts/build-yeasts :wlp022-essex-ale-yeast
-                       {:min-temperature 18.89
-                        :name            "WLP022 Essex Ale Yeast"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "British milds, pale ales, bitters, stouts."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Flavorful British yeast with a drier finish than many ale yeasts. Bready and fruity in character. Well suited for top cropping (collecting). Does not flocculate as much as WLP005 or WLP002."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP022"}))
+                       {cbf/min-temperature 18.89
+                        cbf/name            "WLP022 Essex Ale Yeast"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "British milds, pale ales, bitters, stouts."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Flavorful British yeast with a drier finish than many ale yeasts. Bready and fruity in character. Well suited for top cropping (collecting). Does not flocculate as much as WLP005 or WLP002."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP022"}))
 
 
 (def wlp023-burton-ale
@@ -235,17 +237,17 @@
    
    Flavors include apple, pear, and clover honey."
   (yeasts/build-yeasts :wlp023-burton-ale
-                       {:min-temperature 20.0
-                        :name            "WLP023 Burton Ale"
-                        :max-temperature 22.78
-                        :type            "Ale"
-                        :best-for        "All English styles including Pale Ale, IPA, Porter, Stout and Bitters."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Burton-on-trent yeast produces a complex character. Flavors include apple, pear, and clover honey."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP023"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP023 Burton Ale"
+                        cbf/max-temperature 22.78
+                        cbf/type            "Ale"
+                        cbf/best-for        "All English styles including Pale Ale, IPA, Porter, Stout and Bitters."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Burton-on-trent yeast produces a complex character. Flavors include apple, pear, and clover honey."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP023"}))
 
 
 (def wlp025-southwold-ale
@@ -254,17 +256,17 @@
    Products complex fruity and citrus flavors. 
    Slight sulfer production, but this will fade with aging."
   (yeasts/build-yeasts :wlp025-southwold-ale
-                       {:min-temperature 18.89
-                        :name            "WLP025 Southwold Ale"
-                        :max-temperature 20.56
-                        :type            "Ale"
-                        :best-for        "British bitters and pale ales."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "From Suffolk county. Products complex fruity and citrus flavors. Slight sulfer production, but this will fade with aging."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP025"}))
+                       {cbf/min-temperature 18.89
+                        cbf/name            "WLP025 Southwold Ale"
+                        cbf/max-temperature 20.56
+                        cbf/type            "Ale"
+                        cbf/best-for        "British bitters and pale ales."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "From Suffolk county. Products complex fruity and citrus flavors. Slight sulfer production, but this will fade with aging."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP025"}))
 
 
 (def wlp026-premium-bitter-ale
@@ -274,33 +276,33 @@
    High attenuation - ferments strong and dry. 
    Suitable for high gravity beers."
   (yeasts/build-yeasts :wlp026-premium-bitter-ale
-                       {:min-temperature 19.44
-                        :name            "WLP026 Premium Bitter Ale"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "All English ales including bitters, milds, ESB, Porter, Stout and Barley Wine"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "From Staffordshire England. Mild, but complex estery flavor. High attenuation - ferments strong and dry. Suitable for high gravity beers."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP026"}))
+                       {cbf/min-temperature 19.44
+                        cbf/name            "WLP026 Premium Bitter Ale"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "All English ales including bitters, milds, ESB, Porter, Stout and Barley Wine"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "From Staffordshire England. Mild, but complex estery flavor. High attenuation - ferments strong and dry. Suitable for high gravity beers."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP026"}))
 
 
 (def wlp028-edinburgh-ale
   "Malty strong ale yeast. Reproduces complex, malty, flavorful schottish ales. Hop character comes through well."
   (yeasts/build-yeasts :wlp028-edinburgh-ale
-                       {:min-temperature 18.33
-                        :name            "WLP028 Edinburgh Ale"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "Strong Scottish style ales, ESB, Irish Reds"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Malty strong ale yeast. Reproduces complex, malty, flavorful schottish ales. Hop character comes through well."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP028"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP028 Edinburgh Ale"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "Strong Scottish style ales, ESB, Irish Reds"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Malty strong ale yeast. Reproduces complex, malty, flavorful schottish ales. Hop character comes through well."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP028"}))
 
 
 (def wlp029-german-ale-kolsch
@@ -309,17 +311,17 @@
    Accentuates hop flavors. 
    Slight sulfer flavor will fade with age and leave a clean, lager like ale."
   (yeasts/build-yeasts :wlp029-german-ale-kolsch
-                       {:min-temperature 18.33
-                        :name            "WLP029 German Ale/Kolsch"
-                        :max-temperature 20.56
-                        :type            "Ale"
-                        :best-for        "Kolsch, Altbiers, Pale Ales, Blonde and Honey Ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Great for light beers. Accentuates hop flavors. Slight sulfer flavor will fade with age and leave a clean, lager like ale."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP029"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP029 German Ale/Kolsch"
+                        cbf/max-temperature 20.56
+                        cbf/type            "Ale"
+                        cbf/best-for        "Kolsch, Altbiers, Pale Ales, Blonde and Honey Ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Great for light beers. Accentuates hop flavors. Slight sulfer flavor will fade with age and leave a clean, lager like ale."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP029"}))
 
 
 (def wlp033-klassic-ale-yeast
@@ -328,17 +330,17 @@
    Produces ester character, and allows hop flavor through. 
    Leaves a slightly sweet malt character in ales."
   (yeasts/build-yeasts :wlp033-klassic-ale-yeast
-                       {:min-temperature 18.89
-                        :name            "WLP033 Klassic Ale Yeast"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "Bitters, milds, porters stouts and scottish ale styles."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Traditional English Ale style yeast. Produces ester character, and allows hop flavor through. Leaves a slightly sweet malt character in ales."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP033"}))
+                       {cbf/min-temperature 18.89
+                        cbf/name            "WLP033 Klassic Ale Yeast"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "Bitters, milds, porters stouts and scottish ale styles."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Traditional English Ale style yeast. Produces ester character, and allows hop flavor through. Leaves a slightly sweet malt character in ales."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP033"}))
 
 
 (def wlp036-dusseldorf-alt-yeast
@@ -347,17 +349,17 @@
    Produces clean, slightly sweet alt beers. 
    Does not accentuate hop flavor like WLP029 does."
   (yeasts/build-yeasts :wlp036-dusseldorf-alt-yeast
-                       {:min-temperature 18.33
-                        :name            "WLP036 Dusseldorf Alt Yeast"
-                        :max-temperature 20.56
-                        :type            "Ale"
-                        :best-for        "Alt biers, Dusseldorf Alts, German Ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Traditional alternative yeast from Dusseldorf, Germany. Produces clean, slightly sweet alt beers. Does not accentuate hop flavor like WLP029 does."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP036"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP036 Dusseldorf Alt Yeast"
+                        cbf/max-temperature 20.56
+                        cbf/type            "Ale"
+                        cbf/best-for        "Alt biers, Dusseldorf Alts, German Ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Traditional alternative yeast from Dusseldorf, Germany. Produces clean, slightly sweet alt beers. Does not accentuate hop flavor like WLP029 does."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP036"}))
 
 
 (def wlp037-yorkshire-square-ale-yeast
@@ -366,17 +368,17 @@
    Expect toasty flavors with malt driven esters. 
    Highly flocculent and a good choice for many English ales."
   (yeasts/build-yeasts :wlp037-yorkshire-square-ale-yeast
-                       {:min-temperature 18.33
-                        :name            "WLP037 Yorkshire Square Ale Yeast"
-                        :max-temperature 20.56
-                        :type            "Ale"
-                        :best-for        "English pale ales, English brown ales and Mild ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "This yeast produces a malty but well balanced profile. Expect toasty flavors with malt driven esters. Highly flocculent and a good choice for many English ales."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "WLP037"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP037 Yorkshire Square Ale Yeast"
+                        cbf/max-temperature 20.56
+                        cbf/type            "Ale"
+                        cbf/best-for        "English pale ales, English brown ales and Mild ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "This yeast produces a malty but well balanced profile. Expect toasty flavors with malt driven esters. Highly flocculent and a good choice for many English ales."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP037"}))
 
 
 (def wlp038-manchester-ale-yeast
@@ -385,17 +387,17 @@
    Moderately flocculent with a clean, dry finish. 
    Low ester profile for producing a balanced English ale."
   (yeasts/build-yeasts :wlp038-manchester-ale-yeast
-                       {:min-temperature 18.33
-                        :name            "WLP038 Manchester Ale Yeast"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "English style ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Top fermenting strain that is good for top-cropping. Moderately flocculent with a clean, dry finish. Low ester profile for producing a balanced English ale."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP038"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP038 Manchester Ale Yeast"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "English style ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Top fermenting strain that is good for top-cropping. Moderately flocculent with a clean, dry finish. Low ester profile for producing a balanced English ale."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP038"}))
 
 
 (def wlp039-nottingham-ale-yeast
@@ -404,17 +406,17 @@
    Medium to low fruit and fusel alcohol production. 
    Good top fermenting yeast for cropping."
   (yeasts/build-yeasts :wlp039-nottingham-ale-yeast
-                       {:min-temperature 18.89
-                        :name            "WLP039 Nottingham Ale Yeast"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "British ales, pale ales, ambers, porters and stouts."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "British style of ale yeast with a very dry finish and high attenuation. Medium to low fruit and fusel alcohol production. Good top fermenting yeast for cropping."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP039"}))
+                       {cbf/min-temperature 18.89
+                        cbf/name            "WLP039 Nottingham Ale Yeast"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "British ales, pale ales, ambers, porters and stouts."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "British style of ale yeast with a very dry finish and high attenuation. Medium to low fruit and fusel alcohol production. Good top fermenting yeast for cropping."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP039"}))
 
 
 (def wlp041-pacific-ale
@@ -424,33 +426,33 @@
    More fruity than WLP002. 
    Suitable for many English and American styles."
   (yeasts/build-yeasts :wlp041-pacific-ale
-                       {:min-temperature 18.33
-                        :name            "WLP041 Pacific Ale"
-                        :max-temperature 20.0
-                        :type            "Ale"
-                        :best-for        "English & American ales including milds, bitters, IPA, porters and English stouts."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Popular yeast from the Pacific Northwest. Leaves a clear and malty profile. More fruity than WLP002. Suitable for many English and American styles."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "WLP041"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP041 Pacific Ale"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "English & American ales including milds, bitters, IPA, porters and English stouts."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Popular yeast from the Pacific Northwest. Leaves a clear and malty profile. More fruity than WLP002. Suitable for many English and American styles."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP041"}))
 
 
 (def wlp051-california-ale-v
   "Similar to White Labs California Ale Yeast, but slightly lower attenuation leaves a fuller bodied beer."
   (yeasts/build-yeasts :wlp051-california-ale-v
-                       {:min-temperature 18.89
-                        :name            "WLP051 California Ale V"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "American style Pales, Ambers, Browns, IPAs, American Strong Ale"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Similar to White Labs California Ale Yeast, but slightly lower attenuation leaves a fuller bodied beer."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "WLP051"}))
+                       {cbf/min-temperature 18.89
+                        cbf/name            "WLP051 California Ale V"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "American style Pales, Ambers, Browns, IPAs, American Strong Ale"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Similar to White Labs California Ale Yeast, but slightly lower attenuation leaves a fuller bodied beer."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP051"}))
 
 
 (def wlp060-american-ale-yeast-blend
@@ -458,17 +460,17 @@
    
    This strain is versatile and adds two other yeast strains that are also clean/neutral in flavor to add a bit of complexity - almost a lager like finish."
   (yeasts/build-yeasts :wlp060-american-ale-yeast-blend
-                       {:min-temperature 20.0
-                        :name            "WLP060 American Ale Yeast Blend"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "American ales with clean finish"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "A blend that celebrates WLP001 (California Ale Yeast's) clean, neutral fermentation. This strain is versatile and adds two other yeast strains that are also clean/neutral in flavor to add a bit of complexity - almost a lager like finish."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP060"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP060 American Ale Yeast Blend"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "American ales with clean finish"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "A blend that celebrates WLP001 (California Ale Yeast's) clean, neutral fermentation. This strain is versatile and adds two other yeast strains that are also clean/neutral in flavor to add a bit of complexity - almost a lager like finish."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP060"}))
 
 
 (def wlp080-cream-ale-yeast-blend
@@ -477,17 +479,17 @@
    A pleasing estery aroma may be perceived. 
    Hop flavors and bitterness are slightly subdued."
   (yeasts/build-yeasts :wlp080-cream-ale-yeast-blend
-                       {:min-temperature 18.33
-                        :name            "WLP080 Cream Ale Yeast Blend"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "Cream Ale, Hybrids"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "A blend of ale and lager yeast strains that work together to create a clean, light American lager style ale. A pleasing estery aroma may be perceived. Hop flavors and bitterness are slightly subdued."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP080"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP080 Cream Ale Yeast Blend"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "Cream Ale, Hybrids"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "A blend of ale and lager yeast strains that work together to create a clean, light American lager style ale. A pleasing estery aroma may be perceived. Hop flavors and bitterness are slightly subdued."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP080"}))
 
 
 (def wlp090-san-diego-super-yeast
@@ -497,17 +499,17 @@
    Alcohol-tolerant and very versatile for a wide variety of styles. 
    Similar to California Ale Yeast WLP001 but it generally ferments faster."
   (yeasts/build-yeasts :wlp090-san-diego-super-yeast
-                       {:min-temperature 18.33
-                        :name            "WLP090 San Diego Super Yeast"
-                        :max-temperature 20.0
-                        :type            "Ale"
-                        :best-for        "IPAs, American ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "A super clean, super-fast fermenting strain. A low ester-producing strain that results in a balanced, neutral flavor and aroma profile. Alcohol-tolerant and very versatile for a wide variety of styles. Similar to California Ale Yeast WLP001 but it generally ferments faster."
-                        :flocculation    "Very High"
-                        :form            "Liquid"
-                        :product-id      "WLP090"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP090 San Diego Super Yeast"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "IPAs, American ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "A super clean, super-fast fermenting strain. A low ester-producing strain that results in a balanced, neutral flavor and aroma profile. Alcohol-tolerant and very versatile for a wide variety of styles. Similar to California Ale Yeast WLP001 but it generally ferments faster."
+                        cbf/flocculation    "Very High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP090"}))
 
 
 (def wlp099-super-high-gravity-ale
@@ -518,17 +520,17 @@
    Refer to White Labs web page for tips on fermenting high gravity ales.
    Colloquially known as \"Turbo Yeast\"."
   (yeasts/build-yeasts :wlp099-super-high-gravity-ale
-                       {:min-temperature 20.56
-                        :name            "WLP099 Super High Gravity Ale"
-                        :max-temperature 23.33
-                        :type            "Ale"
-                        :best-for        "Very high gravity beers and barley wine up to 25% alcohol."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Ferments up to 25% alcohol content. Flavor may vary greatly depending on beer alcohol. English like esters at low gravity, but will become more wine-like as alcohol exceeds 16% ABV. Refer to White Labs web page for tips on fermenting high gravity ales."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP099"}))
+                       {cbf/min-temperature 20.56
+                        cbf/name            "WLP099 Super High Gravity Ale"
+                        cbf/max-temperature 23.33
+                        cbf/type            "Ale"
+                        cbf/best-for        "Very high gravity beers and barley wine up to 25% alcohol."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Ferments up to 25% alcohol content. Flavor may vary greatly depending on beer alcohol. English like esters at low gravity, but will become more wine-like as alcohol exceeds 16% ABV. Refer to White Labs web page for tips on fermenting high gravity ales."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP099"}))
 
 
 (def wlp300-hefeweizen-ale
@@ -536,17 +538,17 @@
    
    Also produces desired cloudy look."
   (yeasts/build-yeasts :wlp300-hefeweizen-ale
-                       {:min-temperature 20.0
-                        :name            "WLP300 Hefeweizen Ale"
-                        :max-temperature 22.22
-                        :type            "Wheat"
-                        :best-for        "German style wheat beers. Weiss, Weizen, Hefeweizen"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Produces the banana and clove nose traditionally associated with German Wheat beers. Also produces desired cloudy look."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP300"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP300 Hefeweizen Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Wheat"
+                        cbf/best-for        "German style wheat beers. Weiss, Weizen, Hefeweizen"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Produces the banana and clove nose traditionally associated with German Wheat beers. Also produces desired cloudy look."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP300"}))
 
 
 (def wlp320-american-hefeweizen-ale
@@ -554,17 +556,17 @@
    
    Some sulfur, and creates desired cloudy look."
   (yeasts/build-yeasts :wlp320-american-hefeweizen-ale
-                       {:min-temperature 18.33
-                        :name            "WLP320 American Hefeweizen Ale"
-                        :max-temperature 20.56
-                        :type            "Wheat"
-                        :best-for        "Oregon style American Hefeweizen"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Produces a much smaller amount of clove and banana flavor than the German Hefeweizen White Labs yeast. Some sulfur, and creates desired cloudy look."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP320"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP320 American Hefeweizen Ale"
+                        cbf/max-temperature 20.56
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Oregon style American Hefeweizen"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Produces a much smaller amount of clove and banana flavor than the German Hefeweizen White Labs yeast. Some sulfur, and creates desired cloudy look."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP320"}))
 
 
 (def wlp351-bavarian-weizen-yeast
@@ -572,17 +574,17 @@
    
    Produces a classic German style wheat beer with moderately high, spicy, phenolic overtones reminiscent of cloves."
   (yeasts/build-yeasts :wlp351-bavarian-weizen-yeast
-                       {:min-temperature 18.89
-                        :name            "WLP351 Bavarian Weizen Yeast"
-                        :max-temperature 21.11
-                        :type            "Wheat"
-                        :best-for        "Bavarian Weizen and wheat beers."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Former yeast lab W51 strain. Produces a classic German style wheat beer with moderately high, spicy, phenolic overtones reminiscent of cloves."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP351"}))
+                       {cbf/min-temperature 18.89
+                        cbf/name            "WLP351 Bavarian Weizen Yeast"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Bavarian Weizen and wheat beers."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Former yeast lab W51 strain. Produces a classic German style wheat beer with moderately high, spicy, phenolic overtones reminiscent of cloves."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP351"}))
 
 
 (def wlp380-hefeweizen-iv-ale
@@ -591,17 +593,17 @@
    Citrus and apricot notes. 
    Crisp and drinkable, with some sulfur production."
   (yeasts/build-yeasts :wlp380-hefeweizen-iv-ale
-                       {:min-temperature 18.89
-                        :name            "WLP380 Hefeweizen IV Ale"
-                        :max-temperature 21.11
-                        :type            "Wheat"
-                        :best-for        "German style Hefeweizen"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Large clove and phenolic aroma, but with minimal banana flavor. Citrus and apricot notes. Crisp and drinkable, with some sulfur production."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP380"}))
+                       {cbf/min-temperature 18.89
+                        cbf/name            "WLP380 Hefeweizen IV Ale"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Wheat"
+                        cbf/best-for        "German style Hefeweizen"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Large clove and phenolic aroma, but with minimal banana flavor. Citrus and apricot notes. Crisp and drinkable, with some sulfur production."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP380"}))
 
 
 (def wlp400-belgian-wit-ale
@@ -609,17 +611,17 @@
    
    The original yeast used to produce Wit in Belgium."
   (yeasts/build-yeasts :wlp400-belgian-wit-ale
-                       {:min-temperature 19.44
-                        :name            "WLP400 Belgian Wit Ale"
-                        :max-temperature 23.33
-                        :type            "Wheat"
-                        :best-for        "Belgian Wit"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Phenolic and tart. The original yeast used to produce Wit in Belgium."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP400"}))
+                       {cbf/min-temperature 19.44
+                        cbf/name            "WLP400 Belgian Wit Ale"
+                        cbf/max-temperature 23.33
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Belgian Wit"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Phenolic and tart. The original yeast used to produce Wit in Belgium."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP400"}))
 
 
 (def wlp410-belgian-wit-ii
@@ -627,17 +629,17 @@
    
    Leaves a little more sweetness and flocculation is higher than WLP400."
   (yeasts/build-yeasts :wlp410-belgian-wit-ii
-                       {:min-temperature 19.44
-                        :name            "WLP410 Belgian Wit II"
-                        :max-temperature 23.33
-                        :type            "Ale"
-                        :best-for        "Belgian Wit, Spiced Ale, Wheat Ales and Specialty Beers"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Less phenolic than WLP400 (Belgian Wit Ale) but more spicy. Leaves a little more sweetness and flocculation is higher than WLP400."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP410"}))
+                       {cbf/min-temperature 19.44
+                        cbf/name            "WLP410 Belgian Wit II"
+                        cbf/max-temperature 23.33
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Wit, Spiced Ale, Wheat Ales and Specialty Beers"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Less phenolic than WLP400 (Belgian Wit Ale) but more spicy. Leaves a little more sweetness and flocculation is higher than WLP400."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP410"}))
 
 
 (def wlp500-trappist-ale
@@ -645,17 +647,17 @@
    
    Excellent for high gravity beers."
   (yeasts/build-yeasts :wlp500-trappist-ale
-                       {:min-temperature 18.33
-                        :name            "WLP500 Trappist Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Trappist Ale, Dubbel, Trippel, Belgian Ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Distinctive fruitiness and plum characteristics. Excellent for high gravity beers."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP500"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP500 Trappist Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Trappist Ale, Dubbel, Trippel, Belgian Ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Distinctive fruitiness and plum characteristics. Excellent for high gravity beers."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP500"}))
 
 
 (def wlp510-bastogne-belgian-ale
@@ -664,17 +666,17 @@
    Creates a dry beer with a slightly acidic finish. 
    Cleaner finish and slightly less spicy than WLP500 or WLP530."
   (yeasts/build-yeasts :wlp510-bastogne-belgian-ale
-                       {:min-temperature 18.89
-                        :name            "WLP510 Bastogne Belgian Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "High gravity beers, Belgian ales, Dubbels, Trippels."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "High gravity Trappist ale yeast. Creates a dry beer with a slightly acidic finish. Cleaner finish and slightly less spicy than WLP500 or WLP530."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP510"}))
+                       {cbf/min-temperature 18.89
+                        cbf/name            "WLP510 Bastogne Belgian Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "High gravity beers, Belgian ales, Dubbels, Trippels."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "High gravity Trappist ale yeast. Creates a dry beer with a slightly acidic finish. Cleaner finish and slightly less spicy than WLP500 or WLP530."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP510"}))
 
 
 (def wlp515-antwerp-ale-yeast
@@ -685,17 +687,17 @@
    Hop flavors are accentuated. 
    Slight sulfur during fermentation, and a lager like flavor profile."
   (yeasts/build-yeasts :wlp515-antwerp-ale-yeast
-                       {:min-temperature 19.44
-                        :name            "WLP515 Antwerp Ale Yeast"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "Belgian pale and amber ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Clean, almost lager like Belgian ale yeast. Good for Belgian pale and amber ales or with other Belgian yeasts in a blend. Biscuity, ale like aroma present. Hop flavors are accentuated. Slight sulfur during fermentation, and a lager like flavor profile."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP515"}))
+                       {cbf/min-temperature 19.44
+                        cbf/name            "WLP515 Antwerp Ale Yeast"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian pale and amber ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Clean, almost lager like Belgian ale yeast. Good for Belgian pale and amber ales or with other Belgian yeasts in a blend. Biscuity, ale like aroma present. Hop flavors are accentuated. Slight sulfur during fermentation, and a lager like flavor profile."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP515"}))
 
 
 (def wlp530-abbey-ale
@@ -704,17 +706,17 @@
    Distinctive plum and fruitiness. 
    Good for high gravity beers."
   (yeasts/build-yeasts :wlp530-abbey-ale
-                       {:min-temperature 18.89
-                        :name            "WLP530 Abbey Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Belgian Trappist Ale, Spiced Ale, Trippel, Dubbel, Grand Cru"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Used in two of six remaining Trappist breweries. Distinctive plum and fruitiness. Good for high gravity beers."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP530"}))
+                       {cbf/min-temperature 18.89
+                        cbf/name            "WLP530 Abbey Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Trappist Ale, Spiced Ale, Trippel, Dubbel, Grand Cru"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Used in two of six remaining Trappist breweries. Distinctive plum and fruitiness. Good for high gravity beers."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP530"}))
 
 
 (def wlp540-abbey-iv-ale-yeast
@@ -723,17 +725,17 @@
    Use for Belgian ales including abbey ales (dubbels, tripels). 
    Fruit character is medium - between WLP500 (high) and WLP530 (low)."
   (yeasts/build-yeasts :wlp540-abbey-iv-ale-yeast
-                       {:min-temperature 18.89
-                        :name            "WLP540 Abbey IV Ale Yeast"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Trappist Belgian Ales, Dubbels, Tripels and Specialty ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "An authentic Trappist style ale yeast. Use for Belgian ales including abbey ales (dubbels, tripels). Fruit character is medium - between WLP500 (high) and WLP530 (low)."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP540"}))
+                       {cbf/min-temperature 18.89
+                        cbf/name            "WLP540 Abbey IV Ale Yeast"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Trappist Belgian Ales, Dubbels, Tripels and Specialty ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "An authentic Trappist style ale yeast. Use for Belgian ales including abbey ales (dubbels, tripels). Fruit character is medium - between WLP500 (high) and WLP530 (low)."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP540"}))
 
 
 (def wlp545-belgian-strong-ale-yeast
@@ -742,17 +744,17 @@
    Results in a dry but balanced finish. 
    Use for dark or strong abbey ales."
   (yeasts/build-yeasts :wlp545-belgian-strong-ale-yeast
-                       {:min-temperature 18.33
-                        :name            "WLP545 Belgian Strong Ale Yeast"
-                        :max-temperature 22.78
-                        :type            "Ale"
-                        :best-for        "Belgian dark strongs, Abbey ales and Christmas beers"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "From the Ardennes region of Belgium, this classic strain produces moderate esters and spicy phenolic character. Results in a dry but balanced finish. Use for dark or strong abbey ales."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP545"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP545 Belgian Strong Ale Yeast"
+                        cbf/max-temperature 22.78
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian dark strongs, Abbey ales and Christmas beers"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "From the Ardennes region of Belgium, this classic strain produces moderate esters and spicy phenolic character. Results in a dry but balanced finish. Use for dark or strong abbey ales."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP545"}))
 
 
 (def wlp550-belgian-ale
@@ -760,17 +762,17 @@
    
    Complex profile, with less fruitiness than White's Trappist Ale strain."
   (yeasts/build-yeasts :wlp550-belgian-ale
-                       {:min-temperature 20.0
-                        :name            "WLP550 Belgian Ale"
-                        :max-temperature 25.56
-                        :type            "Ale"
-                        :best-for        "Belgian Ales, Saisons, Belgian Reds, Belgian Browns, White beers"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Phenolic and spicy flavors. Complex profile, with less fruitiness than White's Trappist Ale strain."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP550"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP550 Belgian Ale"
+                        cbf/max-temperature 25.56
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Ales, Saisons, Belgian Reds, Belgian Browns, White beers"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Phenolic and spicy flavors. Complex profile, with less fruitiness than White's Trappist Ale strain."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP550"}))
 
 
 (def wlp565-belgian-saison-i-ale
@@ -779,17 +781,17 @@
    Earthy, spicy and peppery notes. 
    Slightly sweet."
   (yeasts/build-yeasts :wlp565-belgian-saison-i-ale
-                       {:min-temperature 20.0
-                        :name            "WLP565 Belgian Saison I Ale"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "Saison Ale, Belgian Ale, Dubbel, Trippel"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Saison yeast from Wallonia. Earthy, spicy and peppery notes. Slightly sweet."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP565"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP565 Belgian Saison I Ale"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "Saison Ale, Belgian Ale, Dubbel, Trippel"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Saison yeast from Wallonia. Earthy, spicy and peppery notes. Slightly sweet."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP565"}))
 
 
 (def wlp566-belgian-saison-ii-yeast
@@ -798,17 +800,17 @@
    Moderately phenolic with a clove-like characteristic in finished beer flavor and aroma. 
    Ferments quickly."
   (yeasts/build-yeasts :wlp566-belgian-saison-ii-yeast
-                       {:min-temperature 20.0
-                        :name            "WLP566 Belgian Saison II Yeast"
-                        :max-temperature 25.56
-                        :type            "Ale"
-                        :best-for        "Belgian or French Saison"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Saison strain with a more fruity ester profile than WLP565 (Belgian Saison I Yeast). Moderately phenolic with a clove-like characteristic in finished beer flavor and aroma. Ferments quickly."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP566"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP566 Belgian Saison II Yeast"
+                        cbf/max-temperature 25.56
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian or French Saison"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Saison strain with a more fruity ester profile than WLP565 (Belgian Saison I Yeast). Moderately phenolic with a clove-like characteristic in finished beer flavor and aroma. Ferments quickly."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP566"}))
 
 
 (def wlp568-belgian-style-saison-ale-yeast-blend
@@ -818,17 +820,17 @@
    The blend of yeast strains encourages complete fermentation in a timely manner. 
    Phenolic, spicy, earthy, and clove like flavor."
   (yeasts/build-yeasts :wlp568-belgian-style-saison-ale-yeast-blend
-                       {:min-temperature 21.11
-                        :name            "WLP568 Belgian Style Saison Ale Yeast Blend"
-                        :max-temperature 26.67
-                        :type            "Ale"
-                        :best-for        "Belgian and French Saison"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "This blend melds Belgian style ale and Saison strains. The strains work in harmony to create complex, fruity aromas and flavors. The blend of yeast strains encourages complete fermentation in a timely manner. Phenolic, spicy, earthy, and clove like flavor."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP568"}))
+                       {cbf/min-temperature 21.11
+                        cbf/name            "WLP568 Belgian Style Saison Ale Yeast Blend"
+                        cbf/max-temperature 26.67
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian and French Saison"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "This blend melds Belgian style ale and Saison strains. The strains work in harmony to create complex, fruity aromas and flavors. The blend of yeast strains encourages complete fermentation in a timely manner. Phenolic, spicy, earthy, and clove like flavor."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP568"}))
 
 
 (def wlp570-belgian-golden-ale
@@ -836,17 +838,17 @@
    
    Some sulfur which will dissapate following fermentation."
   (yeasts/build-yeasts :wlp570-belgian-golden-ale
-                       {:min-temperature 20.0
-                        :name            "WLP570 Belgian Golden Ale"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "Belgian Ales, Dubbel, Grand Cru, Belgian Holiday Ale"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Combination of fruitiness and phenolic characters dominate the profile. Some sulfur which will dissapate following fermentation."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP570"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP570 Belgian Golden Ale"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Ales, Dubbel, Grand Cru, Belgian Holiday Ale"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Combination of fruitiness and phenolic characters dominate the profile. Some sulfur which will dissapate following fermentation."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP570"}))
 
 
 (def wlp575-belgian-style-ale-yeast-blend
@@ -854,17 +856,17 @@
    
    Creates a versatile blend to be used for Trappist and other Belgian style ales."
   (yeasts/build-yeasts :wlp575-belgian-style-ale-yeast-blend
-                       {:min-temperature 20.0
-                        :name            "WLP575 Belgian Style Ale Yeast Blend"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "Trappist and other Belgian ales."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Blend of two trappist ale yeasts and one Belgian ale yeast. Creates a versatile blend to be used for Trappist and other Belgian style ales."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP575"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP575 Belgian Style Ale Yeast Blend"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "Trappist and other Belgian ales."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Blend of two trappist ale yeasts and one Belgian ale yeast. Creates a versatile blend to be used for Trappist and other Belgian style ales."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP575"}))
 
 
 (def wlp630-berliner-weisse-blend
@@ -873,17 +875,17 @@
    Can take several months to develop tart character. 
    Perfect for traditional Berliner Weisse."
   (yeasts/build-yeasts :wlp630-berliner-weisse-blend
-                       {:min-temperature 20.0
-                        :name            "WLP630 Berliner Weisse Blend"
-                        :max-temperature 22.22
-                        :type            "Wheat"
-                        :best-for        "Berliner Weisse"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "A blend of a traditional German Weizen yeast and Lactobacillus to create a subtle, tart, drinkable beer. Can take several months to develop tart character. Perfect for traditional Berliner Weisse."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP630"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP630 Berliner Weisse Blend"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Berliner Weisse"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "A blend of a traditional German Weizen yeast and Lactobacillus to create a subtle, tart, drinkable beer. Can take several months to develop tart character. Perfect for traditional Berliner Weisse."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP630"}))
 
 
 (def wlp645-brettanomyces-claussenii
@@ -894,17 +896,17 @@
    More aroma than flavor contribution. 
    Fruity, pineapple like aroma."
   (yeasts/build-yeasts :wlp645-brettanomyces-claussenii
-                       {:min-temperature 18.33
-                        :name            "WLP645 Brettanomyces Claussenii"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Sour ales (in secondary)"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Low intensity Brett character. Originally isolated from strong English stock beer, in the early 20th century. The Brett flavors produced are more subtle than WLP650 and WLP653. More aroma than flavor contribution. Fruity, pineapple like aroma."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP645"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP645 Brettanomyces Claussenii"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Sour ales (in secondary)"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Low intensity Brett character. Originally isolated from strong English stock beer, in the early 20th century. The Brett flavors produced are more subtle than WLP650 and WLP653. More aroma than flavor contribution. Fruity, pineapple like aroma."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP645"}))
 
 
 (def wlp650-brettanomyces-bruxellensis
@@ -913,17 +915,17 @@
    Classic strain used in secondary fermentation for Belgian style beers and lambics. 
    One Trappist brewery uses this strain in secondary fermentation."
   (yeasts/build-yeasts :wlp650-brettanomyces-bruxellensis
-                       {:min-temperature 18.33
-                        :name            "WLP650 Brettanomyces Bruxellensis"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Belgian sour ales and labics (in secondary)"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Medium intensity Brett character. Classic strain used in secondary fermentation for Belgian style beers and lambics. One Trappist brewery uses this strain in secondary fermentation."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP650"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP650 Brettanomyces Bruxellensis"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian sour ales and labics (in secondary)"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Medium intensity Brett character. Classic strain used in secondary fermentation for Belgian style beers and lambics. One Trappist brewery uses this strain in secondary fermentation."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP650"}))
 
 
 (def wlp653-brettanomyces-lambicus
@@ -933,17 +935,17 @@
    Defines the \"Brett character\": Horsey, smoky and spicy flavors. 
    As the name suggests, this strain is found most often in Lambic style beers, which are spontaneously fermented beers."
   (yeasts/build-yeasts :wlp653-brettanomyces-lambicus
-                       {:min-temperature 18.33
-                        :name            "WLP653 Brettanomyces Lambicus"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Lambics and Flanders/Sour Brown ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Use in secondary. High intensity Brett character. Defines the \"Brett character\": Horsey, smoky and spicy flavors. As the name suggests, this strain is found most often in Lambic style beers, which are spontaneously fermented beers."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP653"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP653 Brettanomyces Lambicus"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Lambics and Flanders/Sour Brown ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Use in secondary. High intensity Brett character. Defines the \"Brett character\": Horsey, smoky and spicy flavors. As the name suggests, this strain is found most often in Lambic style beers, which are spontaneously fermented beers."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP653"}))
 
 
 (def wlp655-belgian-sour-mix-1
@@ -952,17 +954,17 @@
    A unique blend perfect for Belgian style beers. 
    Includes Brettanomyces, Saccharomyces, and the bacterial strains Lactobacillus and Pediococcus."
   (yeasts/build-yeasts :wlp655-belgian-sour-mix-1
-                       {:min-temperature 18.33
-                        :name            "WLP655 Belgian Sour Mix 1"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Belgian sour beers (in secondary)"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Note: Bacteria to use in secondary only. A unique blend perfect for Belgian style beers. Includes Brettanomyces, Saccharomyces, and the bacterial strains Lactobacillus and Pediococcus."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP655"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP655 Belgian Sour Mix 1"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian sour beers (in secondary)"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Note: Bacteria to use in secondary only. A unique blend perfect for Belgian style beers. Includes Brettanomyces, Saccharomyces, and the bacterial strains Lactobacillus and Pediococcus."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP655"}))
 
 
 (def wlp670-american-farmhouse-blend
@@ -972,17 +974,17 @@
    It consists of a traditional farmhouse yeast strain and Brettanomyces. 
    Great yeast for farmhouse styles."
   (yeasts/build-yeasts :wlp670-american-farmhouse-blend
-                       {:min-temperature 20.0
-                        :name            "WLP670 American Farmhouse Blend"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Saisons, Farmhouse Ales"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Inspired by local American brewers crafting semi- traditional Belgian-style ales. This blend creates a complex flavor profile with a moderate level of sourness. It consists of a traditional farmhouse yeast strain and Brettanomyces. Great yeast for farmhouse styles."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP670"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP670 American Farmhouse Blend"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Saisons, Farmhouse Ales"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Inspired by local American brewers crafting semi- traditional Belgian-style ales. This blend creates a complex flavor profile with a moderate level of sourness. It consists of a traditional farmhouse yeast strain and Brettanomyces. Great yeast for farmhouse styles."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP670"}))
 
 
 (def wlp675-malolactic-bacteria
@@ -991,17 +993,17 @@
    Malolactic fermentation is the conversion of malic acid to lactic acid by bacteria from the lactic acid bacteria family. 
    Lactic acid is less acidic than malic acid, which in turn decreases acidity and helps to soften."
   (yeasts/build-yeasts :wlp675-malolactic-bacteria
-                       {:min-temperature 18.33
-                        :name            "WLP675 Malolactic Bacteria"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Primarily wine"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Bacteria for use in secondary. Malolactic fermentation is the conversion of malic acid to lactic acid by bacteria from the lactic acid bacteria family. Lactic acid is less acidic than malic acid, which in turn decreases acidity and helps to soften."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP675"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP675 Malolactic Bacteria"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Primarily wine"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Bacteria for use in secondary. Malolactic fermentation is the conversion of malic acid to lactic acid by bacteria from the lactic acid bacteria family. Lactic acid is less acidic than malic acid, which in turn decreases acidity and helps to soften."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP675"}))
 
 
 (def wlp677-lactobacillus-bacteria
@@ -1009,17 +1011,17 @@
    
    This lactic acid bacteria produces moderate levels of acidity and sour flavors found in lambics, Berliner Weiss, sour brown ale and gueze."
   (yeasts/build-yeasts :wlp677-lactobacillus-bacteria
-                       {:min-temperature 18.33
-                        :name            "WLP677 Lactobacillus Bacteria"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Lambic, Berliner Weiss, Sour Brown and Gueze (secondary)"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Bacteria for use in secondary. This lactic acid bacteria produces moderate levels of acidity and sour flavors found in lambics, Berliner Weiss, sour brown ale and gueze."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP677"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "WLP677 Lactobacillus Bacteria"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Lambic, Berliner Weiss, Sour Brown and Gueze (secondary)"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Bacteria for use in secondary. This lactic acid bacteria produces moderate levels of acidity and sour flavors found in lambics, Berliner Weiss, sour brown ale and gueze."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP677"}))
 
 
 (def wlp700-flor-sherry-yeast
@@ -1030,17 +1032,17 @@
    For use in secondary fermentation. 
    Slow fermentor."
   (yeasts/build-yeasts :wlp700-flor-sherry-yeast
-                       {:min-temperature 21.11
-                        :name            "WLP700 Flor Sherry Yeast"
-                        :max-temperature 24.44
-                        :type            "Wine"
-                        :best-for        "Sherry wine yeast"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "This yeast develops a film (flor) on the surface of the wine. Creates green almond, granny smith and nougat characteristics found in sherry. Can also be used for Port, Madeira and other sweet styles. For use in secondary fermentation. Slow fermentor."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP700"}))
+                       {cbf/min-temperature 21.11
+                        cbf/name            "WLP700 Flor Sherry Yeast"
+                        cbf/max-temperature 24.44
+                        cbf/type            "Wine"
+                        cbf/best-for        "Sherry wine yeast"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "This yeast develops a film (flor) on the surface of the wine. Creates green almond, granny smith and nougat characteristics found in sherry. Can also be used for Port, Madeira and other sweet styles. For use in secondary fermentation. Slow fermentor."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP700"}))
 
 
 (def wlp705-sake-yeast
@@ -1050,17 +1052,17 @@
    WLP705 produces full body sake character, and subtle fragrance. 
    Alcohol tolerance to 16%."
   (yeasts/build-yeasts :wlp705-sake-yeast
-                       {:min-temperature 21.11
-                        :name            "WLP705 Sake Yeast"
-                        :max-temperature 24.44
-                        :type            "Wine"
-                        :best-for        "Sake wine yeast"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "For use in rice based fermentations. For sake, use this yeast in conjunction with Koji (to produce fermentable sugar). WLP705 produces full body sake character, and subtle fragrance. Alcohol tolerance to 16%."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP705"}))
+                       {cbf/min-temperature 21.11
+                        cbf/name            "WLP705 Sake Yeast"
+                        cbf/max-temperature 24.44
+                        cbf/type            "Wine"
+                        cbf/best-for        "Sake wine yeast"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "For use in rice based fermentations. For sake, use this yeast in conjunction with Koji (to produce fermentable sugar). WLP705 produces full body sake character, and subtle fragrance. Alcohol tolerance to 16%."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP705"}))
 
 
 (def wlp715-champagne-yeast
@@ -1068,17 +1070,17 @@
    
    For Barley Wine or Meads."
   (yeasts/build-yeasts :wlp715-champagne-yeast
-                       {:min-temperature 21.11
-                        :name            "WLP715 Champagne Yeast"
-                        :max-temperature 23.89
-                        :type            "Champagne"
-                        :best-for        "Wine, Mead and Cider"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Can tolerate alcohol up to 17%. For Barley Wine or Meads."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP715"}))
+                       {cbf/min-temperature 21.11
+                        cbf/name            "WLP715 Champagne Yeast"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Champagne"
+                        cbf/best-for        "Wine, Mead and Cider"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Can tolerate alcohol up to 17%. For Barley Wine or Meads."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP715"}))
 
 
 (def wlp718-avize-wine-yeast
@@ -1087,17 +1089,17 @@
    Contributes elegance, especially in barrel fermented Chardonnays. 
    Alcohol tolerance to 15%."
   (yeasts/build-yeasts :wlp718-avize-wine-yeast
-                       {:min-temperature 15.56
-                        :name            "WLP718 Avize Wine Yeast"
-                        :max-temperature 32.22
-                        :type            "Wine"
-                        :best-for        "Chardonnay"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Champagne isolate used for complexity in whites. Contributes elegance, especially in barrel fermented Chardonnays. Alcohol tolerance to 15%."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP718"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "WLP718 Avize Wine Yeast"
+                        cbf/max-temperature 32.22
+                        cbf/type            "Wine"
+                        cbf/best-for        "Chardonnay"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Champagne isolate used for complexity in whites. Contributes elegance, especially in barrel fermented Chardonnays. Alcohol tolerance to 15%."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP718"}))
 
 
 (def wlp720-sweet-mead-wine
@@ -1106,17 +1108,17 @@
    Leaves some residual sweetness as well as fruity flavor. 
    Alcohol concentration up to 15%."
   (yeasts/build-yeasts :wlp720-sweet-mead-wine
-                       {:min-temperature 21.11
-                        :name            "WLP720 Sweet Mead/Wine"
-                        :max-temperature 23.89
-                        :type            "Wine"
-                        :best-for        "Sweet Mead, Wine and Cider"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Lower attenuation than White Labs Champagne Yeast. Leaves some residual sweetness as well as fruity flavor. Alcohol concentration up to 15%."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP720"}))
+                       {cbf/min-temperature 21.11
+                        cbf/name            "WLP720 Sweet Mead/Wine"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Wine"
+                        cbf/best-for        "Sweet Mead, Wine and Cider"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Lower attenuation than White Labs Champagne Yeast. Leaves some residual sweetness as well as fruity flavor. Alcohol concentration up to 15%."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP720"}))
 
 
 (def wlp727-steinberg-geisenheim-wine
@@ -1125,17 +1127,17 @@
    High fruit/ester production. 
    Moderate fermentation characteristics and cold tolerant."
   (yeasts/build-yeasts :wlp727-steinberg-geisenheim-wine
-                       {:min-temperature 10.0
-                        :name            "WLP727 Steinberg-Geisenheim Wine"
-                        :max-temperature 32.22
-                        :type            "Wine"
-                        :best-for        "Riesling wines."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "German origin wine yeast. High fruit/ester production. Moderate fermentation characteristics and cold tolerant."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP727"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "WLP727 Steinberg-Geisenheim Wine"
+                        cbf/max-temperature 32.22
+                        cbf/type            "Wine"
+                        cbf/best-for        "Riesling wines."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "German origin wine yeast. High fruit/ester production. Moderate fermentation characteristics and cold tolerant."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP727"}))
 
 
 (def wlp730-chardonnay-white-wine-yeast
@@ -1146,17 +1148,17 @@
    WLP730 is a good choice for all white and blush wines, including Chablis, Chenin Blanc, Semillon, and Sauvignon Blanc. 
    Fermentation speed is moderate."
   (yeasts/build-yeasts :wlp730-chardonnay-white-wine-yeast
-                       {:min-temperature 10.0
-                        :name            "WLP730 Chardonnay White Wine Yeast"
-                        :max-temperature 32.22
-                        :type            "Wine"
-                        :best-for        "Chardonnay Wine"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Dry wine yeast. Slight ester production, low sulfur dioxide production. Enhances varietal character. WLP730 is a good choice for all white and blush wines, including Chablis, Chenin Blanc, Semillon, and Sauvignon Blanc. Fermentation speed is moderate."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP730"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "WLP730 Chardonnay White Wine Yeast"
+                        cbf/max-temperature 32.22
+                        cbf/type            "Wine"
+                        cbf/best-for        "Chardonnay Wine"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Dry wine yeast. Slight ester production, low sulfur dioxide production. Enhances varietal character. WLP730 is a good choice for all white and blush wines, including Chablis, Chenin Blanc, Semillon, and Sauvignon Blanc. Fermentation speed is moderate."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP730"}))
 
 
 (def wlp735-french-white-wine-yeast
@@ -1166,17 +1168,17 @@
    Gives an enhanced creamy texture. 
    Alcohol Tolerance: 16%"
   (yeasts/build-yeasts :wlp735-french-white-wine-yeast
-                       {:min-temperature 15.56
-                        :name            "WLP735 French White Wine Yeast"
-                        :max-temperature 32.22
-                        :type            "Wine"
-                        :best-for        "French white wines"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Classic yeast for white wine fermentation. Slow to moderate fermenter and foam producer. Gives an enhanced creamy texture. Alcohol Tolerance: 16%."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP735"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "WLP735 French White Wine Yeast"
+                        cbf/max-temperature 32.22
+                        cbf/type            "Wine"
+                        cbf/best-for        "French white wines"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Classic yeast for white wine fermentation. Slow to moderate fermenter and foam producer. Gives an enhanced creamy texture. Alcohol Tolerance: 16%."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP735"}))
 
 
 (def wlp740-merlot-red-wine-yeast
@@ -1187,17 +1189,17 @@
    WLP740 is well suited for Merlot, Shiraz, Pinot Noir, Chardonnay, Cabernet, Sauvignon Blanc, and Semillon. 
    Alcohol Tolerance: 18%"
   (yeasts/build-yeasts :wlp740-merlot-red-wine-yeast
-                       {:min-temperature 15.56
-                        :name            "WLP740 Merlot Red Wine Yeast"
-                        :max-temperature 32.22
-                        :type            "Wine"
-                        :best-for        "Merlot, Shiraz, Pinot Noir, Chardonnay, Cabernet, Sauvignon Blanc, and Semillon"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Neutral, low fusel alcohol production. Will ferment to dryness, alcohol tolerance to 18%. Vigorous fermenter. WLP740 is well suited for Merlot, Shiraz, Pinot Noir, Chardonnay, Cabernet, Sauvignon Blanc, and Semillon. Alcohol Tolerance: 18%."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP740"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "WLP740 Merlot Red Wine Yeast"
+                        cbf/max-temperature 32.22
+                        cbf/type            "Wine"
+                        cbf/best-for        "Merlot, Shiraz, Pinot Noir, Chardonnay, Cabernet, Sauvignon Blanc, and Semillon"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Neutral, low fusel alcohol production. Will ferment to dryness, alcohol tolerance to 18%. Vigorous fermenter. WLP740 is well suited for Merlot, Shiraz, Pinot Noir, Chardonnay, Cabernet, Sauvignon Blanc, and Semillon. Alcohol Tolerance: 18%."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP740"}))
 
 
 (def wlp749-assmanshausen-wine-yeast
@@ -1207,17 +1209,17 @@
    Slow to moderate fermenter which is cold tolerant. 
    Alcohol Tolerance: 16%"
   (yeasts/build-yeasts :wlp749-assmanshausen-wine-yeast
-                       {:min-temperature 10.0
-                        :name            "WLP749 Assmanshausen Wine Yeast"
-                        :max-temperature 32.22
-                        :type            "Wine"
-                        :best-for        "Pinot Noir and Zinfandel"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "German red wine yeast, which results in spicy, fruit aromas. Perfect for Pinot Noir and Zinfandel. Slow to moderate fermenter which is cold tolerant. Alcohol Tolerance: 16%."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP749"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "WLP749 Assmanshausen Wine Yeast"
+                        cbf/max-temperature 32.22
+                        cbf/type            "Wine"
+                        cbf/best-for        "Pinot Noir and Zinfandel"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "German red wine yeast, which results in spicy, fruit aromas. Perfect for Pinot Noir and Zinfandel. Slow to moderate fermenter which is cold tolerant. Alcohol Tolerance: 16%."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP749"}))
 
 
 (def wlp750-french-red-wine-yeast
@@ -1228,17 +1230,17 @@
    Rich, smooth flavor profile. 
    Alcohol Tolerance: 17%."
   (yeasts/build-yeasts :wlp750-french-red-wine-yeast
-                       {:min-temperature 15.56
-                        :name            "WLP750 French Red Wine Yeast"
-                        :max-temperature 32.22
-                        :type            "Wine"
-                        :best-for        "Bordeaux"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Classic Bordeaux yeast for red wine fermentations. Moderate fermentation characteristics. Tolerates lower fermentation temperatures. Rich, smooth flavor profile. Alcohol Tolerance: 17%."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP750"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "WLP750 French Red Wine Yeast"
+                        cbf/max-temperature 32.22
+                        cbf/type            "Wine"
+                        cbf/best-for        "Bordeaux"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Classic Bordeaux yeast for red wine fermentations. Moderate fermentation characteristics. Tolerates lower fermentation temperatures. Rich, smooth flavor profile. Alcohol Tolerance: 17%."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP750"}))
 
 
 (def wlp760-cabernet-red-wine-yeast
@@ -1249,17 +1251,17 @@
    WLP760 is also suitable for Merlot, Chardonnay, Chianti, Chenin Blanc, and Sauvignon Blanc. 
    Alcohol Tolerance: 16%"
   (yeasts/build-yeasts :wlp760-cabernet-red-wine-yeast
-                       {:min-temperature 15.56
-                        :name            "WLP760 Cabernet Red Wine Yeast"
-                        :max-temperature 32.22
-                        :type            "Wine"
-                        :best-for        "Merlot, Chardonnay, Chianti, Chenin Blanc, and Sauvignon Blanc"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "High temperature tolerance. Moderate fermentation speed. Excellent for full-bodied red wines, ester production complements flavor. WLP760 is also suitable for Merlot, Chardonnay, Chianti, Chenin Blanc, and Sauvignon Blanc. Alcohol Tolerance: 16%."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP760"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "WLP760 Cabernet Red Wine Yeast"
+                        cbf/max-temperature 32.22
+                        cbf/type            "Wine"
+                        cbf/best-for        "Merlot, Chardonnay, Chianti, Chenin Blanc, and Sauvignon Blanc"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "High temperature tolerance. Moderate fermentation speed. Excellent for full-bodied red wines, ester production complements flavor. WLP760 is also suitable for Merlot, Chardonnay, Chianti, Chenin Blanc, and Sauvignon Blanc. Alcohol Tolerance: 16%."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP760"}))
 
 
 (def wlp770-suremain-burgundy-wine-yeast
@@ -1268,17 +1270,17 @@
    High nutrient requirement to avoid volatile acidity production. 
    Alcohol Tolerance: 16%."
   (yeasts/build-yeasts :wlp770-suremain-burgundy-wine-yeast
-                       {:min-temperature 15.56
-                        :name            "WLP770 Suremain Burgundy Wine Yeast"
-                        :max-temperature 32.22
-                        :type            "Wine"
-                        :best-for        "Burgundy"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Emphasizes fruit aromas in barrel fermentations. High nutrient requirement to avoid volatile acidity production. Alcohol Tolerance: 16%."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "WLP770"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "WLP770 Suremain Burgundy Wine Yeast"
+                        cbf/max-temperature 32.22
+                        cbf/type            "Wine"
+                        cbf/best-for        "Burgundy"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Emphasizes fruit aromas in barrel fermentations. High nutrient requirement to avoid volatile acidity production. Alcohol Tolerance: 16%."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP770"}))
 
 
 (def wlp775-english-cider-yeast
@@ -1287,17 +1289,17 @@
    Ferments dry, but retains apple flavor. 
    Some sulfer produced during fermentation will fade with age."
   (yeasts/build-yeasts :wlp775-english-cider-yeast
-                       {:min-temperature 20.0
-                        :name            "WLP775 English Cider Yeast"
-                        :max-temperature 23.89
-                        :type            "Wine"
-                        :best-for        "Cider, Wine and High Gravity Beer"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Classic Cider yeast. Ferments dry, but retains apple flavor. Some sulfer produced during fermentation will fade with age."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP775"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP775 English Cider Yeast"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Wine"
+                        cbf/best-for        "Cider, Wine and High Gravity Beer"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Classic Cider yeast. Ferments dry, but retains apple flavor. Some sulfer produced during fermentation will fade with age."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP775"}))
 
 
 (def wlp800-pilsner-lager
@@ -1305,17 +1307,17 @@
    
    Dry with a malty finish."
   (yeasts/build-yeasts :wlp800-pilsner-lager
-                       {:min-temperature 10.0
-                        :name            "WLP800 Pilsner Lager"
-                        :max-temperature 12.78
-                        :type            "Lager"
-                        :best-for        "European Pilsners, Bohemian Pilsner"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Classic pilsner strain from Czech Republic. Dry with a malty finish."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "WLP800"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "WLP800 Pilsner Lager"
+                        cbf/max-temperature 12.78
+                        cbf/type            "Lager"
+                        cbf/best-for        "European Pilsners, Bohemian Pilsner"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Classic pilsner strain from Czech Republic. Dry with a malty finish."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP800"}))
 
 
 (def wlp802-czech-budejovice-lager
@@ -1323,33 +1325,33 @@
    
    From Southern Czech Republic."
   (yeasts/build-yeasts :wlp802-czech-budejovice-lager
-                       {:min-temperature 10.0
-                        :name            "WLP802 Czech Budejovice Lager"
-                        :max-temperature 12.78
-                        :type            "Lager"
-                        :best-for        "Bohemian Style Pilsner"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Dry and crisp with low diacetyl production. From Southern Czech Republic."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP802"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "WLP802 Czech Budejovice Lager"
+                        cbf/max-temperature 12.78
+                        cbf/type            "Lager"
+                        cbf/best-for        "Bohemian Style Pilsner"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Dry and crisp with low diacetyl production. From Southern Czech Republic."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP802"}))
 
 
 (def wlp810-san-francisco-lager
   "Produces \"California Common\" style beer."
   (yeasts/build-yeasts :wlp810-san-francisco-lager
-                       {:min-temperature 14.44
-                        :name            "WLP810 San Francisco Lager"
-                        :max-temperature 18.33
-                        :type            "Lager"
-                        :best-for        "California and Premium Lagers, all American Lagers"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Produces \"California Common\" style beer."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "WLP810"}))
+                       {cbf/min-temperature 14.44
+                        cbf/name            "WLP810 San Francisco Lager"
+                        cbf/max-temperature 18.33
+                        cbf/type            "Lager"
+                        cbf/best-for        "California and Premium Lagers, all American Lagers"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Produces \"California Common\" style beer."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP810"}))
 
 
 (def wlp815-belgian-lager-yeast
@@ -1358,17 +1360,17 @@
    The strain originates from a very old brewery in West Belgium. 
    Great for European style pilsners, dark lagers, Vienna lager, and American style lagers."
   (yeasts/build-yeasts :wlp815-belgian-lager-yeast
-                       {:min-temperature 10.0
-                        :name            "WLP815 Belgian Lager Yeast"
-                        :max-temperature 12.78
-                        :type            "Lager"
-                        :best-for        "European style pilsners, dark lagers, Vienna lager, and American style lagers"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Clean, crisp European lager yeast with low sulfur production. The strain originates from a very old brewery in West Belgium. Great for European style pilsners, dark lagers, Vienna lager, and American style lagers."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP815"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "WLP815 Belgian Lager Yeast"
+                        cbf/max-temperature 12.78
+                        cbf/type            "Lager"
+                        cbf/best-for        "European style pilsners, dark lagers, Vienna lager, and American style lagers"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Clean, crisp European lager yeast with low sulfur production. The strain originates from a very old brewery in West Belgium. Great for European style pilsners, dark lagers, Vienna lager, and American style lagers."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP815"}))
 
 
 (def wlp820-octoberfest-marzen-lager
@@ -1377,17 +1379,17 @@
    Does not finish as dry or as fast as White's German Lager yeast. 
    Longer lagering or starter recommended."
   (yeasts/build-yeasts :wlp820-octoberfest-marzen-lager
-                       {:min-temperature 11.11
-                        :name            "WLP820 Octoberfest/Marzen Lager"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "Marzen, Oktoberfest, European Lagers, Bocks, Munich Helles"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Produces a malty, bock style beer. Does not finish as dry or as fast as White's German Lager yeast. Longer lagering or starter recommended."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP820"}))
+                       {cbf/min-temperature 11.11
+                        cbf/name            "WLP820 Octoberfest/Marzen Lager"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "Marzen, Oktoberfest, European Lagers, Bocks, Munich Helles"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Produces a malty, bock style beer. Does not finish as dry or as fast as White's German Lager yeast. Longer lagering or starter recommended."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP820"}))
 
 
 (def wlp830-german-lager
@@ -1395,17 +1397,17 @@
    
    One of the world's most popular lager yeasts."
   (yeasts/build-yeasts :wlp830-german-lager
-                       {:min-temperature 10.0
-                        :name            "WLP830 German Lager"
-                        :max-temperature 12.78
-                        :type            "Lager"
-                        :best-for        "German Marzen, Pilsner, Lagers, Oktoberfest beers."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Very malty and clean. One of the world's most popular lager yeasts."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP830"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "WLP830 German Lager"
+                        cbf/max-temperature 12.78
+                        cbf/type            "Lager"
+                        cbf/best-for        "German Marzen, Pilsner, Lagers, Oktoberfest beers."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Very malty and clean. One of the world's most popular lager yeasts."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP830"}))
 
 
 (def wlp833-german-bock-lager
@@ -1413,17 +1415,17 @@
    
    From Southern Bavaria."
   (yeasts/build-yeasts :wlp833-german-bock-lager
-                       {:min-temperature 8.89
-                        :name            "WLP833 German Bock Lager"
-                        :max-temperature 12.78
-                        :type            "Lager"
-                        :best-for        "Bocks, Doppelbocks, Oktoberfest, Vienna, Helles, some American Pilsners"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Produces beer that has balanced malt and hop character. From Southern Bavaria."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP833"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "WLP833 German Bock Lager"
+                        cbf/max-temperature 12.78
+                        cbf/type            "Lager"
+                        cbf/best-for        "Bocks, Doppelbocks, Oktoberfest, Vienna, Helles, some American Pilsners"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Produces beer that has balanced malt and hop character. From Southern Bavaria."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP833"}))
 
 
 (def wlp838-southern-german-lager
@@ -1431,17 +1433,17 @@
    
    Strong fermenter, slight sulfur and low diacetyl."
   (yeasts/build-yeasts :wlp838-southern-german-lager
-                       {:min-temperature 10.0
-                        :name            "WLP838 Southern German Lager"
-                        :max-temperature 12.78
-                        :type            "Lager"
-                        :best-for        "German Pilsner, Helles, Oktoberfest, Marzen, Bocks"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Malty finish and balanced aroma. Strong fermenter, slight sulfur and low diacetyl."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "WLP838"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "WLP838 Southern German Lager"
+                        cbf/max-temperature 12.78
+                        cbf/type            "Lager"
+                        cbf/best-for        "German Pilsner, Helles, Oktoberfest, Marzen, Bocks"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Malty finish and balanced aroma. Strong fermenter, slight sulfur and low diacetyl."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP838"}))
 
 
 (def wlp840-american-lager-yeast
@@ -1449,17 +1451,17 @@
    
    Minimal sulfer and diacetyl."
   (yeasts/build-yeasts :wlp840-american-lager-yeast
-                       {:min-temperature 10.0
-                        :name            "WLP840 American Lager Yeast"
-                        :max-temperature 12.78
-                        :type            "Lager"
-                        :best-for        "All American Style Lagers -- both light and dark."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Dry and clean with very slight apple fruitiness. Minimal sulfer and diacetyl."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP840"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "WLP840 American Lager Yeast"
+                        cbf/max-temperature 12.78
+                        cbf/type            "Lager"
+                        cbf/best-for        "All American Style Lagers -- both light and dark."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Dry and clean with very slight apple fruitiness. Minimal sulfer and diacetyl."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP840"}))
 
 
 (def wlp860-munich-helles
@@ -1468,17 +1470,17 @@
    This yeast helps to produce a malty, but balanced traditional Munich-style lager. 
    Clean and strong fermenter, it's great for a variety of lager styles ranging from Helles to Rauchbier."
   (yeasts/build-yeasts :wlp860-munich-helles
-                       {:min-temperature 8.89
-                        :name            "WLP860 Munich Helles"
-                        :max-temperature 11.11
-                        :type            "Ale"
-                        :best-for        "Munich Helles, Oktoberfest"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Possible Augustiner Strain. This yeast helps to produce a malty, but balanced traditional Munich-style lager. Clean and strong fermenter, it's great for a variety of lager styles ranging from Helles to Rauchbier."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP860"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "WLP860 Munich Helles"
+                        cbf/max-temperature 11.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "Munich Helles, Oktoberfest"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Possible Augustiner Strain. This yeast helps to produce a malty, but balanced traditional Munich-style lager. Clean and strong fermenter, it's great for a variety of lager styles ranging from Helles to Rauchbier."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP860"}))
 
 
 (def wlp862-cry-havoc
@@ -1487,17 +1489,17 @@
    This yeast was used to brew many of his original recipes. 
    Diverse strain can ferment at ale and lager temps."
   (yeasts/build-yeasts :wlp862-cry-havoc
-                       {:min-temperature 20.0
-                        :name            "WLP862 Cry Havoc"
-                        :max-temperature 23.33
-                        :type            "Lager"
-                        :best-for        "All American Style Lagers -- both light and dark."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Licensed by White Labs from Charlie Papazian, author of \"The Complete Joy of Home Brewing\". This yeast was used to brew many of his original recipes. Diverse strain can ferment at ale and lager temps."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP862"}))
+                       {cbf/min-temperature 20.0
+                        cbf/name            "WLP862 Cry Havoc"
+                        cbf/max-temperature 23.33
+                        cbf/type            "Lager"
+                        cbf/best-for        "All American Style Lagers -- both light and dark."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Licensed by White Labs from Charlie Papazian, author of \"The Complete Joy of Home Brewing\". This yeast was used to brew many of his original recipes. Diverse strain can ferment at ale and lager temps."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP862"}))
 
 
 (def wlp885-zurich-lager
@@ -1506,17 +1508,17 @@
    Sulfer and diacetyl production is minimal. 
    May be used for high gravity lagers with proper care."
   (yeasts/build-yeasts :wlp885-zurich-lager
-                       {:min-temperature 10.0
-                        :name            "WLP885 Zurich Lager"
-                        :max-temperature 12.78
-                        :type            "Lager"
-                        :best-for        "Swiss style lager, and high gravity lagers (over 11% ABV)"
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Swiss style lager yeast. Sulfer and diacetyl production is minimal. May be used for high gravity lagers with proper care."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP885"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "WLP885 Zurich Lager"
+                        cbf/max-temperature 12.78
+                        cbf/type            "Lager"
+                        cbf/best-for        "Swiss style lager, and high gravity lagers (over 11% ABV)"
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Swiss style lager yeast. Sulfer and diacetyl production is minimal. May be used for high gravity lagers with proper care."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP885"}))
 
 
 (def wlp920-old-bavarian-lager
@@ -1524,17 +1526,17 @@
    
    Finishes malty with a slight ester profile."
   (yeasts/build-yeasts :wlp920-old-bavarian-lager
-                       {:min-temperature 10.0
-                        :name            "WLP920 Old Bavarian Lager"
-                        :max-temperature 12.78
-                        :type            "Lager"
-                        :best-for        "Oktoberfest, Marzen, Bock and Dark Lagers."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "Southern Germany/Bavarian lager yeast. Finishes malty with a slight ester profile."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP920"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "WLP920 Old Bavarian Lager"
+                        cbf/max-temperature 12.78
+                        cbf/type            "Lager"
+                        cbf/best-for        "Oktoberfest, Marzen, Bock and Dark Lagers."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Southern Germany/Bavarian lager yeast. Finishes malty with a slight ester profile."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP920"}))
 
 
 (def wlp940-mexican-lager
@@ -1542,17 +1544,17 @@
    
    Good for mexican style beers."
   (yeasts/build-yeasts :wlp940-mexican-lager
-                       {:min-temperature 10.0
-                        :name            "WLP940 Mexican Lager"
-                        :max-temperature 12.78
-                        :type            "Lager"
-                        :best-for        "Mexican style light and dark lagers."
-                        :laboratory      "White Labs"
-                        :attenuation     0.765
-                        :notes           "From Mexico City - produces a clean lager beer with a crisp finish. Good for mexican style beers."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "WLP940"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "WLP940 Mexican Lager"
+                        cbf/max-temperature 12.78
+                        cbf/type            "Lager"
+                        cbf/best-for        "Mexican style light and dark lagers."
+                        cbf/laboratory      "White Labs"
+                        cbf/attenuation     0.765
+                        cbf/notes           "From Mexico City - produces a clean lager beer with a crisp finish. Good for mexican style beers."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "WLP940"}))
 
 
 (def white-labs

--- a/src/common_beer_data/yeasts/wyeast.cljc
+++ b/src/common_beer_data/yeasts/wyeast.cljc
@@ -2,23 +2,25 @@
   "Data for yeasts cultivated by Wyeast.
    
    https://wyeastlab.com/"
-  (:require [common-beer-data.yeasts.yeasts :as yeasts]))
+  {:added "1.0"}
+  (:require [common-beer-data.yeasts.yeasts :as yeasts]
+            [common-beer-format.yeasts :as cbf]))
 
 
 (def german-ale-1007
   "Crisp, dry finish with a mild flavor."
   (yeasts/build-yeasts :german-ale-1007
-                       {:min-temperature 12.78
-                        :name            "1007 German Ale"
-                        :max-temperature 18.89
-                        :type            "Ale"
-                        :best-for        "German Ales, Alts, Kolsch, Dry Stout"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Crisp, dry finish with a mild flavor."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "1007"}))
+                       {cbf/min-temperature 12.78
+                        cbf/name            "1007 German Ale"
+                        cbf/max-temperature 18.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "German Ales, Alts, Kolsch, Dry Stout"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Crisp, dry finish with a mild flavor."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1007"}))
 
 
 (def american-wheat-ale-1010
@@ -26,17 +28,17 @@
    
    Low flocculation aids in producing desired chill haze."
   (yeasts/build-yeasts :american-wheat-ale-1010
-                       {:min-temperature 14.44
-                        :name            "1010 American Wheat Ale"
-                        :max-temperature 23.33
-                        :type            "Ale"
-                        :best-for        "American Wheat, Berlin Weiss, Hefeweizen"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Dry, Crisp, tart beer in the American Hefeweizen style. Low flocculation aids in producing desired chill haze."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "1010"}))
+                       {cbf/min-temperature 14.44
+                        cbf/name            "1010 American Wheat Ale"
+                        cbf/max-temperature 23.33
+                        cbf/type            "Ale"
+                        cbf/best-for        "American Wheat, Berlin Weiss, Hefeweizen"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Dry, Crisp, tart beer in the American Hefeweizen style. Low flocculation aids in producing desired chill haze."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1010"}))
 
 
 (def british-cask-ale-1026
@@ -45,33 +47,33 @@
    Produces nice malt profile with a hint of fruit. 
    Finishes dry and slightly tart."
   (yeasts/build-yeasts :british-cask-ale-1026
-                       {:min-temperature 17.22
-                        :name            "1026 British Cask Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "British Ales"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "A great choice for any cask conditioned British Ale. Produces nice malt profile with a hint of fruit. Finishes dry and slightly tart."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "1026"}))
+                       {cbf/min-temperature 17.22
+                        cbf/name            "1026 British Cask Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "British Ales"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "A great choice for any cask conditioned British Ale. Produces nice malt profile with a hint of fruit. Finishes dry and slightly tart."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1026"}))
 
 
 (def london-ale-yeast-1028
   "Dry finish, bold, rich flavor, some fruit profile and a crisp finish."
   (yeasts/build-yeasts :london-ale-yeast-1028
-                       {:min-temperature 15.56
-                        :name            "1028 London Ale Yeast"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "English Ales, Bitters, IPAs, Brown Ale"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Dry finish, bold, rich flavor, some fruit profile and a crisp finish."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "1028"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "1028 London Ale Yeast"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "English Ales, Bitters, IPAs, Brown Ale"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Dry finish, bold, rich flavor, some fruit profile and a crisp finish."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1028"}))
 
 
 (def american-ale-1056
@@ -80,17 +82,17 @@
    Very well balanced. 
    Very versitile - works well with many ale styles."
   (yeasts/build-yeasts :american-ale-1056
-                       {:min-temperature 15.56
-                        :name            "1056 American Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "American Pale Ale, Scottish Ale, Porters, Sweet Stout, Barley Wine, Alt"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Soft, smooth, clean finish. Very well balanced. Very versitile - works well with many ale styles."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "1056"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "1056 American Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "American Pale Ale, Scottish Ale, Porters, Sweet Stout, Barley Wine, Alt"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Soft, smooth, clean finish. Very well balanced. Very versitile - works well with many ale styles."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1056"}))
 
 
 (def irish-ale-1084
@@ -98,17 +100,17 @@
    
    Full bodied, dry, clean flavor."
   (yeasts/build-yeasts :irish-ale-1084
-                       {:min-temperature 16.67
-                        :name            "1084 Irish Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "Irish Dry Stouts, Porter, Scottish Ale, Brown Ale, Imperial Stout, Barley Wine"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Dry diacetyl, fruity flavor characteristic of stouts. Full bodied, dry, clean flavor."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "1084"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "1084 Irish Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "Irish Dry Stouts, Porter, Scottish Ale, Brown Ale, Imperial Stout, Barley Wine"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Dry diacetyl, fruity flavor characteristic of stouts. Full bodied, dry, clean flavor."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1084"}))
 
 
 (def wyeast-ale-blend-1087
@@ -116,17 +118,17 @@
    
    Balanced finish suitable for most American and British ale styles."
   (yeasts/build-yeasts :wyeast-ale-blend-1087
-                       {:min-temperature 17.78
-                        :name            "1087 Wyeast Ale Blend"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "American and British Ale Styles."
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Blend of ale strains designed to provide quick starts, good flavor, balance and flocculation. Balanced finish suitable for most American and British ale styles."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "1087"}))
+                       {cbf/min-temperature 17.78
+                        cbf/name            "1087 Wyeast Ale Blend"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "American and British Ale Styles."
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Blend of ale strains designed to provide quick starts, good flavor, balance and flocculation. Balanced finish suitable for most American and British ale styles."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1087"}))
 
 
 (def british-ale-yeast-1098
@@ -134,17 +136,17 @@
    
    Very well balanced."
   (yeasts/build-yeasts :british-ale-yeast-1098
-                       {:min-temperature 17.78
-                        :name            "1098 British Ale Yeast"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "All British Ales, Pales, Bitters, English Strong Ale"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Fruity, tart, dry crisp finish. Very well balanced."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "1098"}))
+                       {cbf/min-temperature 17.78
+                        cbf/name            "1098 British Ale Yeast"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "All British Ales, Pales, Bitters, English Strong Ale"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Fruity, tart, dry crisp finish. Very well balanced."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1098"}))
 
 
 (def whitbread-ale-1099
@@ -152,17 +154,17 @@
    
    Clear and highly flocculant."
   (yeasts/build-yeasts :whitbread-ale-1099
-                       {:min-temperature 17.78
-                        :name            "1099 Whitbread Ale"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "Whitbread Ale, British Ales, Pales, Bitters"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Slightly more fruity and malty than Wyeast's British Ale. Clear and highly flocculant."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "1099"}))
+                       {cbf/min-temperature 17.78
+                        cbf/name            "1099 Whitbread Ale"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "Whitbread Ale, British Ales, Pales, Bitters"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Slightly more fruity and malty than Wyeast's British Ale. Clear and highly flocculant."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1099"}))
 
 
 (def ringwood-ale-1187
@@ -171,17 +173,17 @@
    Highly flocculant with complex, clear, but malty profile. 
    Slightly fruity ester."
   (yeasts/build-yeasts :ringwood-ale-1187
-                       {:min-temperature 17.78
-                        :name            "1187 Ringwood Ale"
-                        :max-temperature 23.33
-                        :type            "Ale"
-                        :best-for        "Ringwood Ale, Brown Ales"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "European ale yeast. Highly flocculant with complex, clear, but malty profile. Slightly fruity ester."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "1187"}))
+                       {cbf/min-temperature 17.78
+                        cbf/name            "1187 Ringwood Ale"
+                        cbf/max-temperature 23.33
+                        cbf/type            "Ale"
+                        cbf/best-for        "Ringwood Ale, Brown Ales"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "European ale yeast. Highly flocculant with complex, clear, but malty profile. Slightly fruity ester."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1187"}))
 
 
 (def belgian-ale-yeast-1214
@@ -189,17 +191,17 @@
    
    Complex estery flavor."
   (yeasts/build-yeasts :belgian-ale-yeast-1214
-                       {:min-temperature 14.44
-                        :name            "1214 Belgian Ale Yeast"
-                        :max-temperature 20.0
-                        :type            "Ale"
-                        :best-for        "Belgian Ales, Abbey Ales, Trappist Ales"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Trappist style ale yeast. Complex estery flavor."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "1214"}))
+                       {cbf/min-temperature 14.44
+                        cbf/name            "1214 Belgian Ale Yeast"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Ales, Abbey Ales, Trappist Ales"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Trappist style ale yeast. Complex estery flavor."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1214"}))
 
 
 (def american-ale-ii-1272
@@ -207,17 +209,17 @@
    
    More fruity than Wyeast American Ale yeast."
   (yeasts/build-yeasts :american-ale-ii-1272
-                       {:min-temperature 15.56
-                        :name            "1272 American Ale II"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "All American Ales, Brown Ales, Barley Wine"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Clean, tart, nutty flavor. More fruity than Wyeast American Ale yeast."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "1272"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "1272 American Ale II"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "All American Ales, Brown Ales, Barley Wine"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Clean, tart, nutty flavor. More fruity than Wyeast American Ale yeast."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1272"}))
 
 
 (def gf-all-american-ale-1272
@@ -226,17 +228,17 @@
    Produces beers that are nutty, clean with a slight tart finish. 
    Ferment warmer to accentuate hops and add fruitiness or ferment cold for clean light citrus character."
   (yeasts/build-yeasts :gf-all-american-ale-1272
-                       {:min-temperature 15.56
-                        :name            "1272 GF All American Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "American Amber, Brown, IPA, Pale ales and stouts. Blondes and fruit beers."
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Popular all purpose American ale style now in a Gluten Free strain. Produces beers that are nutty, clean with a slight tart finish. Ferment warmer to accentuate hops and add fruitiness or ferment cold for clean light citrus character."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "1272"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "1272 GF All American Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "American Amber, Brown, IPA, Pale ales and stouts. Blondes and fruit beers."
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Popular all purpose American ale style now in a Gluten Free strain. Produces beers that are nutty, clean with a slight tart finish. Ferment warmer to accentuate hops and add fruitiness or ferment cold for clean light citrus character."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1272"}))
 
 
 (def thames-valley-ale-1275
@@ -245,17 +247,17 @@
    Low in fruit, low in esters, rich in flavor. 
    Hops come through well."
   (yeasts/build-yeasts :thames-valley-ale-1275
-                       {:min-temperature 16.67
-                        :name            "1275 Thames Valley Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "British Bitters, ESB, India Pale Ale, English Strong Ale"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Clean, complex flavor. Low in fruit, low in esters, rich in flavor. Hops come through well."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "1275"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "1275 Thames Valley Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "British Bitters, ESB, India Pale Ale, English Strong Ale"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Clean, complex flavor. Low in fruit, low in esters, rich in flavor. Hops come through well."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1275"}))
 
 
 (def london-ale-iii-1318
@@ -263,17 +265,17 @@
    
    Balanced flavor with hint of sweetness."
   (yeasts/build-yeasts :london-ale-iii-1318
-                       {:min-temperature 17.78
-                        :name            "1318 London Ale III"
-                        :max-temperature 23.33
-                        :type            "Ale"
-                        :best-for        "British Ales, Bitters"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Light, fruity flavor. Balanced flavor with hint of sweetness."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "1318"}))
+                       {cbf/min-temperature 17.78
+                        cbf/name            "1318 London Ale III"
+                        cbf/max-temperature 23.33
+                        cbf/type            "Ale"
+                        cbf/best-for        "British Ales, Bitters"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Light, fruity flavor. Balanced flavor with hint of sweetness."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1318"}))
 
 
 (def northwest-ale-1332
@@ -281,17 +283,17 @@
    
    Slight fruit flavor, malty ale with good body and balance."
   (yeasts/build-yeasts :northwest-ale-1332
-                       {:min-temperature 18.33
-                        :name            "1332 Northwest Ale"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "Oregon Ales, All American Ale styles"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Classic Northwest US ale yeast. Slight fruit flavor, malty ale with good body and balance."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "1332"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "1332 Northwest Ale"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "Oregon Ales, All American Ale styles"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Classic Northwest US ale yeast. Slight fruit flavor, malty ale with good body and balance."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1332"}))
 
 
 (def british-ale-ii-1335
@@ -299,17 +301,17 @@
    
    Dry flavor."
   (yeasts/build-yeasts :british-ale-ii-1335
-                       {:min-temperature 17.22
-                        :name            "1335 British Ale II"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "British and Canadian Ales, English Bitters"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Malty, clean, crisp finish. Dry flavor."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "1335"}))
+                       {cbf/min-temperature 17.22
+                        cbf/name            "1335 British Ale II"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "British and Canadian Ales, English Bitters"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Malty, clean, crisp finish. Dry flavor."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1335"}))
 
 
 (def european-ale-yeast-1338
@@ -317,17 +319,17 @@
    
    Complex character."
   (yeasts/build-yeasts :european-ale-yeast-1338
-                       {:min-temperature 16.67
-                        :name            "1338 European Ale Yeast"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "European Ales, German Ales, Alts, Pale Ale, Brown Ale, Kolsch"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Very malty flavor characteristic of Bavarian/Munich Ales. Complex character."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "1338"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "1338 European Ale Yeast"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "European Ales, German Ales, Alts, Pale Ale, Brown Ale, Kolsch"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Very malty flavor characteristic of Bavarian/Munich Ales. Complex character."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1338"}))
 
 
 (def belgian-strong-ale-1388
@@ -335,17 +337,17 @@
    
    High alcohol tolerance."
   (yeasts/build-yeasts :belgian-strong-ale-1388
-                       {:min-temperature 18.33
-                        :name            "1388 Belgian Strong Ale"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "Belgian Ales, Scottish Strong Ale,Trappist Ales, Dubbels, Trippels"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Dry, tart, fruity flavor. High alcohol tolerance."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "1388"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "1388 Belgian Strong Ale"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Ales, Scottish Strong Ale,Trappist Ales, Dubbels, Trippels"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Dry, tart, fruity flavor. High alcohol tolerance."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1388"}))
 
 
 (def denny-s-favorite-50-1450
@@ -353,33 +355,33 @@
    
    It is unique in that it produces a big mouthfeel and accentuates the malt, caramel, or fruit character of a beer without being sweet or under-attenuated."
   (yeasts/build-yeasts :denny-s-favorite-50-1450
-                       {:min-temperature 15.56
-                        :name            "1450 Denny's Favorite 50"
-                        :max-temperature 21.11
-                        :type            "Ale"
-                        :best-for        "almost any style"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "This terrific all-round yeast can be used for almost any beer style, and is a mainstay of one of our local homebrewers, Mr. Denny Conn. It is unique in that it produces a big mouthfeel and accentuates the malt, caramel, or fruit character of a beer without being sweet or under-attenuated."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "1450"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "1450 Denny's Favorite 50"
+                        cbf/max-temperature 21.11
+                        cbf/type            "Ale"
+                        cbf/best-for        "almost any style"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "This terrific all-round yeast can be used for almost any beer style, and is a mainstay of one of our local homebrewers, Mr. Denny Conn. It is unique in that it produces a big mouthfeel and accentuates the malt, caramel, or fruit character of a beer without being sweet or under-attenuated."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1450"}))
 
 
 (def scottish-ale-1728
   "High alcohol tolerance."
   (yeasts/build-yeasts :scottish-ale-1728
-                       {:min-temperature 12.78
-                        :name            "1728 Scottish Ale"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "Scottish Ale, Scottish Strong Ales, Sweet Stout, Imperial Stout, Barley Wine"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "High alcohol tolerance."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "1728"}))
+                       {cbf/min-temperature 12.78
+                        cbf/name            "1728 Scottish Ale"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "Scottish Ale, Scottish Strong Ales, Sweet Stout, Imperial Stout, Barley Wine"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "High alcohol tolerance."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1728"}))
 
 
 (def belgian-abbey-ii-1762
@@ -387,17 +389,17 @@
    
    High alcohol tolerance."
   (yeasts/build-yeasts :belgian-abbey-ii-1762
-                       {:min-temperature 18.33
-                        :name            "1762 Belgian Abbey II"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "Belgian Ales, Trappist Ales, Abbey Ales, Grand Cru"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Dry flavor with slight fruitiness. High alcohol tolerance."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "1762"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "1762 Belgian Abbey II"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Ales, Trappist Ales, Abbey Ales, Grand Cru"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Dry flavor with slight fruitiness. High alcohol tolerance."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1762"}))
 
 
 (def london-esb-ale-1968
@@ -406,17 +408,17 @@
    Fruity, rich finish. 
    Excellent for cask conditioned ales and bitters."
   (yeasts/build-yeasts :london-esb-ale-1968
-                       {:min-temperature 17.78
-                        :name            "1968 London ESB Ale"
-                        :max-temperature 22.22
-                        :type            "Ale"
-                        :best-for        "English Bitters, IPA, Brown Ales, Mild Ales"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Malty, balanced flavor. Fruity, rich finish. Excellent for cask conditioned ales and bitters."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "1968"}))
+                       {cbf/min-temperature 17.78
+                        cbf/name            "1968 London ESB Ale"
+                        cbf/max-temperature 22.22
+                        cbf/type            "Ale"
+                        cbf/best-for        "English Bitters, IPA, Brown Ales, Mild Ales"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Malty, balanced flavor. Fruity, rich finish. Excellent for cask conditioned ales and bitters."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "1968"}))
 
 
 (def budvar-lager-2000
@@ -426,17 +428,17 @@
    Rich malt profile, but dry crisp finish. 
    Hop character accentuated by dry finish."
   (yeasts/build-yeasts :budvar-lager-2000
-                       {:min-temperature 7.78
-                        :name            "2000 Budvar Lager"
-                        :max-temperature 13.33
-                        :type            "Lager"
-                        :best-for        "Bohemian Pilsner, Classic Pilsners, Dortmunder and Light Lagers"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Classic pilsner lager yeast. Malty nose and subtle fruit. Rich malt profile, but dry crisp finish. Hop character accentuated by dry finish."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "2000"}))
+                       {cbf/min-temperature 7.78
+                        cbf/name            "2000 Budvar Lager"
+                        cbf/max-temperature 13.33
+                        cbf/type            "Lager"
+                        cbf/best-for        "Bohemian Pilsner, Classic Pilsners, Dortmunder and Light Lagers"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Classic pilsner lager yeast. Malty nose and subtle fruit. Rich malt profile, but dry crisp finish. Hop character accentuated by dry finish."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2000"}))
 
 
 (def urquell-lager-2001
@@ -446,17 +448,17 @@
    Subtle malt character. 
    Clean and neutral finish."
   (yeasts/build-yeasts :urquell-lager-2001
-                       {:min-temperature 8.89
-                        :name            "2001 Urquell Lager"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "Bohemian Pilsner"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Pilsner Urquell yeast with mild fruit/floral aroma. Very dry and clean on palate with full mouth feel. Subtle malt character. Clean and neutral finish."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "2001"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "2001 Urquell Lager"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "Bohemian Pilsner"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Pilsner Urquell yeast with mild fruit/floral aroma. Very dry and clean on palate with full mouth feel. Subtle malt character. Clean and neutral finish."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2001"}))
 
 
 (def pilsen-lager-2007
@@ -465,17 +467,17 @@
    Smooth with a malty flavor. 
    Dry and crisp fermentation."
   (yeasts/build-yeasts :pilsen-lager-2007
-                       {:min-temperature 8.89
-                        :name            "2007 Pilsen Lager"
-                        :max-temperature 13.33
-                        :type            "Lager"
-                        :best-for        "American Pilsner, Bohemian Pilsner, Light Lagers"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Classic American pilsner strain. Smooth with a malty flavor. Dry and crisp fermentation."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "2007"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "2007 Pilsen Lager"
+                        cbf/max-temperature 13.33
+                        cbf/type            "Lager"
+                        cbf/best-for        "American Pilsner, Bohemian Pilsner, Light Lagers"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Classic American pilsner strain. Smooth with a malty flavor. Dry and crisp fermentation."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2007"}))
 
 
 (def american-lager-2035
@@ -483,17 +485,17 @@
    
    Good flavor depth characteristics for a wide variety of lager beers."
   (yeasts/build-yeasts :american-lager-2035
-                       {:min-temperature 8.89
-                        :name            "2035 American Lager"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "American Lagers and Pilsners"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Bold, with a complex aroma. Good flavor depth characteristics for a wide variety of lager beers."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "2035"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "2035 American Lager"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "American Lagers and Pilsners"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Bold, with a complex aroma. Good flavor depth characteristics for a wide variety of lager beers."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2035"}))
 
 
 (def danish-lager-2042
@@ -501,17 +503,17 @@
    
    Soft profile accentuates hop flavor."
   (yeasts/build-yeasts :danish-lager-2042
-                       {:min-temperature 7.78
-                        :name            "2042 Danish Lager"
-                        :max-temperature 13.33
-                        :type            "Lager"
-                        :best-for        "Dortmund/Export Lagers"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Rich, Dortmund style, with a crisp, dry finish. Soft profile accentuates hop flavor."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "2042"}))
+                       {cbf/min-temperature 7.78
+                        cbf/name            "2042 Danish Lager"
+                        cbf/max-temperature 13.33
+                        cbf/type            "Lager"
+                        cbf/best-for        "Dortmund/Export Lagers"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Rich, Dortmund style, with a crisp, dry finish. Soft profile accentuates hop flavor."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2042"}))
 
 
 (def california-lager-2112
@@ -519,33 +521,33 @@
    
    Lagers at high temperature and produces malty, clear beers."
   (yeasts/build-yeasts :california-lager-2112
-                       {:min-temperature 14.44
-                        :name            "2112 California Lager"
-                        :max-temperature 20.0
-                        :type            "Lager"
-                        :best-for        "California common beers, Steam Beer"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Suited for 19th century California style beers. Lagers at high temperature and produces malty, clear beers."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "2112"}))
+                       {cbf/min-temperature 14.44
+                        cbf/name            "2112 California Lager"
+                        cbf/max-temperature 20.0
+                        cbf/type            "Lager"
+                        cbf/best-for        "California common beers, Steam Beer"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Suited for 19th century California style beers. Lagers at high temperature and produces malty, clear beers."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2112"}))
 
 
 (def bohemian-lager-2124
   "Ferments clean and malty, with rich malty flavor for full gravity pilsners."
   (yeasts/build-yeasts :bohemian-lager-2124
-                       {:min-temperature 8.89
-                        :name            "2124 Bohemian Lager"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "Bohemian Pilsners, Pilsners, German Helles, Bocks"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Ferments clean and malty, with rich malty flavor for full gravity pilsners."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "2124"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "2124 Bohemian Lager"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "Bohemian Pilsners, Pilsners, German Helles, Bocks"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Ferments clean and malty, with rich malty flavor for full gravity pilsners."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2124"}))
 
 
 (def wyeast-lager-blend-2178
@@ -553,17 +555,17 @@
    
    Suitable for many common lager styles."
   (yeasts/build-yeasts :wyeast-lager-blend-2178
-                       {:min-temperature 8.89
-                        :name            "2178 Wyeast Lager Blend"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "Classic Pilsners, Lagers, Bocks."
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Blend of lager strains to produce a complex but clean lager flavor profile. Suitable for many common lager styles."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "2178"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "2178 Wyeast Lager Blend"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "Classic Pilsners, Lagers, Bocks."
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Blend of lager strains to produce a complex but clean lager flavor profile. Suitable for many common lager styles."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2178"}))
 
 
 (def bavarian-lager-2206
@@ -571,17 +573,17 @@
    
    Produces a full-bodied, rich, malty beer."
   (yeasts/build-yeasts :bavarian-lager-2206
-                       {:min-temperature 7.78
-                        :name            "2206 Bavarian Lager"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "German Bocks, Vienna, Oktoberfest, Hells, Marzens, Dunkel"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Use by many German breweries. Produces a full-bodied, rich, malty beer."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "2206"}))
+                       {cbf/min-temperature 7.78
+                        cbf/name            "2206 Bavarian Lager"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "German Bocks, Vienna, Oktoberfest, Hells, Marzens, Dunkel"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Use by many German breweries. Produces a full-bodied, rich, malty beer."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2206"}))
 
 
 (def european-lager-ii-2247
@@ -589,17 +591,17 @@
    
    Dry finish, mild aroma, slight sulfur production."
   (yeasts/build-yeasts :european-lager-ii-2247
-                       {:min-temperature 7.78
-                        :name            "2247 European Lager II"
-                        :max-temperature 13.33
-                        :type            "Lager"
-                        :best-for        "Bohemian Pilsner, American Pilsner, Helles, Dunkel"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Clean, dry flavor profile for aggressively hopped pilsners. Dry finish, mild aroma, slight sulfur production."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "2247"}))
+                       {cbf/min-temperature 7.78
+                        cbf/name            "2247 European Lager II"
+                        cbf/max-temperature 13.33
+                        cbf/type            "Lager"
+                        cbf/best-for        "Bohemian Pilsner, American Pilsner, Helles, Dunkel"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Clean, dry flavor profile for aggressively hopped pilsners. Dry finish, mild aroma, slight sulfur production."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2247"}))
 
 
 (def north-american-lager-2272
@@ -607,17 +609,17 @@
    
    Malty finish makes it suitable for Marzens/Oktoberfest as well."
   (yeasts/build-yeasts :north-american-lager-2272
-                       {:min-temperature 8.89
-                        :name            "2272 North American Lager"
-                        :max-temperature 13.33
-                        :type            "Lager"
-                        :best-for        "American Pilsner, California Common, Canadian Lager, Oktoberfest, Marzen"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "American and Canadian lager yeast. Malty finish makes it suitable for Marzens/Oktoberfest as well."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "2272"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "2272 North American Lager"
+                        cbf/max-temperature 13.33
+                        cbf/type            "Lager"
+                        cbf/best-for        "American Pilsner, California Common, Canadian Lager, Oktoberfest, Marzen"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "American and Canadian lager yeast. Malty finish makes it suitable for Marzens/Oktoberfest as well."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2272"}))
 
 
 (def czech-pilsner-lager-2278
@@ -626,17 +628,17 @@
    Creates a dry but malty finish. 
    Perfect for Pilsners and bocks. Some sulfur produced, but will fade with time."
   (yeasts/build-yeasts :czech-pilsner-lager-2278
-                       {:min-temperature 10.0
-                        :name            "2278 Czech Pilsner Lager"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "Bohemian and American Pilsner, Bocks, Oktoberfest, Marzen"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Classic Pilsner strain. Creates a dry but malty finish. Perfect for Pilsners and bocks. Some sulfur produced, but will fade with time."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "2278"}))
+                       {cbf/min-temperature 10.0
+                        cbf/name            "2278 Czech Pilsner Lager"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "Bohemian and American Pilsner, Bocks, Oktoberfest, Marzen"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Classic Pilsner strain. Creates a dry but malty finish. Perfect for Pilsners and bocks. Some sulfur produced, but will fade with time."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2278"}))
 
 
 (def munich-lager-2308
@@ -645,17 +647,17 @@
    Very smooth, well-rounded and full bodied. 
    Benefits from a diacetyl rest."
   (yeasts/build-yeasts :munich-lager-2308
-                       {:min-temperature 8.89
-                        :name            "2308 Munich Lager"
-                        :max-temperature 13.33
-                        :type            "Lager"
-                        :best-for        "Pilsners, Light Lagers, Dortmond/Export, Marzen/Oktoberfest, Dunkel"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Unique Pilsner strain. Very smooth, well-rounded and full bodied. Benefits from a diacetyl rest."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "2308"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "2308 Munich Lager"
+                        cbf/max-temperature 13.33
+                        cbf/type            "Lager"
+                        cbf/best-for        "Pilsners, Light Lagers, Dortmond/Export, Marzen/Oktoberfest, Dunkel"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Unique Pilsner strain. Very smooth, well-rounded and full bodied. Benefits from a diacetyl rest."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2308"}))
 
 
 (def kolsch-yeast-2565
@@ -663,17 +665,17 @@
    
    Crisp, clean finish."
   (yeasts/build-yeasts :kolsch-yeast-2565
-                       {:min-temperature 13.33
-                        :name            "2565 Kolsch Yeast"
-                        :max-temperature 17.78
-                        :type            "Ale"
-                        :best-for        "Kolsch, European Ales"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Very malty flavor with mix of lager and ale character. Crisp, clean finish."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "2565"}))
+                       {cbf/min-temperature 13.33
+                        cbf/name            "2565 Kolsch Yeast"
+                        cbf/max-temperature 17.78
+                        cbf/type            "Ale"
+                        cbf/best-for        "Kolsch, European Ales"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Very malty flavor with mix of lager and ale character. Crisp, clean finish."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2565"}))
 
 
 (def octoberfest-lager-blend-2633
@@ -682,33 +684,33 @@
    It attenuates well while leaving plenty of malt character and mouthfeel. 
    This strain is low in sulfur production."
   (yeasts/build-yeasts :octoberfest-lager-blend-2633
-                       {:min-temperature 8.89
-                        :name            "2633 Octoberfest Lager Blend"
-                        :max-temperature 14.44
-                        :type            "Lager"
-                        :best-for        "Octoberfest, Marzen, Bavarian lagers"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "This blend of lager strains is designed to produce a rich, malty, complex and full bodied Octoberfest style beer. It attenuates well while leaving plenty of malt character and mouthfeel. This strain is low in sulfur production."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "2633"}))
+                       {cbf/min-temperature 8.89
+                        cbf/name            "2633 Octoberfest Lager Blend"
+                        cbf/max-temperature 14.44
+                        cbf/type            "Lager"
+                        cbf/best-for        "Octoberfest, Marzen, Bavarian lagers"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "This blend of lager strains is designed to produce a rich, malty, complex and full bodied Octoberfest style beer. It attenuates well while leaving plenty of malt character and mouthfeel. This strain is low in sulfur production."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "2633"}))
 
 
 (def bavarian-wheat-yeast-3056
   "Blend of top-fermenting ale and wheat yeasts providing a mild ester and phenolic profile."
   (yeasts/build-yeasts :bavarian-wheat-yeast-3056
-                       {:min-temperature 17.78
-                        :name            "3056 Bavarian Wheat Yeast"
-                        :max-temperature 23.33
-                        :type            "Wheat"
-                        :best-for        "Bavarian style wheat beers."
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Blend of top-fermenting ale and wheat yeasts providing a mild ester and phenolic profile."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "3056"}))
+                       {cbf/min-temperature 17.78
+                        cbf/name            "3056 Bavarian Wheat Yeast"
+                        cbf/max-temperature 23.33
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Bavarian style wheat beers."
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Blend of top-fermenting ale and wheat yeasts providing a mild ester and phenolic profile."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3056"}))
 
 
 (def weihenstephan-weizen-3068
@@ -716,17 +718,17 @@
    
    Best when fermented at around 68 deg F."
   (yeasts/build-yeasts :weihenstephan-weizen-3068
-                       {:min-temperature 17.78
-                        :name            "3068 Weihenstephan Weizen"
-                        :max-temperature 23.89
-                        :type            "Wheat"
-                        :best-for        "Bavarian Weizen"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Unique Bavarian wheat yeast that produces the spicy weizen clove and banana flavor. Best when fermented at around 68 deg F."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "3068"}))
+                       {cbf/min-temperature 17.78
+                        cbf/name            "3068 Weihenstephan Weizen"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Bavarian Weizen"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Unique Bavarian wheat yeast that produces the spicy weizen clove and banana flavor. Best when fermented at around 68 deg F."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3068"}))
 
 
 (def brettanomyces-bruxellensis-3112
@@ -735,17 +737,17 @@
    Adds classic sweaty horse hair flavor as well as sourness and cherry-pie like flavor. 
    Generally used in conjunction with S. Cerevisiae after the primary fermentation has begun."
   (yeasts/build-yeasts :brettanomyces-bruxellensis-3112
-                       {:min-temperature 15.56
-                        :name            "3112 Brettanomyces Bruxellensis"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "Belgian Lambic, Gueze Lambic, and Sour Browns"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Wild yeast strain isolated from Brussels region of Belgium. Adds classic sweaty horse hair flavor as well as sourness and cherry-pie like flavor. Generally used in conjunction with S. Cerevisiae after the primary fermentation has begun."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "3112"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "3112 Brettanomyces Bruxellensis"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Lambic, Gueze Lambic, and Sour Browns"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Wild yeast strain isolated from Brussels region of Belgium. Adds classic sweaty horse hair flavor as well as sourness and cherry-pie like flavor. Generally used in conjunction with S. Cerevisiae after the primary fermentation has begun."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3112"}))
 
 
 (def belgian-lambic-blend-3278
@@ -753,17 +755,17 @@
    
    Blend of organisms helps create lactic flavor of Belgian Lambics."
   (yeasts/build-yeasts :belgian-lambic-blend-3278
-                       {:min-temperature 17.22
-                        :name            "3278 Belgian Lambic Blend"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "Belgian Lambic"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Lambic culture of Saccharomyces Cerevisiar and a mixture of yeasts and bacterias. Blend of organisms helps create lactic flavor of Belgian Lambics."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "3278"}))
+                       {cbf/min-temperature 17.22
+                        cbf/name            "3278 Belgian Lambic Blend"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Lambic"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Lambic culture of Saccharomyces Cerevisiar and a mixture of yeasts and bacterias. Blend of organisms helps create lactic flavor of Belgian Lambics."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3278"}))
 
 
 (def german-wheat-3333
@@ -771,17 +773,17 @@
    
    Sharp, fruity, crisp, sherry like flavor."
   (yeasts/build-yeasts :german-wheat-3333
-                       {:min-temperature 17.22
-                        :name            "3333 German Wheat"
-                        :max-temperature 23.89
-                        :type            "Wheat"
-                        :best-for        "Bavarian Weizen"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Subtle flavor profile. Sharp, fruity, crisp, sherry like flavor."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "3333"}))
+                       {cbf/min-temperature 17.22
+                        cbf/name            "3333 German Wheat"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Bavarian Weizen"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Subtle flavor profile. Sharp, fruity, crisp, sherry like flavor."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3333"}))
 
 
 (def forbidden-fruit-3463
@@ -789,17 +791,17 @@
    
    Available seasonally."
   (yeasts/build-yeasts :forbidden-fruit-3463
-                       {:min-temperature 17.22
-                        :name            "3463 Forbidden Fruit"
-                        :max-temperature 24.44
-                        :type            "Wheat"
-                        :best-for        "Belgian Wit, Grand Cru"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Phenolic profile with subdued fruitiness. Available seasonally."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "3463"}))
+                       {cbf/min-temperature 17.22
+                        cbf/name            "3463 Forbidden Fruit"
+                        cbf/max-temperature 24.44
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Belgian Wit, Grand Cru"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Phenolic profile with subdued fruitiness. Available seasonally."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3463"}))
 
 
 (def belgian-ardennes-3522
@@ -807,17 +809,17 @@
    
    Mild fruitiness and complex spicy flavor."
   (yeasts/build-yeasts :belgian-ardennes-3522
-                       {:min-temperature 18.33
-                        :name            "3522 Belgian Ardennes"
-                        :max-temperature 29.44
-                        :type            "Wheat"
-                        :best-for        "Belgian Ale"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Phenolics develop at increased temperature. Mild fruitiness and complex spicy flavor."
-                        :flocculation    "High"
-                        :form            "Liquid"
-                        :product-id      "3522"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "3522 Belgian Ardennes"
+                        cbf/max-temperature 29.44
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Belgian Ale"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Phenolics develop at increased temperature. Mild fruitiness and complex spicy flavor."
+                        cbf/flocculation    "High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3522"}))
 
 
 (def bavarian-wheat-3638
@@ -826,17 +828,17 @@
    Bubble gum, banana flavors with apple/plum ester profile. 
    Malty flavor."
   (yeasts/build-yeasts :bavarian-wheat-3638
-                       {:min-temperature 17.78
-                        :name            "3638 Bavarian Wheat"
-                        :max-temperature 23.89
-                        :type            "Wheat"
-                        :best-for        "Bavarian Weizen, Hefeweizen"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Hefeweizen yeast with complex flavor and aroma. Bubble gum, banana flavors with apple/plum ester profile. Malty flavor."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "3638"}))
+                       {cbf/min-temperature 17.78
+                        cbf/name            "3638 Bavarian Wheat"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Bavarian Weizen, Hefeweizen"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Hefeweizen yeast with complex flavor and aroma. Bubble gum, banana flavors with apple/plum ester profile. Malty flavor."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3638"}))
 
 
 (def french-saison-3711
@@ -844,17 +846,17 @@
    
    This strain enhances the use of spices and aroma hops, and is extremely attenuative."
   (yeasts/build-yeasts :french-saison-3711
-                       {:min-temperature 18.33
-                        :name            "3711 French Saison"
-                        :max-temperature 25.0
-                        :type            "Ale"
-                        :best-for        "French and Belgian Saison or Farmhouse ales"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "A very versatile strain that produces Saison or farmhouse style biers as well as other Belgian style beers that are highly aromatic (estery), peppery, spicy and citrusy. This strain enhances the use of spices and aroma hops, and is extremely attenuative."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "3711"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "3711 French Saison"
+                        cbf/max-temperature 25.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "French and Belgian Saison or Farmhouse ales"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "A very versatile strain that produces Saison or farmhouse style biers as well as other Belgian style beers that are highly aromatic (estery), peppery, spicy and citrusy. This strain enhances the use of spices and aroma hops, and is extremely attenuative."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3711"}))
 
 
 (def belgian-saison-3724
@@ -866,17 +868,17 @@
    Ferment at warm temperature. 
    May have vigorous fermentation start."
   (yeasts/build-yeasts :belgian-saison-3724
-                       {:min-temperature 21.11
-                        :name            "3724 Belgian Saison"
-                        :max-temperature 35.0
-                        :type            "Ale"
-                        :best-for        "Belgian Saison beer"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Classic farmhouse ale yeast. Spicy, complex aromatics including bubble gum. Tart and dry on the palate with mild fruitiness. Finishes crisp and mildly acidic. Ferment at warm temperature. May have vigorous fermentation start."
-                        :flocculation    "Low"
-                        :form            "Liquid"
-                        :product-id      "3724"}))
+                       {cbf/min-temperature 21.11
+                        cbf/name            "3724 Belgian Saison"
+                        cbf/max-temperature 35.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian Saison beer"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Classic farmhouse ale yeast. Spicy, complex aromatics including bubble gum. Tart and dry on the palate with mild fruitiness. Finishes crisp and mildly acidic. Ferment at warm temperature. May have vigorous fermentation start."
+                        cbf/flocculation    "Low"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3724"}))
 
 
 (def roselare-belgian-blend-3763
@@ -886,17 +888,17 @@
    May be used for primary fermentation. 
    Primarily for sour brown and red Belgian styles."
   (yeasts/build-yeasts :roselare-belgian-blend-3763
-                       {:min-temperature 12.78
-                        :name            "3763 Roselare Belgian Blend"
-                        :max-temperature 26.67
-                        :type            "Ale"
-                        :best-for        "Belgian sour brown and red beers."
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Culture of Saccharomyces, Brettonomyces and Lactic Acid Bacteria. Complex aromas and flavors. May be used for primary fermentation. Primarily for sour brown and red Belgian styles."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "3763"}))
+                       {cbf/min-temperature 12.78
+                        cbf/name            "3763 Roselare Belgian Blend"
+                        cbf/max-temperature 26.67
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian sour brown and red beers."
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Culture of Saccharomyces, Brettonomyces and Lactic Acid Bacteria. Complex aromas and flavors. May be used for primary fermentation. Primarily for sour brown and red Belgian styles."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3763"}))
 
 
 (def trappist-high-gravity-3787
@@ -905,17 +907,17 @@
    Phenolic character and alcohol tolerance up to 12%. 
    Rich ester profile and malty flavor."
   (yeasts/build-yeasts :trappist-high-gravity-3787
-                       {:min-temperature 17.78
-                        :name            "3787 Trappist High Gravity"
-                        :max-temperature 25.56
-                        :type            "Wheat"
-                        :best-for        "Belgian Wit, Trappist Ale, High gravity ales"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Robust top cropping yeast. Phenolic character and alcohol tolerance up to 12%. Rich ester profile and malty flavor."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "3787"}))
+                       {cbf/min-temperature 17.78
+                        cbf/name            "3787 Trappist High Gravity"
+                        cbf/max-temperature 25.56
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Belgian Wit, Trappist Ale, High gravity ales"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Robust top cropping yeast. Phenolic character and alcohol tolerance up to 12%. Rich ester profile and malty flavor."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3787"}))
 
 
 (def belgian-wheat-yeast-3942
@@ -923,17 +925,17 @@
    
    lum and apple aroma with a dry finish."
   (yeasts/build-yeasts :belgian-wheat-yeast-3942
-                       {:min-temperature 17.78
-                        :name            "3942 Belgian Wheat Yeast"
-                        :max-temperature 23.33
-                        :type            "Wheat"
-                        :best-for        "Belgian Wheat, Bavarian Weizen"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Estery lor phenol yeast. Plum and apple aroma with a dry finish."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "3942"}))
+                       {cbf/min-temperature 17.78
+                        cbf/name            "3942 Belgian Wheat Yeast"
+                        cbf/max-temperature 23.33
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Belgian Wheat, Bavarian Weizen"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Estery lor phenol yeast. Plum and apple aroma with a dry finish."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3942"}))
 
 
 (def belgian-witbier-3944
@@ -942,17 +944,17 @@
    For Wits and Grand Cru. 
    Tolerates high gravity beers well."
   (yeasts/build-yeasts :belgian-witbier-3944
-                       {:min-temperature 16.67
-                        :name            "3944 Belgian Witbier"
-                        :max-temperature 23.89
-                        :type            "Wheat"
-                        :best-for        "Belgian Wit, Grand Cru"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Tart, slightly phenolic character. For Wits and Grand Cru. Tolerates high gravity beers well."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "3944"}))
+                       {cbf/min-temperature 16.67
+                        cbf/name            "3944 Belgian Witbier"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Wheat"
+                        cbf/best-for        "Belgian Wit, Grand Cru"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Tart, slightly phenolic character. For Wits and Grand Cru. Tolerates high gravity beers well."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "3944"}))
 
 
 (def lactobacillus-delbrueckii-4335
@@ -961,17 +963,17 @@
    Produces mild acidity and sourness found in many types of Belgian beers. 
    Always used in conjunction with S. Cerevisiae and wild yeasts."
   (yeasts/build-yeasts :lactobacillus-delbrueckii-4335
-                       {:min-temperature 15.56
-                        :name            "4335 Lactobacillus Delbrueckii"
-                        :max-temperature 35.0
-                        :type            "Ale"
-                        :best-for        "Belgian gueze, lambic, sour brown ales, and Berliner Weisse."
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Lactic acid bacteria isolated from Belgium. Produces mild acidity and sourness found in many types of Belgian beers. Always used in conjunction with S. Cerevisiae and wild yeasts."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "4335"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "4335 Lactobacillus Delbrueckii"
+                        cbf/max-temperature 35.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian gueze, lambic, sour brown ales, and Berliner Weisse."
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Lactic acid bacteria isolated from Belgium. Produces mild acidity and sourness found in many types of Belgian beers. Always used in conjunction with S. Cerevisiae and wild yeasts."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "4335"}))
 
 
 (def pediococcus-cerevisiae-4733
@@ -980,17 +982,17 @@
    Creates a high level of lactic acidity over a long time. 
    Often used with other yeasts, and it may take several months for flavor to fully develop."
   (yeasts/build-yeasts :pediococcus-cerevisiae-4733
-                       {:min-temperature 15.56
-                        :name            "4733 Pediococcus Cerevisiae"
-                        :max-temperature 35.0
-                        :type            "Ale"
-                        :best-for        "Gueze and other Belgian styles."
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Lactic acid bacteria isolated from Belgium. Creates a high level of lactic acidity over a long time. Often used with other yeasts, and it may take several months for flavor to fully develop."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "4733"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "4733 Pediococcus Cerevisiae"
+                        cbf/max-temperature 35.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "Gueze and other Belgian styles."
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Lactic acid bacteria isolated from Belgium. Creates a high level of lactic acidity over a long time. Often used with other yeasts, and it may take several months for flavor to fully develop."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "4733"}))
 
 
 (def brettanomyces-bruxellensis-5112
@@ -998,34 +1000,34 @@
    
    It produces the classic sweaty horse blanket character and may form a pellicle in bottles or casks."
   (yeasts/build-yeasts :brettanomyces-bruxellensis-5112
-                       {:min-temperature 15.56
-                        :name            "5112 Brettanomyces Bruxellensis"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "Gueuze, Lambics and Sour Browns"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "This strain of wild yeast was isolated from brewery cultures in the Brussels region of Belgium. It produces the classic sweaty horse blanket character and may form a pellicle in bottles or casks."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "5112"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "5112 Brettanomyces Bruxellensis"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "Gueuze, Lambics and Sour Browns"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "This strain of wild yeast was isolated from brewery cultures in the Brussels region of Belgium. It produces the classic sweaty horse blanket character and may form a pellicle in bottles or casks."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "5112"}))
 
 
 (def lactobacillus-5335
   "Lactic acid bacteria isolated from a Belgian brewery. 
    This culture produces moderate levels of acidity and is commonly found in many types of beers including gueuze, lambics, sour brown ales and Berliner Weisse."
   (yeasts/build-yeasts :lactobacillus-5335
-                       {:min-temperature 15.56
-                        :name            "5335 Lactobacillus"
-                        :max-temperature 35.0
-                        :type            "Ale"
-                        :best-for        "Belgian sout beers (secondary)"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Lactic acid bacteria isolated from a Belgian brewery. This culture produces moderate levels of acidity and is commonly found in many types of beers including gueuze, lambics, sour brown ales and Berliner Weisse."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "5335"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "5335 Lactobacillus"
+                        cbf/max-temperature 35.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian sout beers (secondary)"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Lactic acid bacteria isolated from a Belgian brewery. This culture produces moderate levels of acidity and is commonly found in many types of beers including gueuze, lambics, sour brown ales and Berliner Weisse."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "5335"}))
 
 
 (def brettanomyces-lambucus-5526
@@ -1035,17 +1037,17 @@
    A pellicle may form in bottles or casks. 
    This strain works best in conjunction with other yeasts."
   (yeasts/build-yeasts :brettanomyces-lambucus-5526
-                       {:min-temperature 15.56
-                        :name            "5526 Brettanomyces Lambucus"
-                        :max-temperature 23.89
-                        :type            "Ale"
-                        :best-for        "Lambic"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "This is a wild yeast strain isolated from Belgian lambic beers. It produces a pie cherry-like flavor and sourness with a distinct Brett character. A pellicle may form in bottles or casks. This strain works best in conjunction with other yeasts."
-                        :flocculation    "Very High"
-                        :form            "Liquid"
-                        :product-id      "5526"}))
+                       {cbf/min-temperature 15.56
+                        cbf/name            "5526 Brettanomyces Lambucus"
+                        cbf/max-temperature 23.89
+                        cbf/type            "Ale"
+                        cbf/best-for        "Lambic"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "This is a wild yeast strain isolated from Belgian lambic beers. It produces a pie cherry-like flavor and sourness with a distinct Brett character. A pellicle may form in bottles or casks. This strain works best in conjunction with other yeasts."
+                        cbf/flocculation    "Very High"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "5526"}))
 
 
 (def pediococcus-5733
@@ -1055,17 +1057,17 @@
    Acid production will increase with storage time. 
    It may also cause ropiness and produce low level."
   (yeasts/build-yeasts :pediococcus-5733
-                       {:min-temperature 18.33
-                        :name            "5733 Pediococcus"
-                        :max-temperature 35.0
-                        :type            "Ale"
-                        :best-for        "Belgian sour ales"
-                        :laboratory      "Wyeast"
-                        :attenuation     0.765
-                        :notes           "Lactic acid bacteria used in the production of Belgian style beers where additional acidity is desirable. Often found in gueuze and other Belgian style beer. Acid production will increase with storage time. It may also cause ropiness and produce low level."
-                        :flocculation    "Medium"
-                        :form            "Liquid"
-                        :product-id      "5733"}))
+                       {cbf/min-temperature 18.33
+                        cbf/name            "5733 Pediococcus"
+                        cbf/max-temperature 35.0
+                        cbf/type            "Ale"
+                        cbf/best-for        "Belgian sour ales"
+                        cbf/laboratory      "Wyeast"
+                        cbf/attenuation     0.765
+                        cbf/notes           "Lactic acid bacteria used in the production of Belgian style beers where additional acidity is desirable. Often found in gueuze and other Belgian style beer. Acid production will increase with storage time. It may also cause ropiness and produce low level."
+                        cbf/flocculation    "Medium"
+                        cbf/form            "Liquid"
+                        cbf/product-id      "5733"}))
 
 
 (def wyeast

--- a/src/common_beer_data/yeasts/yeasts.cljc
+++ b/src/common_beer_data/yeasts/yeasts.cljc
@@ -15,7 +15,7 @@
   (let [display-min-temp (str (:min-temperature yeast-data) "C")
         display-max-temp (str (:max-temperature yeast-data) "C")
         yeast-definition (merge yeast-defaults yeast-data)
-        yeast            (assoc yeast-definition :display-min-temp display-min-temp :display-max-temp display-max-temp)
+        yeast            (assoc yeast-definition :disp-min-temp display-min-temp :disp-max-temp display-max-temp)
         cleaned-yeast    (-> yeast
                              (update :flocculation str/capitalize)
                              (update :form str/capitalize)

--- a/src/common_beer_data/yeasts/yeasts.cljc
+++ b/src/common_beer_data/yeasts/yeasts.cljc
@@ -1,23 +1,24 @@
 (ns ^:no-doc common-beer-data.yeasts.yeasts
   "Function to help minimize repeated data in yeast entry"
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [common-beer-format.yeasts :as cbf]))
 
 
 (def ^:private yeast-defaults
   "Defaults to generate complete records that match the ::yeast spec"
-  {:version 1
-   :amount  0.0})
+  {cbf/version 1
+   cbf/amount  0.0})
 
 
 (defn build-yeasts
   "Construct a yeast, including display/range values derived from core yeast data."
   [yeast-key yeast-data]
-  (let [display-min-temp (str (:min-temperature yeast-data) "C")
-        display-max-temp (str (:max-temperature yeast-data) "C")
+  (let [display-min-temp (str (cbf/min-temperature yeast-data) "C")
+        display-max-temp (str (cbf/max-temperature yeast-data) "C")
         yeast-definition (merge yeast-defaults yeast-data)
-        yeast            (assoc yeast-definition :disp-min-temp display-min-temp :disp-max-temp display-max-temp)
+        yeast            (assoc yeast-definition cbf/disp-min-temp display-min-temp cbf/disp-max-temp display-max-temp)
         cleaned-yeast    (-> yeast
-                             (update :flocculation str/capitalize)
-                             (update :form str/capitalize)
-                             (update :type str/capitalize))]
+                             (update cbf/flocculation str/capitalize)
+                             (update cbf/form str/capitalize)
+                             (update cbf/type str/capitalize))]
     {yeast-key cleaned-yeast}))


### PR DESCRIPTION
Fixed key name is yeast creation. This was caused by a silly non-contraction of a data element name- the exact problem the symbolic keys pattern is designed to solve. All static data and static data functions are now defined with common-beer-format keys explicitly instead of implicitly.


## Pre-merge Checklist

- [x] Write + run tests
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
